### PR TITLE
Fixed selenium-standalone to 4.7.0 for now

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "gulp-util": "latest",
     "gulp-watch": "latest",
     "web-component-tester": "3.3.10",
+    "selenium-standalone" : "4.7.0",
     "yargs": "latest"
   },
   "devDependencies": {


### PR DESCRIPTION
Something wrong with the newly released 4.8.0. This is needed for now to make CI work

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-grid/285)
<!-- Reviewable:end -->
