### PR TITLE
Clear selection on refresh items

### DIFF
--- a/test/grid-binding-data.html
+++ b/test/grid-binding-data.html
@@ -282,6 +282,14 @@
           expect(qLocal('.vaadin-grid-body .vaadin-grid-cell')).to.exist;
         });
       });
+
+      it('should clear selection', function() {
+        grid.selection.select(0);
+
+        grid.refreshItems();
+
+        expect(grid.selection.selected()).to.be.empty;
+      });
     });
 
     describe('size', function() {

--- a/vaadin-grid.html
+++ b/vaadin-grid.html
@@ -1457,6 +1457,7 @@ See the [demo](demo/index.html) for use case examples.
      * @type {Function}
      */
     refreshItems: function() {
+      this.selection.clear();
       if (this._grid.getDataSource()) {
         this._grid.getDataSource().refreshItems();
       }


### PR DESCRIPTION
Fixes #344 

When `refreshItems()` is called, data is refetched from the data source. As we have no guarantee that the items returned will be the same and/or in same order as before, there's a high possibility that `selected` indexes are incorrect. This leads to situations like described in #344.

In some cases clearing the selection on refresh might be undesirable, if we won't do it by default, the alternative solution would be to add documentation and instruct users to clear the selection manually before calling `refreshItems()`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-grid/476)
<!-- Reviewable:end -->
