### PR TITLE
Make sure _ignoreScroll gets cleared

### DIFF
--- a/test/helpers.html
+++ b/test/helpers.html
@@ -44,7 +44,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   function scrollToEnd(grid, callback) {
     var table = grid.$.scroller.$.table;
-    table.addEventListener('scroll', function () {
+    var listener = function () {
       grid.async(function () {
         table.scrollTop = table.scrollHeight;
       }, 1);
@@ -52,9 +52,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       grid.debounce('scroll-done', function () {
         // Ensure rows are in order
         grid.flushDebouncer('reorderrows');
+        table.removeEventListener('scroll', listener);
         callback();
       }, 100);
-    });
+    };
+    table.addEventListener('scroll', listener);
     table.scrollTop = table.scrollHeight;
   }
 

--- a/test/outer-scroller.html
+++ b/test/outer-scroller.html
@@ -51,11 +51,11 @@
         expect(spy.called).to.be.true;
       });
 
-      it('should invoke frozen element translate handler once', function(done) {
+      it('should invoke frozen element translate handler', function(done) {
         var spy = sinon.spy(scroller, '_translateStationaryElements');
         outerScroller.scrollLeft = 1;
         setTimeout(function () {
-          expect(spy.callCount).to.equal(1);
+          expect(spy.called).to.be.true;
           done();
         }, 200);
       });

--- a/test/row-height.html
+++ b/test/row-height.html
@@ -209,6 +209,45 @@
         };
       });
 
+      it('should not misalign on resize (wheel)', function(done) {
+        init('default-content');
+        scrollToEnd(grid, function() {
+          // Simulate a wheel event that doesn't cause a scroll event
+          var e = new CustomEvent('wheel', {bubbles: true});
+          e.deltaY = 0;
+          e.deltaX = -100;
+          scroller.$.table.dispatchEvent(e);
+
+          // Simulate a (window) resize
+          grid.style.width = '200px';
+          scroller.fire('iron-resize');
+
+          scroller.async(function() {
+            expect(header.getBoundingClientRect().top).to.be.closeTo(scroller.getBoundingClientRect().top, 1);
+            done();
+          }, 100);
+        });
+      });
+
+      it('should not misalign on resize (outer-scroller)', function(done) {
+        init('default-content');
+        scrollToEnd(grid, function() {
+          scroller.$.outerscroller.addEventListener('scroll', function() {
+            // Simulate a (window) resize
+            grid.style.width = '200px';
+            scroller.fire('iron-resize');
+
+            scroller.async(function() {
+              expect(header.getBoundingClientRect().top).to.be.closeTo(scroller.getBoundingClientRect().top, 1);
+              done();
+            }, 100);
+          });
+
+          // Scroll with the outer-scroller
+          scroller.$.outerscroller.scrollTop = 100;
+        });
+      });
+
     });
   </script>
 

--- a/vaadin-grid-table-outer-scroller.html
+++ b/vaadin-grid-table-outer-scroller.html
@@ -96,7 +96,6 @@
           this.scrollTarget.scrollLeft = this.scrollLeft;
 
           this.domHost._scrollHandler();
-          this.domHost._ignoreScroll = true;
         }
         this._syncingOuterScroller = false;
 

--- a/vaadin-grid-table-scroll-behavior.html
+++ b/vaadin-grid-table-scroll-behavior.html
@@ -78,7 +78,6 @@
       this.$.table.scrollTop += e.deltaY;
       this.$.table.scrollLeft += e.deltaX;
       this._scrollHandler();
-      this._ignoreScroll = true;
     },
 
     _adjustVirtualIndexOffset: function(delta) {

--- a/vaadin-grid-table.html
+++ b/vaadin-grid-table.html
@@ -317,11 +317,6 @@
      * items in the viewport and recycle tiles as needed.
      */
     _scrollHandler: function(e) {
-      // We may ignore a duplicate invocation if this was handled on wheel event already
-      if (this._ignoreScroll && e) {
-        this._ignoreScroll = false;
-        return;
-      }
       // clamp the `scrollTop` value
       var scrollTop = Math.max(0, Math.min(this._maxScrollTop, this._scrollTop));
       var delta = scrollTop - this._scrollPosition;


### PR DESCRIPTION
If scroller._ignoreScroll is true while resizing the grid, the headers/footers might get misplaced. This PR makes sure  _ignoreScroll flag gets cleared.
<img width="457" alt="screenshot 2016-10-07 12 00 00" src="https://cloud.githubusercontent.com/assets/1222264/19193232/f7f3f408-8cb1-11e6-92fd-f20e42e54161.png">

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-grid/481)
<!-- Reviewable:end -->
