### PR TITLE
Corrected invalid scroll-bar if grid is full sized in window

### DIFF
--- a/test/grid-resizing.html
+++ b/test/grid-resizing.html
@@ -249,6 +249,8 @@
 
           beforeEach(function() {
             return grid.then(function() {
+              document.body.style.margin=0;
+              document.body.style.padding=0;
               grid.style.position = 'absolute';
               grid.style.width = '100%';
               grid.style.height = '100%';
@@ -265,6 +267,7 @@
           it('should match dimensions with the surrounding div', function(done) {
             waitUntil(function() {
               return height(grid) === document.body.clientHeight &&
+                document.body.scrollHeight === height(grid) &&
                 Math.abs(document.body.clientWidth - width(grid)) <= 1;
             }, done);
           });

--- a/vaadin-grid.html
+++ b/vaadin-grid.html
@@ -512,6 +512,7 @@ See the [demo](demo/index.html) for use case examples.
     pointer-events: none !important;
     position: absolute !important;
     left: -100% !important;
+    top: -100% !important;
     opacity: 0 !important;
     /* This is used to force a non-zero client height to the measure object. */
     padding-bottom: 1px !important;


### PR DESCRIPTION
If you have the grid in Fullscreen the measure-iframe looks a bit over the bottom of the grid and so a vertical scrollbar is created. M solution is to move the measure-iframe also on y-axis (top: -100%).

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-grid/320)
<!-- Reviewable:end -->
