### PR TITLE
Fix the count of visible scrollers

### DIFF
--- a/test/helpers.html
+++ b/test/helpers.html
@@ -11,6 +11,23 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <script>
   var defaultCellWidth = 100;
 
+  function getScrollbarWidth() {
+    // Create the measurement node
+    var scrollDiv = document.createElement("div");
+    scrollDiv.style.width = '100px';
+    scrollDiv.style.height = '100px';
+    scrollDiv.style.overflow = 'scroll';
+    scrollDiv.style.position = 'absolute';
+    scrollDiv.style.top = '-9999px';
+    document.body.appendChild(scrollDiv);
+    // Get the scrollbar width
+    var scrollbarWidth = scrollDiv.offsetWidth - scrollDiv.clientWidth;
+
+    // Delete the DIV
+    document.body.removeChild(scrollDiv);
+    return scrollbarWidth;
+  }
+
   function infiniteDataSource(opts, callback) {
     callback(Array.apply(null, Array(opts.pageSize)).map(function(item, index) { return {value: 'foo' + index}; } ));
   }

--- a/test/outer-scroller.html
+++ b/test/outer-scroller.html
@@ -138,23 +138,6 @@
           node.dispatchEvent(e);
         }
 
-        var scrollbarWidth = (function() {
-          // Create the measurement node
-          var scrollDiv = document.createElement("div");
-          scrollDiv.style.width = '100px';
-          scrollDiv.style.height = '100px';
-          scrollDiv.style.overflow = 'scroll';
-          scrollDiv.style.position = 'absolute';
-          scrollDiv.style.top = '-9999px';
-          document.body.appendChild(scrollDiv);
-          // Get the scrollbar width
-          var scrollbarWidth = scrollDiv.offsetWidth - scrollDiv.clientWidth;
-
-          // Delete the DIV
-          document.body.removeChild(scrollDiv);
-          return scrollbarWidth;
-        })();
-
         function outerScrollerInUse() {
           return window.getComputedStyle(outerScroller).pointerEvents !== 'none';
         }
@@ -170,7 +153,7 @@
 
         it('should not passtrough iff scrollbars exist (vertical scrollbar hover)', function(done) {
           scroller.addEventListener('mousemove', function() {
-            expect(outerScrollerInUse()).to.be[scrollbarWidth > 0 ? 'true' : 'false'];
+            expect(outerScrollerInUse()).to.be[getScrollbarWidth() > 0 ? 'true' : 'false'];
             done();
           });
           move(tableRect.width, 1);
@@ -178,7 +161,7 @@
 
         it('should not passtrough iff scrollbars exist (horizontal scrollbar hover)', function(done) {
           scroller.addEventListener('mousemove', function() {
-            expect(outerScrollerInUse()).to.be[scrollbarWidth > 0 ? 'true' : 'false'];
+            expect(outerScrollerInUse()).to.be[getScrollbarWidth() > 0 ? 'true' : 'false'];
             done();
           });
           move(1, tableRect.height);

--- a/test/scrolling-mode.html
+++ b/test/scrolling-mode.html
@@ -43,6 +43,13 @@
         return window.getComputedStyle(element).position === 'fixed';
       }
 
+      it('should have the right amount of scrollbars/scrollers', function() {
+        var scrollbars = 0;
+        scrollbars += window.getComputedStyle(scroller.$.table).overflow === 'hidden' ? 0 : 1;
+        scrollbars += window.getComputedStyle(scroller.$.outerscroller).overflow === 'hidden' ? 0 : 1;
+        expect(scrollbars).to.equal(getScrollbarWidth() > 0 ? 2 : 1);
+      });
+
       it('should/should not have fixed container elements depending on scrolling mode', function() {
         expect(isFixed(scroller.$.items)).to.equal(fixedContainers);
         expect(isFixed(scroller.$.header)).to.equal(fixedContainers);

--- a/vaadin-grid-table.html
+++ b/vaadin-grid-table.html
@@ -63,7 +63,7 @@
         background: #fff;
       }
 
-      table[overflow-hidden] {
+      [overflow-hidden] {
         overflow: hidden;
       }
 
@@ -161,7 +161,7 @@
       <tfoot id="footer" is="vaadin-grid-table-footer" columns="[[columns]]" frozen-columns="[[frozenColumns]]"></tfoot>
     </table>
 
-    <vaadin-grid-table-outer-scroller id="outerscroller" scroll-target="[[scrollTarget]]" hidden="[[_hideOuterScroller(scrollbarWidth, safari)]]" ios$=[[ios]]>
+    <vaadin-grid-table-outer-scroller id="outerscroller" scroll-target="[[scrollTarget]]" overflow-hidden$="[[_hideOuterScroller(scrollbarWidth, safari)]]" ios$=[[ios]]>
       <div is="vaadin-grid-sizer" scroll-height="[[_estScrollHeight]]" columns="[[columns]]"></div>
     </vaadin-grid-table-outer-scroller>
 


### PR DESCRIPTION
The grid shows 2 scollbars (on top of each other) (on native shadow) since the `display: block;` defined in `:host` seems to be stronger than `hidden`.

Instead of trying to hide the outer scroller use the same approach as with the table element and set it's overflow hidden to hide the scrollbar.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-grid/495)
<!-- Reviewable:end -->
