### PR TITLE
Use a data attribute for cell content id

### DIFF
--- a/vaadin-grid-table-cell.html
+++ b/vaadin-grid-table-cell.html
@@ -108,10 +108,10 @@
         if (Polymer.Settings.useShadow) {
           // Shadow
           target._contentIndex = target._contentIndex + 1 || 0;
-          this._cellContent.setAttribute('cell-content-id', target._contentIndex);
+          this._cellContent.setAttribute('data-cell-content-id', target._contentIndex);
 
           var content = document.createElement('content');
-          content.setAttribute('select', '[cell-content-id="' + target._contentIndex +'"]');
+          content.setAttribute('select', '[data-cell-content-id="' + target._contentIndex +'"]');
           Polymer.dom(this).appendChild(content);
         } else {
           // Non-shadow


### PR DESCRIPTION
The current 'cell-content-id' is a non-standard attribute for a div element

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-grid/496)
<!-- Reviewable:end -->
