### PR TITLE
Use a dedicated spinner element

### DIFF
--- a/vaadin-grid-data-source-behavior.html
+++ b/vaadin-grid-data-source-behavior.html
@@ -17,7 +17,7 @@
           transform: rotate(360deg);
         }
       }
-      :host(::before) {
+      #spinner {
         border: 2px solid var(--primary-color, #03A9F4);
         border-radius: 50%;
         border-right-color: transparent;
@@ -34,7 +34,7 @@
         opacity: 0;
       }
 
-      :host([loading]::before)  {
+      :host([loading]) #spinner  {
         opacity: 1;
         -webkit-animation: vaadin-grid-spin-360 400ms linear infinite;
         animation: vaadin-grid-spin-360 400ms linear infinite;

--- a/vaadin-grid-table.html
+++ b/vaadin-grid-table.html
@@ -162,6 +162,7 @@
       }
     </style>
     <content select="vaadin-grid-column, vaadin-grid-column-group"></content>
+    <div id="spinner"></div>
     <table id="table" class="table table-striped" overflow-hidden$="[[_hideTableOverflow(scrollbarWidth, safari)]]">
       <caption>
         <div is="vaadin-grid-sizer" scroll-height="[[_estScrollHeight]]" column-tree="[[columnTree]]">


### PR DESCRIPTION
Animations seem to get ignored by host pseudo-elements. A browser bug perhaps.

Fixes #491

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-grid/545)
<!-- Reviewable:end -->
