### PR TITLE
Fix excessive calls when setting the `frozenColumns` property

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,7 +6,7 @@ has its own repository.
 - Removed old demos used for developing.
 - Issues fixed:
   - Exception when removing frozen column (#147)
-  - Fix excessive calls when setting the "frozenColumns" property
+  - Fix double setter calls when setting property value
 
 ## Vaadin Grid v0.3.0.beta7 (2015-Sept)
 - Polymer updated to v1.1.1

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ has its own repository.
 - Removed old demos used for developing.
 - Issues fixed:
   - Exception when removing frozen column (#147)
+  - Fix excessive calls when setting the "frozenColumns" property
 
 ## Vaadin Grid v0.3.0.beta7 (2015-Sept)
 - Polymer updated to v1.1.1

--- a/java/src/main/java/com/vaadin/components/grid/GridComponent.java
+++ b/java/src/main/java/com/vaadin/components/grid/GridComponent.java
@@ -91,6 +91,8 @@ public class GridComponent implements SelectionHandler<Object>,
 
     public static final int MAX_AUTO_ROWS = 10;
 
+    private int _frozenColumns;
+
     public GridComponent() {
         grid = new ViolatedGrid();
         grid.setSelectionModel(new IndexBasedSelectionModelSingle());
@@ -218,7 +220,11 @@ public class GridComponent implements SelectionHandler<Object>,
     }
 
     public void setFrozenColumns(int frozenColumn) {
-        grid.setFrozenColumnCount(JSValidate.Integer.val(frozenColumn, 0, 0));
+        if (getColumns().size() > 0) {
+            grid.setFrozenColumnCount(JSValidate.Integer.val(frozenColumn, 0, 0));
+        } else {
+            this._frozenColumns = frozenColumn;
+        }
     }
 
     public void scrollToRow(int index, String scrollDestination) {
@@ -326,6 +332,10 @@ public class GridComponent implements SelectionHandler<Object>,
                 @Override
                 public void onChange(List<ChangeRecord> changes) {
                     setColumns(cols);
+                    if (_frozenColumns > 0) {
+                        setFrozenColumns(_frozenColumns);
+                        _frozenColumns = 0;
+                    }
                 }
             });
         }

--- a/java/src/main/java/com/vaadin/components/grid/GridComponent.java
+++ b/java/src/main/java/com/vaadin/components/grid/GridComponent.java
@@ -91,8 +91,6 @@ public class GridComponent implements SelectionHandler<Object>,
 
     public static final int MAX_AUTO_ROWS = 10;
 
-    private int frozenColumns;
-
     public GridComponent() {
         grid = new ViolatedGrid();
         grid.setSelectionModel(new IndexBasedSelectionModelSingle());
@@ -220,10 +218,7 @@ public class GridComponent implements SelectionHandler<Object>,
     }
 
     public void setFrozenColumns(int frozenColumn) {
-        if (getColumns().size() > 0) {
-            grid.setFrozenColumnCount(JSValidate.Integer.val(frozenColumn, 0, 0));
-        }
-        this.frozenColumns = frozenColumn;
+        grid.setFrozenColumnCount(JSValidate.Integer.val(frozenColumn, 0, 0));
     }
 
     public void scrollToRow(int index, String scrollDestination) {
@@ -338,8 +333,6 @@ public class GridComponent implements SelectionHandler<Object>,
         if (getDataSource() != null) {
             getDataSource().refresh();
         }
-
-        setFrozenColumns(Math.min(frozenColumns, columns.size()));
     }
 
     /**

--- a/java/src/main/java/com/vaadin/components/grid/GridComponent.java
+++ b/java/src/main/java/com/vaadin/components/grid/GridComponent.java
@@ -91,7 +91,7 @@ public class GridComponent implements SelectionHandler<Object>,
 
     public static final int MAX_AUTO_ROWS = 10;
 
-    private int _frozenColumns;
+    private int frozenColumns;
 
     public GridComponent() {
         grid = new ViolatedGrid();
@@ -222,9 +222,8 @@ public class GridComponent implements SelectionHandler<Object>,
     public void setFrozenColumns(int frozenColumn) {
         if (getColumns().size() > 0) {
             grid.setFrozenColumnCount(JSValidate.Integer.val(frozenColumn, 0, 0));
-        } else {
-            this._frozenColumns = frozenColumn;
         }
+        this.frozenColumns = frozenColumn;
     }
 
     public void scrollToRow(int index, String scrollDestination) {
@@ -332,10 +331,6 @@ public class GridComponent implements SelectionHandler<Object>,
                 @Override
                 public void onChange(List<ChangeRecord> changes) {
                     setColumns(cols);
-                    if (_frozenColumns > 0) {
-                        setFrozenColumns(_frozenColumns);
-                        _frozenColumns = 0;
-                    }
                 }
             });
         }
@@ -343,6 +338,8 @@ public class GridComponent implements SelectionHandler<Object>,
         if (getDataSource() != null) {
             getDataSource().refresh();
         }
+
+        setFrozenColumns(Math.min(frozenColumns, columns.size()));
     }
 
     /**

--- a/test/grid-editing-columns.html
+++ b/test/grid-editing-columns.html
@@ -489,6 +489,15 @@
       });
     });
 
+    it('should call _frozenColumnsChanged observer only once', function () {
+      var spy = sinon.spy(grid._grid, "setFrozenColumns");
+      grid.frozenColumns = 2;
+
+      return grid.then(function () {
+        expect(spy.calledOnce).to.be.true;
+      });
+    });
+
   });
 </script>
 

--- a/vaadin-grid.html
+++ b/vaadin-grid.html
@@ -1114,10 +1114,7 @@ More examples available at http://vaadin.github.io/components-examples/vaadin-gr
 
       _frozenColumnsChanged: function(newValue, oldValue) {
         if (newValue != oldValue) {
-          var grid = this._grid;
-          setTimeout(function () {
-            grid.setFrozenColumns(newValue);
-          });
+          this._grid.setFrozenColumns(newValue);
         }
       },
 

--- a/vaadin-grid.html
+++ b/vaadin-grid.html
@@ -1115,7 +1115,7 @@ More examples available at http://vaadin.github.io/components-examples/vaadin-gr
       _frozenColumnsChanged: function(newValue, oldValue) {
         if (newValue != oldValue) {
           var grid = this._grid;
-          this.then(function () {
+          setTimeout(function () {
             grid.setFrozenColumns(newValue);
           });
         }

--- a/vaadin-grid.html
+++ b/vaadin-grid.html
@@ -697,28 +697,6 @@ More examples available at http://vaadin.github.io/components-examples/vaadin-gr
 
       properties: {
         /**
-         * The number of frozen columns in this grid. Setting it to 0
-         * means that no data columns will be frozen, but the built-in selection
-         * checkbox column will still be frozen if it's in use. Setting the count to
-         * -1 will also disable the selection column.
-         *
-         * Attribute: `frozen-columns`
-         *
-         * @property {number} frozenColumns
-         * @default 0
-         * @type {number}
-         */
-        frozenColumns: {
-          type: Number,
-          notify: true,
-          reflectToAttribute: true,
-          value: function() {
-            return this._grid.getFrozenColumns();
-          },
-          observer: '_frozenColumnsChanged'
-        },
-
-        /**
          * Object for controlling and accessing the data source of the grid.
          *
          * @property {Data} data
@@ -1112,9 +1090,25 @@ More examples available at http://vaadin.github.io/components-examples/vaadin-gr
         this.reflectPropertyToAttribute("disabled");
       },
 
-      _frozenColumnsChanged: function(newValue, oldValue) {
-        if (newValue != oldValue) {
-          this._grid.setFrozenColumns(newValue);
+      /**
+       * The number of frozen columns in this grid. Setting it to 0
+       * means that no data columns will be frozen, but the built-in selection
+       * checkbox column will still be frozen if it's in use. Setting the count to
+       * -1 will also disable the selection column.
+       *
+       * Attribute: `frozen-columns`
+       *
+       * @property {number} frozenColumns
+       * @default 0
+       * @type {number}
+       */
+      get frozenColumns() {
+        return this._grid.getFrozenColumns();
+      },
+      set frozenColumns(frozenColumns) {
+        if (frozenColumns != this.frozenColumns) {
+          this._grid.setFrozenColumns(frozenColumns);
+          this.reflectPropertyToAttribute("frozenColumns");
         }
       },
 

--- a/vaadin-grid.html
+++ b/vaadin-grid.html
@@ -697,6 +697,28 @@ More examples available at http://vaadin.github.io/components-examples/vaadin-gr
 
       properties: {
         /**
+         * The number of frozen columns in this grid. Setting it to 0
+         * means that no data columns will be frozen, but the built-in selection
+         * checkbox column will still be frozen if it's in use. Setting the count to
+         * -1 will also disable the selection column.
+         *
+         * Attribute: `frozen-columns`
+         *
+         * @property {number} frozenColumns
+         * @default 0
+         * @type {number}
+         */
+        frozenColumns: {
+          type: Number,
+          notify: true,
+          reflectToAttribute: true,
+          value: function() {
+            return this._grid.getFrozenColumns();
+          },
+          observer: '_frozenColumnsChanged'
+        },
+
+        /**
          * Object for controlling and accessing the data source of the grid.
          *
          * @property {Data} data
@@ -1090,24 +1112,13 @@ More examples available at http://vaadin.github.io/components-examples/vaadin-gr
         this.reflectPropertyToAttribute("disabled");
       },
 
-      /**
-       * The number of frozen columns in this grid. Setting it to 0
-       * means that no data columns will be frozen, but the built-in selection
-       * checkbox column will still be frozen if it's in use. Setting the count to
-       * -1 will also disable the selection column.
-       *
-       * Attribute: `frozen-columns`
-       *
-       * @property {number} frozenColumns
-       * @default 0
-       * @type {number}
-       */
-      get frozenColumns() {
-        return this._grid.getFrozenColumns();
-      },
-      set frozenColumns(frozenColumns) {
-        this._grid.setFrozenColumns(frozenColumns);
-        this.reflectPropertyToAttribute("frozenColumns");
+      _frozenColumnsChanged: function(newValue, oldValue) {
+        if (newValue != oldValue) {
+          var grid = this._grid;
+          this.then(function () {
+            grid.setFrozenColumns(newValue);
+          });
+        }
       },
 
       /**

--- a/vaadin-grid.html
+++ b/vaadin-grid.html
@@ -876,10 +876,15 @@ More examples available at http://vaadin.github.io/components-examples/vaadin-gr
       attributeChanged: function(name, type, value) {
         switch (name) {
           case 'disabled':
-            this.disabled = typeof value == "string";
+            var disabled = typeof value == "string";
+            if (this.disabled != disabled) {
+              this.disabled = disabled;
+            }
             break;
           case 'selection-mode':
-            this.selection.mode = value;
+            if (this.selection.mode != value) {
+              this.selection.mode = value;
+            }
             break;
           default:
             var property = Polymer.CaseMap.dashToCamelCase(name);

--- a/vaadin-grid.html
+++ b/vaadin-grid.html
@@ -882,7 +882,10 @@ More examples available at http://vaadin.github.io/components-examples/vaadin-gr
             this.selection.mode = value;
             break;
           default:
-            this[Polymer.CaseMap.dashToCamelCase(name)] = value;
+            var property = Polymer.CaseMap.dashToCamelCase(name);
+            if (this[property] != value) {
+              this[property] = value;
+            }
         }
       },
 
@@ -1106,10 +1109,8 @@ More examples available at http://vaadin.github.io/components-examples/vaadin-gr
         return this._grid.getFrozenColumns();
       },
       set frozenColumns(frozenColumns) {
-        if (frozenColumns != this.frozenColumns) {
-          this._grid.setFrozenColumns(frozenColumns);
-          this.reflectPropertyToAttribute("frozenColumns");
-        }
+        this._grid.setFrozenColumns(frozenColumns);
+        this.reflectPropertyToAttribute("frozenColumns");
       },
 
       /**


### PR DESCRIPTION


<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-grid/155)
<!-- Reviewable:end -->
