### PR TITLE
Templatize templates in separate templatizer elements

### DIFF
--- a/demo/columns.html
+++ b/demo/columns.html
@@ -12,6 +12,7 @@
 
   <link rel="import" href="../../paper-checkbox/paper-checkbox.html">
   <link rel="import" href="../../paper-input/paper-input.html">
+  <link rel="import" href="../../paper-button/paper-button.html">
   <link rel="import" href="../../iron-image/iron-image.html">
   <link rel="import" href="../../paper-menu/paper-menu.html">
   <link rel="import" href="../../paper-item/paper-item.html">
@@ -187,6 +188,43 @@
         </dom-module>
       </template>
       <x-grid></x-grid>
+    </demo-snippet>
+
+    <demo-snippet>
+      <h3>Dynamic Columns using dom-repeat</h3>
+      <template>
+        <x-dynamic-columns></x-dynamic-columns>
+        <dom-module id="x-dynamic-columns">
+          <template>
+            <x-data-source data-source="{{dataSource}}"></x-data-source>
+            <vaadin-grid id="grid" data-source="[[dataSource]]" size="200">
+              <template is="dom-repeat" items="[[columns]]" as="column">
+                <vaadin-grid-column>
+                  <template class="header">[[column]]</template>
+                  <template>[[_itemProperty(item, column)]]</template>
+                </vaadin-grid-column>
+              </template>
+            </vaadin-grid>
+          </template>
+          <script>
+            Polymer({
+              is: 'x-dynamic-columns',
+
+              properties: {
+                columns: Array
+              },
+
+              ready: function() {
+                this.columns = ['name.first', 'name.last', 'email'];
+              },
+
+              _itemProperty: function(item, column) {
+                return this.get('user.' + column, item);
+              }
+            });
+          </script>
+        </dom-module>
+      </template>
     </demo-snippet>
   </div>
 </body>

--- a/test/column-groups.html
+++ b/test/column-groups.html
@@ -187,8 +187,7 @@
           expect(cells).not.to.be.empty;
 
           cells.forEach(function(cell) {
-            var el = getCellContent(cell);
-            expect(el.matches(':empty')).to.be.true;
+            expect(cell._isEmpty).to.be.true;
           });
         });
 
@@ -204,8 +203,7 @@
           expect(cells).not.to.be.empty;
 
           cells.forEach(function(cell) {
-            var el = getCellContent(cell);
-            expect(el.matches(':empty')).to.be.true;
+            expect(cell._isEmpty).to.be.true;
           });
         });
 

--- a/vaadin-grid-column.html
+++ b/vaadin-grid-column.html
@@ -1,4 +1,5 @@
 <link rel="import" href="../polymer/polymer.html">
+<link rel="import" href="vaadin-grid-templatizer.html">
 
 <dom-module id="vaadin-grid-column">
 </dom-module>
@@ -71,10 +72,22 @@
     },
 
     _headerTemplateChanged: function(headerTemplate) {
+      if (headerTemplate) {
+        var templatizer = new vaadin.elements.grid.Templatizer(this.dataHost);
+        templatizer._instanceProps = {};
+        templatizer.template = headerTemplate;
+      }
+
       this.fire('property-changed', {path: 'headerTemplate', value: headerTemplate});
     },
 
     _footerTemplateChanged: function(footerTemplate) {
+      if (footerTemplate) {
+        var templatizer = new vaadin.elements.grid.Templatizer(this.dataHost);
+        templatizer._instanceProps = {};
+        templatizer.template = footerTemplate;
+      }
+
       this.fire('property-changed', {path: 'footerTemplate', value: footerTemplate});
     },
 
@@ -125,6 +138,14 @@
     },
 
     _templateChanged: function(template) {
+      var templatizer = new vaadin.elements.grid.Templatizer(this.dataHost);
+
+      // body cell templatizer needs to be attached so that `item-changed` and
+      // `template-instance-changed` events propagate to grid.
+      Polymer.dom(this.root).appendChild(templatizer);
+
+      templatizer.template = template;
+
       // We bubble false for optimisation
       this.fire('property-changed', {path: 'template', value: template}, {bubbles: false});
     },

--- a/vaadin-grid-data-source-behavior.html
+++ b/vaadin-grid-data-source-behavior.html
@@ -65,6 +65,10 @@
    */
   vaadin.elements.grid.DataSourceBehavior = {
 
+    listeners: {
+      'item-changed': '_templateItemChanged'
+    },
+
     properties: {
 
       /**
@@ -101,6 +105,25 @@
           return {};
         }
       },
+    },
+
+    _templateItemChanged: function(e) {
+      var item = e.detail.item;
+
+      // TODO: We could avoid iterating rows by fixing _physicalIndexForKey mapping
+      // in iron-list-behavior so that vidx could be used to fetch the correct row element.
+      Polymer.dom(this.$.scroller.$.items).children.forEach(function(row) {
+        if (row.item === item) {
+          row.iterateCells(function(cell) {
+            // replacing the whole item instead of updating just the updated path
+            // to prevent _forwardInstancePath from firing duplicate `item-changed`
+            // events on all the sibling cells.
+            // main goal is just to get the [[item.xxx]] bindings up-to-date.
+            cell.instance.item = null;
+            cell.instance.item = item;
+          });
+        }
+      });
     },
 
     _getCachedItem: function(index) {

--- a/vaadin-grid-row-details-behavior.html
+++ b/vaadin-grid-row-details-behavior.html
@@ -1,3 +1,5 @@
+<link rel="import" href="vaadin-grid-templatizer.html">
+
 <dom-module id="vaadin-grid-row-details-styles">
   <template>
     <style>
@@ -39,7 +41,8 @@
     },
 
     observers: [
-      '_expandedItemsChanged(expandedItems.*, dataSource)'
+      '_expandedItemsChanged(expandedItems.*, dataSource)',
+      '_rowDetailsTemplateChanged(rowDetailsTemplate)'
     ],
 
     _expandedItemsChanged: function(expandedItems, dataSource) {
@@ -47,6 +50,21 @@
       this.$.scroller._physicalItems.forEach(function(row) {
         row.expanded = this._isExpanded(row.item);
       }.bind(this));
+    },
+
+    _rowDetailsTemplateChanged: function(rowDetailsTemplate) {
+      var templatizer = new vaadin.elements.grid.Templatizer(this.dataHost);
+      templatizer._instanceProps = {
+        expanded: true,
+        item: true,
+        selected: true
+      };
+
+      // row details templatizer needs to be attached so that `item-changed` and
+      // `template-instance-changed` events propagate to grid.
+      Polymer.dom(this.root).appendChild(templatizer);
+
+      templatizer.template = rowDetailsTemplate;
     },
 
     _isExpanded: function(item) {

--- a/vaadin-grid-table-cell.html
+++ b/vaadin-grid-table-cell.html
@@ -40,11 +40,11 @@
         target: Object,
         width: String,
 
-        _forwardedParentProps: Object,
         _childColumns: Array,
 
         _cellContent: Object,
-        _insertionPoint: Object
+        _insertionPoint: Object,
+        _templatizer: Object
       },
 
       observers: ['_columnChanged(column)',
@@ -53,22 +53,14 @@
         '_flexChanged(flex)',
         '_indexChanged(index, instance)',
         '_itemChanged(item, instance)',
-        '_forwardedParentPropsChanged(_forwardedParentProps.*, instance)',
+        '_instanceChanged(instance, target)',
         '_selectedChanged(selected, instance)',
         '_toggleContent(isAttached, _cellContent, _insertionPoint)',
+        '_toggleInstance(isAttached, _templatizer, instance)',
         '_widthChanged(width)',
         '_visibleChildColumnsChanged(_visibleChildColumns)',
         '_childColumnsChanged(_childColumns)'
       ],
-
-      created: function() {
-        this._instanceProps = {
-          expanded: true,
-          index: true,
-          item: true,
-          selected: true
-        };
-      },
 
       _columnChanged: function(column) {
         this.flex = column.flex;
@@ -106,7 +98,8 @@
       },
 
       _expandedChanged: function(expanded, instance) {
-        instance.notifyPath('expanded', expanded);
+        instance.__expanded__ = expanded;
+        instance.expanded = expanded;
       },
 
       _flexChanged: function(flex) {
@@ -114,17 +107,16 @@
       },
 
       _indexChanged: function(index, instance) {
-        instance.notifyPath('index', index);
+        instance.index = index;
       },
 
       _itemChanged: function(item, instance) {
-        // use assignment here instead of notifyPath to avoid triggering
-        // forwardInstancePath for path "item" on cells unnecessarily.
         instance.item = item;
       },
 
       _selectedChanged: function(selected, instance) {
-        instance.notifyPath('selected', selected);
+        instance.__selected__ = selected;
+        instance.selected = selected;
       },
 
       _childColumnsChanged: function(childColumns) {
@@ -146,38 +138,24 @@
         }
       },
 
+      _toggleInstance: function(isAttached, templatizer, instance) {
+        if (isAttached) {
+          templatizer.addInstance(instance);
+        } else {
+          templatizer.removeInstance(instance);
+        }
+      },
+
       _widthChanged: function(width) {
         this.style.flexBasis = width;
       },
 
-      _templateChanged: function(template, target) {
-        this.templatize(template);
+      _templateChanged: function(template) {
+        this.instance = template.templatizer.createInstance();
+        this._templatizer = template.templatizer;
+      },
 
-        // fix _rootDataHost to the context where template has been defined
-        if (template._rootDataHost) {
-          this._getRootDataHost = function() {
-            return template._rootDataHost;
-          };
-        }
-
-        // TODO: hack to avoid: https://github.com/Polymer/polymer/issues/3307
-        this._parentProps = this._parentProps || {};
-
-        this.instance = this.stamp(null);
-        template.instances = template.instances || [];
-        this._templateInstances = template.instances;
-        template.instances.push(this.instance);
-
-        // use the same forwardedParentProps instance for all cells using the same template.
-        template.forwardedParentProps = template.forwardedParentProps || {};
-        this._forwardedParentProps = template.forwardedParentProps;
-
-        // initializing new template instance with previously forwarded parent props.
-        // could be done with observers, but this is simpler.
-        for (var key in this._forwardedParentProps) {
-          this.instance[key] = this._forwardedParentProps[key];
-        }
-
+      _instanceChanged: function(instance, target) {
         this.style.height = '';
 
         this._cellContent = document.createElement('div');
@@ -189,65 +167,6 @@
         this._insertionPoint = document.createElement('content');
         this._insertionPoint.setAttribute('select', '[data-cell-content-id="' + target._contentIndex + '"]');
       },
-
-      _forwardInstanceProp: function(inst, prop, value) {
-        // fire notification event only when a prop is changed through a user-action.
-        // e.g. 'expanded' is different from the originally bound '__expanded__' value.
-        if (this.parentElement &&
-          this.parentElement['__' + prop + '__'] !== undefined &&
-          this.parentElement['__' + prop + '__'] !== value) {
-
-          this.fire('template-instance-changed', {
-            prop: prop,
-            value: value,
-            inst: inst
-          });
-        }
-      },
-
-      _forwardInstancePath: function(inst, path, value) {
-        // TODO: assuming we're currently just listening to [[item.xxxx]] properties
-        // which affect only cells on the current row.
-        if (path.indexOf('item.') === 0) {
-          this.parentElement.iterateCells(function(cell) {
-            if (cell.instance) {
-              cell.instance.notifyPath(path, value);
-            }
-          });
-
-          // instance.notifyPath above will call _forwardInstancePath recursively,
-          // so need to debounce to avoid firing the same event multiple times.
-          this.parentElement.debounce('item-changed', function() {
-            // stripping 'item.' from path.
-            this.parentElement.fire('item-changed', {
-              item: inst.item,
-              path: path.substring(5),
-              value: value
-            });
-          }.bind(this));
-        }
-      },
-
-      _forwardParentProp: function(prop, value) {
-        // _forwardParentProp might be called during this.stamp() before
-        // this.instance is set. We need to delay it until instance is set.
-        this.set('_forwardedParentProps.' + prop, value);
-      },
-
-      _forwardParentPath: function(path, value) {
-        this.set('_forwardedParentProps.' + path, value);
-      },
-
-      _forwardedParentPropsChanged: function(parentProps) {
-        if (parentProps.path !== '_forwardedParentProps') {
-          var prop = parentProps.path.substring(parentProps.path.indexOf('.') + 1);
-          var value = parentProps.value;
-
-          this._templateInstances.forEach(function(inst) {
-            inst.notifyPath(prop, value);
-          });
-        }
-      }
     };
 
     Polymer({
@@ -256,20 +175,17 @@
       extends: 'td',
 
       behaviors: [
-        Polymer.Templatizer,
         vaadinGridTableCellBehavior,
         vaadin.elements.grid.CellClickBehavior
       ],
 
-      observers: ['_templateChanged(template, target)'],
+      observers: ['_templateChanged(template)'],
 
       _cellClick: function() {
         this.fire('cell-click', {
           model: this.instance
         });
-
       }
-
     });
 
     Polymer({
@@ -282,20 +198,21 @@
       },
 
       behaviors: [
-        Polymer.Templatizer,
         vaadinGridTableCellBehavior
       ],
 
-      observers: ['_headerTemplateChanged(headerTemplate, target)'],
+      observers: ['_headerTemplateChanged(headerTemplate)'],
 
-      _headerTemplateChanged: function(headerTemplate, target) {
+      _headerTemplateChanged: function(headerTemplate) {
         if (headerTemplate !== null && (this._isColumnRow || this.column.localName === 'vaadin-grid-column-group')) {
           this._isEmpty = false;
-          this._templateChanged(headerTemplate, target);
+          this.instance = headerTemplate.templatizer.createInstance();
+          this._templatizer = headerTemplate.templatizer;
         } else {
           this._isEmpty = true;
-          this._templateChanged(document.createElement('template'), target);
+          this.instance = {root: document.createElement('div')};
         }
+
         this.fire('cell-empty-changed');
       }
     });
@@ -310,20 +227,21 @@
       },
 
       behaviors: [
-        Polymer.Templatizer,
         vaadinGridTableCellBehavior
       ],
 
-      observers: ['_footerTemplateChanged(footerTemplate, target)'],
+      observers: ['_footerTemplateChanged(footerTemplate)'],
 
-      _footerTemplateChanged: function(footerTemplate, target) {
+      _footerTemplateChanged: function(footerTemplate) {
         if (footerTemplate !== null && (this._isColumnRow || this.column.localName === 'vaadin-grid-column-group')) {
-          this._templateChanged(footerTemplate, target);
           this._isEmpty = false;
+          this.instance = footerTemplate.templatizer.createInstance();
+          this._templatizer = footerTemplate.templatizer;
         } else {
-          this._templateChanged(document.createElement('template'), target);
           this._isEmpty = true;
+          this.instance = {root: document.createElement('div')};
         }
+
         this.fire('cell-empty-changed');
       }
     });

--- a/vaadin-grid-table-row.html
+++ b/vaadin-grid-table-row.html
@@ -78,7 +78,6 @@
           }
         }
 
-        this.__expanded__ = expanded;
         this.iterateCells(function(cell) {
           cell.expanded = expanded;
         });
@@ -148,14 +147,12 @@
       },
 
       _selectedChanged: function(selected, cells) {
-        this.__selected__ = selected;
         cells.forEach(function(cell) {
           cell.selected = selected;
         });
       },
 
       _selectedChangedForDetails: function(selected, rowDetails) {
-        this.__selected__ = selected;
         if (rowDetails) {
           rowDetails.selected = selected;
         }

--- a/vaadin-grid-templatizer.html
+++ b/vaadin-grid-templatizer.html
@@ -1,0 +1,111 @@
+<link rel="import" href="../polymer/polymer.html">
+
+<script>
+  window.vaadin = window.vaadin || {};
+  vaadin.elements = vaadin.elements || {};
+  vaadin.elements.grid = vaadin.elements.grid || {};
+
+  vaadin.elements.grid.Templatizer = Polymer({
+    is: 'vaadin-grid-templatizer',
+
+    factoryImpl: function(dataHost) {
+      this.dataHost = dataHost;
+    },
+
+    behaviors: [Polymer.Templatizer],
+
+    properties: {
+      template: Object,
+
+      _forwardedParentProps: Object,
+      _templateInstances: Array
+    },
+
+    observers: ['_templateChanged(template)', '_forwardedParentPropsChanged(_forwardedParentProps.*, _templateInstances)'],
+
+    created: function() {
+      this._instanceProps = {
+        expanded: true,
+        index: true,
+        item: true,
+        selected: true
+      };
+    },
+
+    createInstance: function() {
+      var instance = this.stamp(null);
+      this.addInstance(instance);
+
+      return instance;
+    },
+
+    addInstance: function(instance) {
+      if (this._templateInstances.indexOf(instance) === -1) {
+        this._templateInstances.push(instance);
+      }
+    },
+
+    removeInstance: function(instance) {
+      var index = this._templateInstances.indexOf(instance);
+
+      this._templateInstances.splice(index, 1);
+    },
+
+    _templateChanged: function(template) {
+      this._forwardedParentProps = {};
+      this._templateInstances = [];
+      template.templatizer = this;
+      this.templatize(template);
+
+      // TODO: hack to avoid: https://github.com/Polymer/polymer/issues/3307
+      this._parentProps = this._parentProps || {};
+    },
+
+    _forwardInstanceProp: function(inst, prop, value) {
+      // fire notification event only when a prop is changed through a user-action.
+      // e.g. 'expanded' is different from the originally bound '__expanded__' value.
+      if (inst['__' + prop + '__'] !== undefined &&
+        inst['__' + prop + '__'] !== value) {
+        this.fire('template-instance-changed', {
+          prop: prop,
+          value: value,
+          inst: inst
+        });
+      }
+    },
+
+    _forwardInstancePath: function(inst, path, value) {
+      // TODO: assuming we're currently just listening to [[item.xxxx]] properties
+      // which affect only cells on the current row.
+      if (path.indexOf('item.') === 0) {
+        this.fire('item-changed', {
+          item: inst.item,
+          // stripping 'item.' from path.
+          path: path.substring(5),
+          value: value
+        });
+      }
+    },
+
+    _forwardParentProp: function(prop, value) {
+      // _forwardParentProp might be called during this.stamp() before
+      // this.instance is set. We need to delay it until instance is set.
+      this.set('_forwardedParentProps.' + prop, value);
+    },
+
+    _forwardParentPath: function(path, value) {
+      this.set('_forwardedParentProps.' + path, value);
+    },
+
+    _forwardedParentPropsChanged: function(e, templateInstances) {
+      if (e.path !== '_forwardedParentProps') {
+        var prop = e.path.substring(e.path.indexOf('.') + 1);
+        var value = e.value;
+
+        templateInstances.forEach(function(inst) {
+          inst.notifyPath(prop, value);
+        });
+      }
+    }
+  });
+</script>

--- a/vaadin-grid.html
+++ b/vaadin-grid.html
@@ -86,7 +86,7 @@
 
     ready: function() {
       this._updateColumnTree();
-      this.rowDetailsTemplate = Polymer.dom(this).querySelector('template.row-details');
+      this.rowDetailsTemplate = Polymer.dom(this).querySelector('template.row-details') || undefined;
     },
 
     _columnPropChanged: function(e) {


### PR DESCRIPTION
Fixes #531 
Fixes #564 

This makes sure each template is only templatized once and that no element
never templatized more than one template.

Also, patches a memory leak which happened due to not removing template
instances from templateInstances array when cells get removed during column
tree update.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-grid/580)
<!-- Reviewable:end -->
