### PR TITLE
Fix scrolling for iOS 10

### DIFF
--- a/vaadin-grid-table-outer-scroller.html
+++ b/vaadin-grid-table-outer-scroller.html
@@ -17,6 +17,15 @@
       :host([passthrough]) {
         pointer-events: none;
       }
+
+      :host([ios]) {
+        pointer-events: all;
+        z-index: -3;
+      }
+
+      :host([ios][scrolling]) {
+        z-index: 0;
+      }
     </style>
 
     <content></content>
@@ -34,6 +43,11 @@
         passthrough: {
           reflectToAttribute: true,
           value: true
+        },
+
+        scrolling: {
+          type: Boolean,
+          reflectToAttribute: true
         }
       },
 
@@ -71,6 +85,8 @@
           this.scrollLeft = this.domHost._scrollLeft;
         }
         this._syncingScrollTarget = false;
+
+        this._scrolling();
       },
 
       _syncScrollTarget: function() {
@@ -83,6 +99,15 @@
           this.domHost._ignoreScroll = true;
         }
         this._syncingOuterScroller = false;
+
+        this._scrolling();
+      },
+
+      _scrolling: function() {
+        this.scrolling = true;
+        this.debounce('scrolling-stopped', function() {
+          this.scrolling = false;
+        }, 100);
       }
     });
   </script>

--- a/vaadin-grid-table.html
+++ b/vaadin-grid-table.html
@@ -138,7 +138,7 @@
       <tfoot id="footer" is="vaadin-grid-table-footer" columns="[[columns]]" frozen-columns="[[frozenColumns]]"></tfoot>
     </table>
 
-    <vaadin-grid-table-outer-scroller id="outerscroller" scroll-target="[[scrollTarget]]" hidden="[[_hideOuterScroller(scrollbarWidth, safari)]]">
+    <vaadin-grid-table-outer-scroller id="outerscroller" scroll-target="[[scrollTarget]]" hidden="[[_hideOuterScroller(scrollbarWidth, safari)]]" ios$=[[ios]]>
       <div is="vaadin-grid-sizer" scroll-height="[[_estScrollHeight]]" columns="[[columns]]"></div>
     </vaadin-grid-table-outer-scroller>
 


### PR DESCRIPTION
Using z-index to hide outerscroller behind the table instead of using pointer-events: none

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-grid/480)
<!-- Reviewable:end -->
