### PR TITLE
Clear cache when data source changes.

### DIFF
--- a/vaadin-grid-data-source-behavior.html
+++ b/vaadin-grid-data-source-behavior.html
@@ -83,7 +83,10 @@
        *
        * `params.pageSize` Current page size
        */
-      dataSource: Function,
+      dataSource: {
+        type: Function,
+        observer: '_dataSourceChanged'
+      },
 
       /**
        * `true` while data is being requested from the data source.
@@ -250,6 +253,12 @@
 
     _pageSizeChanged: function(pageSize, oldPageSize) {
       if (oldPageSize !== undefined && pageSize !== oldPageSize) {
+        this.clearCache();
+      }
+    },
+
+    _dataSourceChanged: function(dataSource, oldDataSource) {
+      if (oldDataSource !== undefined && dataSource !== oldDataSource) {
         this.clearCache();
       }
     }


### PR DESCRIPTION
If the data source is changed, the grid will display incorrect data.
A similar observer was removed in 96db6c2 to address an issue with
the first page loading twice on startup, noting that there was
another observer in place for dataSource. There no longer appears
to be any other observer on the dataSource property, nor does this
change appear to cause a regression where the first page loads twice
on startup.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-grid/585)
<!-- Reviewable:end -->
