### PR TITLE
Improve Safari support by stripping nested CSS calc keywords

### DIFF
--- a/test/column-group.html
+++ b/test/column-group.html
@@ -81,6 +81,12 @@
         expect(group._width).to.eql('calc(20% + 200px)');
       });
 
+      it('should strip nested `calc` keywords', function() {
+        columns[0].width = 'calc(50% + 10px)';
+
+        expect(group._width).to.eql('calc((50% + 10px) + 200px)');
+      });
+
       it('should react to child column flex changes', function() {
         columns[0].flex = 3;
 

--- a/vaadin-grid-column.html
+++ b/vaadin-grid-column.html
@@ -201,7 +201,7 @@
 
       _updateFlexAndWidth: function(visibleChildColumns) {
         this._width = 'calc(' + visibleChildColumns.reduce(function(prev, curr) {
-          return prev += ' + ' + (curr.width || '0');
+          return prev += ' + ' + (curr.width || '0').replace('calc', '');
         }, '').substring(3) + ')';
 
         this._flex = visibleChildColumns.reduce(function(prev, curr) {


### PR DESCRIPTION
Fixes #523

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-grid/524)
<!-- Reviewable:end -->
