### PR TITLE
Changing this.colums to this.columns

### DIFF
--- a/vaadin-grid.html
+++ b/vaadin-grid.html
@@ -1115,7 +1115,7 @@ See the [demo](demo/index.html) for use case examples.
       if (this.hasAttribute('selection-mode')) {
         this.selection.mode = this.getAttribute('selection-mode');
       }
-      if (this.colums) {
+      if (this.columns) {
         this._grid.setColumns(this.columns);
       } else {
         this.columns = this._grid.getColumns();


### PR DESCRIPTION
I expect `this.colums` to be a typo and should be `this.columns`. This makes it possible to set the `columns` directly on the Web Component.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-grid/397)
<!-- Reviewable:end -->
