### PR TITLE
Add cross-scope styling support

### DIFF
--- a/vaadin-components-gwt/src/main/webapp/vaadin-grid/demo.html
+++ b/vaadin-components-gwt/src/main/webapp/vaadin-grid/demo.html
@@ -4,7 +4,11 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="user-scalable=no, initial-scale=1, maximum-scale=1, minimum-scale=1" />
 <script src="../bower_components/webcomponentsjs/webcomponents-lite.js"></script>
+<link rel="import" href="ugly-theme.html">
+<link rel="import" href="material-design-theme.html">
 <script src="../VaadinGrid/VaadinGrid.nocache.js"></script>
+
+<!--<style is="custom-style" include="ugly-theme"></style> -->
 
 <script src="sdm.js"></script>
 <script src="demodata.js"></script>
@@ -23,6 +27,83 @@ td.blue, th.blue, .blue th, .blue td, td.foot2, .foot2 td {
 </head>
 <body>
 <ol>
+
+  <li>
+    <h3>Simplest possible with custom styles</h3>
+    <dom-module id="my-grid-with-custom-styles">
+      <style include="ugly-theme"></style>
+
+      <template>
+        <!--<style include="shared-styles"></style>-->
+        <v-grid selection-mode='multi'>
+          <table>
+            <col header-text="Name">
+            <col header-text="Value">
+            <col header-text="Progress">
+
+            <tfoot>
+            <tr>
+              <th colspan=3>This is a footer line in a cell</th>
+            </tr>
+            <tr>
+              <th colspan=3><span>Some widgets in a footer</span> <input type=text/> <button>Click</button></th>
+            </tr>
+            </tfoot>
+          </table>
+        </v-grid>
+      </template>
+    </dom-module>
+    <script>
+      HTMLImports.whenReady(function() {
+        Polymer({
+          is: 'my-grid-with-custom-styles',
+          ready: function() {
+            this.$$('v-grid').data.source = myBigData;
+          }
+        });
+      });
+    </script>
+    <my-grid-with-custom-styles></my-grid-with-custom-styles>
+  </li>
+
+  <li>
+    <h3>Simplest possible with material design theme</h3>
+    <dom-module id="my-material-grid">
+      <style include="material-design-theme"></style>
+
+      <template>
+        <!--<style include="shared-styles"></style>-->
+        <v-grid selection-mode='multi'>
+          <table>
+            <col header-text="Name">
+            <col header-text="Value">
+            <col header-text="Progress">
+
+            <tfoot>
+            <tr>
+              <th colspan=3>This is a footer line in a cell</th>
+            </tr>
+            <tr>
+              <th colspan=3><span>Some widgets in a footer</span> <input type=text/> <button>Click</button></th>
+            </tr>
+            </tfoot>
+          </table>
+        </v-grid>
+      </template>
+    </dom-module>
+    <script>
+      HTMLImports.whenReady(function() {
+        Polymer({
+          is: 'my-material-grid',
+          ready: function() {
+            this.$$('v-grid').data.source = myBigData;
+          }
+        });
+      });
+    </script>
+    <my-material-grid></my-material-grid>
+  </li>
+
   <li>
   <h3>Simplest possible with inline data</h3>
   <v-grid rows=1>
@@ -610,103 +691,6 @@ td.blue, th.blue, .blue th, .blue td, td.foot2, .foot2 td {
 
       });
     </script>
-  </li>
-
-  <li>
-    <h3>Simplest possible with custom styles</h3>
-    <dom-module id="my-grid-with-custom-styles">
-      <style>
-        :host {
-          --v-grid-color: #7e5e18;
-          --v-grid-background-color: azure;
-          --v-grid-header-color: blueviolet;
-          --v-grid-footer-color: darkgreen;
-          --v-grid-header-background-color: #e4f3f3;
-          --v-grid-footer-background-color: ivory;
-
-          --v-grid: {
-            border: 1px solid lime;
-          }
-
-          --v-grid-row: {
-            border-left: 1px dotted;
-          }
-          --v-grid-hovered-row: {
-            border-left: 4px dotted;
-          }
-          --v-grid-selected-row: {
-            border-left: 4px solid;
-          }
-          --v-grid-focused-row: {
-            border-left: 4px solid red;
-          }
-
-          --v-grid-cell: {
-
-          }
-          --v-grid-hovered-cell: {
-            background-color: #80deea;
-            font-weight: bold;
-          }
-          --v-grid-selected-cell: {
-            font-style: italic;
-            text-decoration: line-through;
-          }
-
-          --v-grid-row-after: {
-            background-color: red;
-          }
-          --v-grid-focused-row-after: {
-            -webkit-transform: scaleX(.5);
-            transform: scaleX(.5);
-          }
-
-          --v-grid-header-row: {
-            font-size: 15px;
-          }
-          --v-grid-header-cell: {
-            text-align: center;
-          }
-
-          --v-grid-footer-row: {
-            font-size: 15px;
-          }
-          --v-grid-footer-cell: {
-            text-align: right;
-          }
-        }
-      </style>
-
-      <template>
-        <v-grid selection-mode='multi'>
-          <table>
-            <col header-text="Name">
-            <col header-text="Value">
-            <col header-text="Progress">
-
-            <tfoot>
-            <tr>
-              <th colspan=3>This is a footer line in a cell</th>
-            </tr>
-            <tr>
-              <th colspan=3><span>Some widgets in a footer</span> <input type=text/> <button>Click</button></th>
-            </tr>
-            </tfoot>
-          </table>
-        </v-grid>
-      </template>
-    </dom-module>
-    <script>
-      HTMLImports.whenReady(function() {
-        Polymer({
-          is: 'my-grid-with-custom-styles',
-          ready: function() {
-            this.$$('v-grid').data.source = myBigData;
-          }
-        });
-      });
-    </script>
-    <my-grid-with-custom-styles></my-grid-with-custom-styles>
   </li>
 
 </ol>

--- a/vaadin-components-gwt/src/main/webapp/vaadin-grid/demo.html
+++ b/vaadin-components-gwt/src/main/webapp/vaadin-grid/demo.html
@@ -612,6 +612,103 @@ td.blue, th.blue, .blue th, .blue td, td.foot2, .foot2 td {
     </script>
   </li>
 
+  <li>
+    <h3>Simplest possible with custom styles</h3>
+    <dom-module id="my-grid-with-custom-styles">
+      <style>
+        :host {
+          --v-grid-color: #7e5e18;
+          --v-grid-background-color: azure;
+          --v-grid-header-color: blueviolet;
+          --v-grid-footer-color: darkgreen;
+          --v-grid-header-background-color: #e4f3f3;
+          --v-grid-footer-background-color: ivory;
+
+          --v-grid: {
+            border: 1px solid lime;
+          }
+
+          --v-grid-row: {
+            border-left: 1px dotted;
+          }
+          --v-grid-hovered-row: {
+            border-left: 4px dotted;
+          }
+          --v-grid-selected-row: {
+            border-left: 4px solid;
+          }
+          --v-grid-focused-row: {
+            border-left: 4px solid red;
+          }
+
+          --v-grid-cell: {
+
+          }
+          --v-grid-hovered-cell: {
+            background-color: #80deea;
+            font-weight: bold;
+          }
+          --v-grid-selected-cell: {
+            font-style: italic;
+            text-decoration: line-through;
+          }
+
+          --v-grid-row-after: {
+            background-color: red;
+          }
+          --v-grid-focused-row-after: {
+            -webkit-transform: scaleX(.5);
+            transform: scaleX(.5);
+          }
+
+          --v-grid-header-row: {
+            font-size: 15px;
+          }
+          --v-grid-header-cell: {
+            text-align: center;
+          }
+
+          --v-grid-footer-row: {
+            font-size: 15px;
+          }
+          --v-grid-footer-cell: {
+            text-align: right;
+          }
+        }
+      </style>
+
+      <template>
+        <v-grid selection-mode='multi'>
+          <table>
+            <col header-text="Name">
+            <col header-text="Value">
+            <col header-text="Progress">
+
+            <tfoot>
+            <tr>
+              <th colspan=3>This is a footer line in a cell</th>
+            </tr>
+            <tr>
+              <th colspan=3><span>Some widgets in a footer</span> <input type=text/> <button>Click</button></th>
+            </tr>
+            </tfoot>
+          </table>
+        </v-grid>
+      </template>
+    </dom-module>
+    <script>
+      HTMLImports.whenReady(function() {
+        Polymer({
+          is: 'my-grid-with-custom-styles',
+          ready: function() {
+            this.$$('v-grid').data.source = myBigData;
+          }
+        });
+      });
+    </script>
+    <my-grid-with-custom-styles></my-grid-with-custom-styles>
+  </li>
+
 </ol>
 </body>
 </html>

--- a/vaadin-components-gwt/src/main/webapp/vaadin-grid/material-design-theme.html
+++ b/vaadin-components-gwt/src/main/webapp/vaadin-grid/material-design-theme.html
@@ -1,0 +1,11 @@
+<link rel='import' href='../bower_components/paper-styles/paper-styles.html'>
+
+<dom-module id="material-design-theme">
+  <template>
+    <style>
+      :root {
+
+      }
+    </style>
+  </template>
+</dom-module>

--- a/vaadin-components-gwt/src/main/webapp/vaadin-grid/ugly-theme.html
+++ b/vaadin-components-gwt/src/main/webapp/vaadin-grid/ugly-theme.html
@@ -1,0 +1,65 @@
+<dom-module id="ugly-theme">
+  <template>
+    <style>
+      :root {
+        --v-grid-color: #7e5e18;
+        --v-grid-background-color: azure;
+        --v-grid-header-color: blueviolet;
+        --v-grid-footer-color: darkgreen;
+        --v-grid-header-background-color: #e4f3f3;
+        --v-grid-footer-background-color: ivory;
+
+        --v-grid: {
+          border: 1px solid lime;
+        }
+
+        --v-grid-row: {
+          border-left: 1px dotted;
+        }
+        --v-grid-hovered-row: {
+          border-left: 4px dotted;
+        }
+        --v-grid-selected-row: {
+          border-left: 4px solid;
+        }
+        --v-grid-focused-row: {
+          border-left: 4px solid red;
+        }
+
+        --v-grid-cell: {
+
+        }
+        --v-grid-hovered-cell: {
+          background-color: #80deea;
+          font-weight: bold;
+        }
+        --v-grid-selected-cell: {
+          font-style: italic;
+          text-decoration: line-through;
+        }
+
+        --v-grid-row-after: {
+          background-color: red;
+        }
+        /*--v-grid-focused-row-after: {
+          -webkit-transform: scaleX(.5);
+          transform: scaleX(.5);
+        }*/
+
+        --v-grid-header-row: {
+          font-size: 15px;
+        }
+        --v-grid-header-cell: {
+          text-align: center;
+        }
+
+        --v-grid-footer-row: {
+          font-size: 15px;
+        }
+        --v-grid-footer-cell: {
+          text-align: right;
+        }
+      }
+    </style>
+  </template>
+</dom-module>

--- a/vaadin-components-gwt/src/main/webapp/vaadin-grid/vaadin-grid.html
+++ b/vaadin-components-gwt/src/main/webapp/vaadin-grid/vaadin-grid.html
@@ -3,6 +3,7 @@
 -->
 
 <link rel='import' href='../bower_components/polymer/polymer.html'>
+<link rel='import' href='../bower_components/paper-styles/paper-styles.html'>
 <!-- <script src="VaadinGridImport.nocache.js"></script> -->
 
 <style>
@@ -35,6 +36,35 @@ Basic usage:
 </v-grid>
 ```
 
+### Styling
+
+The following custom properties and mixins are available for styling:
+
+Custom property | Description | Default
+----------------|-------------|----------
+`--v-grid-background-color`        | Grid background color                                            | `--primary-background-color`
+`--v-grid-color`                   | Grid foreground color                                            | `rgba(0, 0, 0, 0.87)`
+`--v-grid-header-color`            | Foreground color for a header                                    | `rgba(0, 0, 0, 0.54)`
+`--v-grid-header-background-color` | Background color for a header                                    | ``
+`--v-grid-footer-color`            | Foreground color for a footer                                    | `rgba(0, 0, 0, 0.56)`
+`--v-grid-footer-background-color` | Background color for a footer                                    | ``
+`--v-grid`                         | Mixin applied to the grid                                        | `{}`
+`--v-grid-row`                     | Mixin applied to the row                                         | `{}`
+`--v-grid-focused-row`             | Mixin applied to the focused row                                 | `{}`
+`--v-grid-hovered-row`             | Mixin applied to the row under the mouse pointer                 | `{}`
+`--v-grid-selected-row`            | Mixin applied to the selected row                                | `{}`
+`--v-grid-cell`                    | Mixin applied to the cell                                        | `{}`
+`--v-grid-focused-cell`            | Mixin applied to the focused cell                                | `{}`
+`--v-grid-hovered-cell`            | Mixin applied to the cell under the mouse pointer                | `{}`
+`--v-grid-selected-cell`           | Mixin applied to the cell in the selected row                    | `{}`
+`--v-grid-row-after`               | Mixin applied to the ::after pseudo-element for the row          | `{}`
+`--v-grid-selected-row-after`      | Mixin applied to the ::after pseudo-element for the focused row  | `{}`
+`--v-grid-header-row`              | Mixin applied to the row in the header                           | `{}`
+`--v-grid-header-cell`             | Mixin applied to the cell in the header                          | `{}`
+`--v-grid-footer-row`              | Mixin applied to the row in the footer                           | `{}`
+`--v-grid-footer-cell`             | Mixin applied to the cell in the footer                          | `{}`
+
+
 More examples available at http://vaadin.github.io/components-examples/v-grid/
 -->
 <dom-module id="v-grid">
@@ -46,10 +76,12 @@ More examples available at http://vaadin.github.io/components-examples/v-grid/
     box-sizing: border-box;
     display: block;
     font: 400 13px/1.1 Roboto, sans-serif;
-    color: rgba(0, 0, 0, 0.87);
+    color: var(--v-grid-color, rgba(0, 0, 0, 0.87));
     cursor: default;
     transition: opacity 50ms;
     white-space: nowrap;
+
+    @apply(--v-grid);
   }
 
   :host(.v-grid-loading) {
@@ -167,10 +199,14 @@ More examples available at http://vaadin.github.io/components-examples/v-grid/
     left: 0;
     top: 0;
     position: absolute;
+
+    @apply(--v-grid-row);
   }
 
   .v-grid-body td {
     opacity: 0;
+
+    @apply(--v-grid-cell);
   }
 
   .v-grid-row-has-data td {
@@ -184,12 +220,24 @@ More examples available at http://vaadin.github.io/components-examples/v-grid/
     display: block;
   }
 
+  tbody .v-grid-row:hover {
+    @apply(--v-grid-hovered-row);
+  }
+
   tbody .v-grid-row:hover td {
     background-color: #eeeeee;
+
+    @apply(--v-grid-hovered-cell);
+  }
+
+  tbody .v-grid-row-selected {
+    @apply(--v-grid-selected-row);
   }
 
   .v-grid-row-selected td {
     background-color: #f5f5f5;
+
+    @apply(--v-grid-selected-cell);
   }
 
   /* Focus styles */
@@ -206,16 +254,22 @@ More examples available at http://vaadin.github.io/components-examples/v-grid/
     -webkit-transform: scaleX(0.0);
     transform: scaleX(0.0);
     z-index: 1;
+
+    @apply(--v-grid-row-after);
   }
 
   :focus .v-grid-row-focused:after {
     -webkit-transform: scaleX(1.0);
     transform: scaleX(1.0);
+
+    @apply(--v-grid-focused-row-after);
   }
 
   :focus .v-grid-row-focused {
     -webkit-animation: v-grid-row-focused 820ms ease-in-out;
     animation: v-grid-row-focused 820ms ease-in-out;
+
+    @apply(--v-grid-focused-row);
   }
 
   @-webkit-keyframes v-grid-row-focused {
@@ -238,7 +292,7 @@ More examples available at http://vaadin.github.io/components-examples/v-grid/
   .v-grid-cell {
     -webkit-align-items: center;
     align-items: center;
-    background-color: white;
+    background-color: var(--v-grid-background-color, --primary-background-color);
     box-sizing: border-box;
     display: -webkit-inline-flex;
     display: inline-flex;
@@ -259,14 +313,19 @@ More examples available at http://vaadin.github.io/components-examples/v-grid/
   }
 
   .v-grid-header tr {
-    color: rgba(0, 0, 0, 0.54);
+    color: var(--v-grid-header-color, rgba(0, 0, 0, 0.54));
     font-size: 12px;
     height: 56px;
+
+    @apply(--v-grid-header-row);
   }
 
   .v-grid-header th {
     font-weight: 500;
     text-align: left;
+    background-color: var(--v-grid-header-background-color);
+
+    @apply(--v-grid-header-cell);
   }
 
   .v-grid-header-deco {
@@ -314,11 +373,18 @@ More examples available at http://vaadin.github.io/components-examples/v-grid/
     box-shadow: 0 -1px 0 rgba(0, 0, 0, 0.2);
   }
 
+  .v-grid-footer tr {
+    @apply(--v-grid-footer-row);
+  }
+
   .v-grid-footer td {
     font-size: 12px;
     font-weight: 500;
-    color: rgba(0, 0, 0, 0.56);
+    color: var(--v-grid-footer-color, rgba(0, 0, 0, 0.5));
+    background-color: var(--v-grid-footer-background-color);
     height: 56px;
+
+    @apply(--v-grid-footer-cell);
   }
 
   .v-grid-footer-deco {

--- a/vaadin-components-gwt/src/main/webapp/vaadin-grid/vaadin-grid.html
+++ b/vaadin-components-gwt/src/main/webapp/vaadin-grid/vaadin-grid.html
@@ -3,7 +3,6 @@
 -->
 
 <link rel='import' href='../bower_components/polymer/polymer.html'>
-<link rel='import' href='../bower_components/paper-styles/paper-styles.html'>
 <!-- <script src="VaadinGridImport.nocache.js"></script> -->
 
 <style>
@@ -265,11 +264,7 @@ More examples available at http://vaadin.github.io/components-examples/v-grid/
     width: 2px;
     pointer-events: none;
     position: absolute;
-    right: 0;
-    transition: all 0.16s ease-in-out;
-    -webkit-transform: scaleX(0.0);
-    transform: scaleX(0.0);
-    z-index: 1;
+    z-index: 2;
 
     @apply(--v-grid-row-after);
   }

--- a/vaadin-components-package/bower.json
+++ b/vaadin-components-package/bower.json
@@ -18,6 +18,7 @@
     "**/tests"
   ],
   "dependencies": {
-    "polymer": "Polymer/polymer#~1.0.2"
+    "polymer": "Polymer/polymer#~1.0.2",
+    "paper-styles": "PolymerElements/paper-styles#~1.0.2"
   }
 }

--- a/vaadin-components-package/bower.json
+++ b/vaadin-components-package/bower.json
@@ -18,6 +18,7 @@
     "**/tests"
   ],
   "dependencies": {
-    "polymer": "Polymer/polymer#v1.0.9"
+    "polymer": "Polymer/polymer#~1.1.0",
+    "paper-styles": "PolymerElements/paper-styles#~1.0.2"
   }
 }


### PR DESCRIPTION
Allow developers to easily modify the theme of v-grid to suit their brand colors etc. By default vaadin-grid should not look like Material Design, that should be an optional addition (or we could provide a "barebone" version of the element).

Use the paper-styles custom properties as the default values for any suitable properties (such as colors): https://github.com/PolymerElements/paper-styles

- [ ] Research the ways how styles can be imported in Polymer (i.e. affecting all component instances, affecting instances with a certain class, affecting only a single instance)
- [ ] Decide the use cases we want to support (e.g. I want to have most grids with the Material Design but some with a custom theme)
- [ ] Design the pieces of the theme that should be customizable (start small)
- [ ] Design and add a new example to the "Sizing and Styling" section which shows one alternate theme

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/vaadin/components/93)
<!-- Reviewable:end -->
