### PR TITLE
Fix/2.0 flex api

### DIFF
--- a/demo/dev.html
+++ b/demo/dev.html
@@ -51,7 +51,7 @@
             <paper-input value="{{item.user.name.last}}"></paper-input>
           </template>
 
-          <vaadin-grid-column width="45px" flex="0" frozen>
+          <vaadin-grid-column width="45px" flex-grow="0" frozen>
             <template>
               [[index]]
             </template>
@@ -69,7 +69,25 @@
               TGF1
             </template>
 
-            <vaadin-grid-column width="20%">
+            <vaadin-grid-column width="300px" flex-shrink="1" flex-grow="0">
+              <template>
+                <span class="elItem">[[item.user.name.first]]</span>
+              </template>
+              <template class="header">
+                <vaadin-grid-sorter path="user.name.first">TC1</vaadin-grid-sorter>
+              </template>
+              <template class="footer">
+                TCF1
+              </template>
+            </vaadin-grid-column>
+
+            <vaadin-grid-column-group>
+
+              <template class="header">
+                Waat
+              </template>
+
+            <vaadin-grid-column width="300px" flex-shrink="1" flex-grow="0">
               <template>
                 <span class="elItem">[[item.user.name.first]]</span>
               </template>
@@ -92,6 +110,8 @@
                 <vaadin-grid-filter path="user.name.last"></vaadin-grid-filter>
               </template>
             </vaadin-grid-column>
+
+            </vaadin-grid-column-group>
 
           </vaadin-grid-column-group>
 

--- a/demo/index.html
+++ b/demo/index.html
@@ -130,11 +130,11 @@
         <template is="dom-bind">
           <x-data-source data-source="{{dataSource}}"></x-data-source>
           <vaadin-grid data-source="[[dataSource]]" size="200">
-            <vaadin-grid-column width="30px" flex="0">
+            <vaadin-grid-column width="30px" flex-grow="0">
               <template class="header">#</template>
               <template>[[index]]</template>
             </vaadin-grid-column>
-            <vaadin-grid-column width="50px" flex="0">
+            <vaadin-grid-column width="50px" flex-grow="0">
               <template class="header"></template>
               <template>
                 <iron-image src="[[item.user.picture.thumbnail]]"></iron-image>

--- a/demo/selection.html
+++ b/demo/selection.html
@@ -132,7 +132,7 @@
             </style>
             <x-data-source data-source="{{dataSource}}"></x-data-source>
             <vaadin-grid id="grid" data-source="[[dataSource]]" size="200">
-              <vaadin-grid-column width="40px" flex="0" >
+              <vaadin-grid-column width="40px" flex-grow="0" >
                 <template class="header">
                   <input type="checkbox" checked="{{inverted::change}}" />
                 </template>

--- a/docs/vaadin-grid-selection.adoc
+++ b/docs/vaadin-grid-selection.adoc
@@ -56,7 +56,7 @@ NOTE: that you have to explicitly import the element in your component in order 
 [[figure.vaadin-grid.selection.column]]
 image::img/vaadin-grid-selection-column.png[width="450"]
 
-In addition, you can customize the selection column by changing its [propertyname]#width#, [propertyname]#flexGrow#, [propertyname]#flexShrink# and [propertyname]#frozen# properties, or by providing your own templates.
+In addition, you can customize the selection column by changing its [propertyname]#width#, [propertyname]#flexGrow# and [propertyname]#frozen# properties, or by providing your own templates.
 
 [source,html]
 ----

--- a/docs/vaadin-grid-selection.adoc
+++ b/docs/vaadin-grid-selection.adoc
@@ -56,7 +56,7 @@ NOTE: that you have to explicitly import the element in your component in order 
 [[figure.vaadin-grid.selection.column]]
 image::img/vaadin-grid-selection-column.png[width="450"]
 
-In addition, you can customize the selection column by changing its [propertyname]#width#, [propertyname]#flex# and [propertyname]#frozen# properties, or by providing your own templates.
+In addition, you can customize the selection column by changing its [propertyname]#width#, [propertyname]#flexGrow#, [propertyname]#flexShrink# and [propertyname]#frozen# properties, or by providing your own templates.
 
 [source,html]
 ----
@@ -66,7 +66,7 @@ In addition, you can customize the selection column by changing its [propertynam
     <template>[[item]]</template>
   </vaadin-grid-column>
 
-  <vaadin-grid-selection-column width="40px" flex="0" select-all="[[selectAll]]">
+  <vaadin-grid-selection-column width="40px" flex-grow="0" select-all="[[selectAll]]">
     <template class="header">
       <paper-checkbox checked="{{selectAll}}"></paper-checkbox>
     </template>
@@ -122,7 +122,7 @@ For instance in the next example, we implement a single selection model by setti
         <template>[[item]]</template>
       </vaadin-grid-column>
 
-      <vaadin-grid-column width="40px" flex="0">
+      <vaadin-grid-column width="40px" flex-grow="0">
         <template>
           <input type="checkbox" on-change="_onSelectionChange" checked="[[selected]]"></input>
         </template>

--- a/test/column-group.html
+++ b/test/column-group.html
@@ -49,11 +49,11 @@
       <vaadin-grid-column-group>
         <template class="header"></template>
         <template class="footer"></template>
-        <vaadin-grid-column flex-grow="1" flex-shrink="2" width="20%">
+        <vaadin-grid-column flex-grow="1" width="20%">
           <template class="header"></template>
           <template></template>
         </vaadin-grid-column>
-        <vaadin-grid-column flex-grow="2" flex-shrink="1" width="200px">
+        <vaadin-grid-column flex-grow="2" width="200px">
           <template class="header"></template>
           <template></template>
         </vaadin-grid-column>
@@ -75,7 +75,6 @@
 
       it('should sum child column flex-grow', function() {
         expect(group.flexGrow).to.eql(3);
-        expect(group.flexShrink).to.eql(3);
       });
 
       it('should sum child column widths', function() {
@@ -92,12 +91,6 @@
         columns[0].flexGrow = 3;
 
         expect(group.flexGrow).to.eql(5);
-      });
-
-      it('should react to child column flex-shrink changes', function() {
-        columns[0].flexShrink = 3;
-
-        expect(group.flexShrink).to.eql(4);
       });
 
       it('should react to child column width changes', function() {
@@ -165,12 +158,6 @@
         columns[0].hidden = true;
 
         expect(group.flexGrow).to.eql(2);
-      });
-
-      it('should calculate column group flexShrink after hiding a column', function() {
-        columns[0].hidden = true;
-
-        expect(group.flexShrink).to.eql(1);
       });
     });
   </script>

--- a/test/column-group.html
+++ b/test/column-group.html
@@ -49,11 +49,11 @@
       <vaadin-grid-column-group>
         <template class="header"></template>
         <template class="footer"></template>
-        <vaadin-grid-column flex="1" width="20%">
+        <vaadin-grid-column flex-grow="1" flex-shrink="2" width="20%">
           <template class="header"></template>
           <template></template>
         </vaadin-grid-column>
-        <vaadin-grid-column flex="2" width="200px">
+        <vaadin-grid-column flex-grow="2" flex-shrink="1" width="200px">
           <template class="header"></template>
           <template></template>
         </vaadin-grid-column>
@@ -73,8 +73,9 @@
         group.async(done, 100);
       });
 
-      it('should sum child column flex', function() {
-        expect(group.flex).to.eql(3);
+      it('should sum child column flex-grow', function() {
+        expect(group.flexGrow).to.eql(3);
+        expect(group.flexShrink).to.eql(3);
       });
 
       it('should sum child column widths', function() {
@@ -87,10 +88,16 @@
         expect(group.width).to.eql('calc((50% + 10px) + 200px)');
       });
 
-      it('should react to child column flex changes', function() {
-        columns[0].flex = 3;
+      it('should react to child column flex-grow changes', function() {
+        columns[0].flexGrow = 3;
 
-        expect(group.flex).to.eql(5);
+        expect(group.flexGrow).to.eql(5);
+      });
+
+      it('should react to child column flex-shrink changes', function() {
+        columns[0].flexShrink = 3;
+
+        expect(group.flexShrink).to.eql(4);
       });
 
       it('should react to child column width changes', function() {
@@ -154,10 +161,16 @@
         expect(group.width).to.eql('calc(200px)');
       });
 
-      it('should calculate column group flex after hiding a column', function() {
+      it('should calculate column group flexGrow after hiding a column', function() {
         columns[0].hidden = true;
 
-        expect(group.flex).to.eql(2);
+        expect(group.flexGrow).to.eql(2);
+      });
+
+      it('should calculate column group flexShrink after hiding a column', function() {
+        columns[0].hidden = true;
+
+        expect(group.flexShrink).to.eql(1);
       });
     });
   </script>

--- a/test/column-groups.html
+++ b/test/column-groups.html
@@ -237,10 +237,10 @@
           var cell_group0 = getHeaderCell(0, 1);
           var cell_header1 = getHeaderCell(1, 1);
 
-          cell_group0._flexChanged = sinon.spy();
-          cell_header1.column.flex = 3;
+          cell_group0._flexGrowChanged = sinon.spy();
+          cell_header1.column.flexGrow = 3;
 
-          expect(cell_group0._flexChanged.callCount).to.eql(1);
+          expect(cell_group0._flexGrowChanged.callCount).to.eql(1);
         });
 
         it('should set colSpan to spanned header cells', function() {

--- a/test/column.html
+++ b/test/column.html
@@ -63,11 +63,11 @@
       describe('properties', function() {
         describe('flex', function() {
           it('should have default value', function() {
-            expect(column.flex).to.eql(1);
+            expect(column.flexGrow).to.eql(1);
           });
 
           it('should be bound to header cells', function() {
-            column.flex = 2;
+            column.flexGrow = 2;
 
             var header = grid.$.scroller.$.header;
 
@@ -76,13 +76,13 @@
           });
 
           it('should be bound to row cells', function() {
-            column.flex = 2;
+            column.flexGrow = 2;
 
             expect(grid.$.scroller._physicalItems[0].cells[0].style.flexGrow).to.eql('2');
           });
 
           it('should be bound to footer cells', function() {
-            column.flex = 2;
+            column.flexGrow = 2;
 
             expect(grid.$.scroller.$.footer._rows[0].cells[0].style.flexGrow).to.eql('2');
           });
@@ -98,19 +98,19 @@
 
             var header = grid.$.scroller.$.header;
 
-            expect(header._rows[0].cells[0].style.flexBasis).to.eql('calc(20% + 100px)');
+            expect(header._rows[0].cells[0].style.width).to.eql('calc(20% + 100px)');
           });
 
           it('should be bound to row cells', function() {
             column.width = '200px';
 
-            expect(grid.$.scroller._physicalItems[0].cells[0].style.flexBasis).to.eql('200px');
+            expect(grid.$.scroller._physicalItems[0].cells[0].style.width).to.eql('200px');
           });
 
           it('should be bound to footer cells', function() {
             column.width = '200px';
 
-            expect(grid.$.scroller.$.footer._rows[0].cells[0].style.flexBasis).to.eql('200px');
+            expect(grid.$.scroller.$.footer._rows[0].cells[0].style.width).to.eql('200px');
           });
         });
 

--- a/vaadin-grid-column.html
+++ b/vaadin-grid-column.html
@@ -91,8 +91,12 @@
       this.fire('property-changed', {path: 'footerTemplate', value: footerTemplate});
     },
 
-    _flexChanged: function(flex) {
-      this.fire('property-changed', {path: 'flex', value: flex});
+    _flexGrowChanged: function(flexGrow) {
+      this.fire('property-changed', {path: 'flexGrow', value: flexGrow});
+    },
+
+    _flexShrinkChanged: function(flexShrink) {
+      this.fire('property-changed', {path: 'flexShrink', value: flexShrink});
     },
 
     _widthChanged: function(width) {
@@ -114,9 +118,14 @@
         value: '100px'
       },
 
-      flex: {
+      flexGrow: {
         type: Number,
         value: 1
+      },
+
+      flexShrink: {
+        type: Number,
+        value: 0
       },
 
       template: {
@@ -131,7 +140,12 @@
       }
     },
 
-    observers: ['_flexChanged(flex)', '_widthChanged(width)', '_templateChanged(template)', '_frozenChanged(frozen)', '_hiddenChanged(hidden)'],
+    observers: ['_flexGrowChanged(flexGrow)',
+    '_flexShrinkChanged(flexShrink)',
+    '_widthChanged(width)',
+    '_templateChanged(template)',
+    '_frozenChanged(frozen)',
+    '_hiddenChanged(hidden)'],
 
     _frozenChanged: function(frozen) {
       this.fire('property-changed', {path: 'frozen', value: frozen});
@@ -153,7 +167,7 @@
     _hiddenChanged: function(hidden) {
       this.fire('property-changed', {path: 'hidden', value: hidden});
     }
-  }
+  },
 
   /**
    * @polymerBehavior vaadin.elements.grid.ColumnBehavior
@@ -181,7 +195,17 @@
         }
       },
 
-      flex: {
+      flexGrow: {
+        type: Number,
+        readOnly: true
+      },
+
+      minWidth: {
+        type: String,
+        readOnly: true
+      },
+
+      flexShrink: {
         type: Number,
         readOnly: true
       },
@@ -208,12 +232,14 @@
 
     observers: ['_updateVisibleChildColumns(_childColumns)',
     '_childColumnsChanged(_childColumns)',
-    '_flexChanged(flex)',
+    '_flexGrowChanged(flexGrow)',
+    '_flexShrinkChanged(flexShrink)',
     '_widthChanged(width)',
     '_frozenChanged(_childColumns, frozen)',
     '_hiddenChanged(hidden)',
     '_visibleChildColumnsChanged(_visibleChildColumns)',
-    '_colSpanChanged(colSpan)'],
+    '_colSpanChanged(colSpan)',
+    '_minWidthChanged(minWidth)'],
 
     listeners: {
       'property-changed': '_columnPropChanged'
@@ -226,6 +252,10 @@
 
     detached: function() {
       Polymer.dom(this).unobserveNodes(this._observer);
+    },
+
+    _minWidthChanged: function(minWidth) {
+      this.fire('property-changed', {path: 'minWidth', value: minWidth});
     },
 
     _columnPropChanged: function(e) {
@@ -261,9 +291,19 @@
         return prev += ' + ' + (curr.width || '0').replace('calc', '');
       }, '').substring(3) + ')');
 
-      this._setFlex(visibleChildColumns.reduce(function(prev, curr) {
-        return prev + curr.flex;
+      this._setFlexGrow(visibleChildColumns.reduce(function(prev, curr) {
+        return prev + curr.flexGrow;
       }, 0));
+      this._setFlexShrink(visibleChildColumns.reduce(function(prev, curr) {
+        return prev + curr.flexShrink;
+      }, 0));
+
+      this._setMinWidth('calc(' + visibleChildColumns.filter(function(column) {
+        return column.flexShrink === 0;
+      }).reduce(function(prev, curr) {
+        return prev += ' + ' + (curr.width || '0').replace('calc', '');
+      },'').substring(3) + ')');
+
     },
 
     _frozenChanged: function(childColumns, frozen) {

--- a/vaadin-grid-column.html
+++ b/vaadin-grid-column.html
@@ -95,10 +95,6 @@
       this.fire('property-changed', {path: 'flexGrow', value: flexGrow});
     },
 
-    _flexShrinkChanged: function(flexShrink) {
-      this.fire('property-changed', {path: 'flexShrink', value: flexShrink});
-    },
-
     _widthChanged: function(width) {
       this.fire('property-changed', {path: 'width', value: width});
     },
@@ -123,11 +119,6 @@
         value: 1
       },
 
-      flexShrink: {
-        type: Number,
-        value: 0
-      },
-
       template: {
         type: Object,
         value: function() {
@@ -141,7 +132,6 @@
     },
 
     observers: ['_flexGrowChanged(flexGrow)',
-    '_flexShrinkChanged(flexShrink)',
     '_widthChanged(width)',
     '_templateChanged(template)',
     '_frozenChanged(frozen)',
@@ -200,16 +190,6 @@
         readOnly: true
       },
 
-      minWidth: {
-        type: String,
-        readOnly: true
-      },
-
-      flexShrink: {
-        type: Number,
-        readOnly: true
-      },
-
       width: {
         type: String,
         readOnly: true
@@ -233,13 +213,11 @@
     observers: ['_updateVisibleChildColumns(_childColumns)',
     '_childColumnsChanged(_childColumns)',
     '_flexGrowChanged(flexGrow)',
-    '_flexShrinkChanged(flexShrink)',
     '_widthChanged(width)',
     '_frozenChanged(_childColumns, frozen)',
     '_hiddenChanged(hidden)',
     '_visibleChildColumnsChanged(_visibleChildColumns)',
-    '_colSpanChanged(colSpan)',
-    '_minWidthChanged(minWidth)'],
+    '_colSpanChanged(colSpan)'],
 
     listeners: {
       'property-changed': '_columnPropChanged'
@@ -254,16 +232,12 @@
       Polymer.dom(this).unobserveNodes(this._observer);
     },
 
-    _minWidthChanged: function(minWidth) {
-      this.fire('property-changed', {path: 'minWidth', value: minWidth});
-    },
-
     _columnPropChanged: function(e) {
       if (e.detail.path === 'hidden') {
         this._updateVisibleChildColumns(this._childColumns);
       }
 
-      if (/flex|width|hidden|_childColumns/.test(e.detail.path)) {
+      if (/flexGrow|width|hidden|_childColumns/.test(e.detail.path)) {
         this._updateFlexAndWidth(this._visibleChildColumns);
       }
 
@@ -294,16 +268,6 @@
       this._setFlexGrow(visibleChildColumns.reduce(function(prev, curr) {
         return prev + curr.flexGrow;
       }, 0));
-      this._setFlexShrink(visibleChildColumns.reduce(function(prev, curr) {
-        return prev + curr.flexShrink;
-      }, 0));
-
-      this._setMinWidth('calc(' + visibleChildColumns.filter(function(column) {
-        return column.flexShrink === 0;
-      }).reduce(function(prev, curr) {
-        return prev += ' + ' + (curr.width || '0').replace('calc', '');
-      },'').substring(3) + ')');
-
     },
 
     _frozenChanged: function(childColumns, frozen) {

--- a/vaadin-grid-table-cell.html
+++ b/vaadin-grid-table-cell.html
@@ -20,8 +20,6 @@
         column: Object,
         expanded: Boolean,
         flexGrow: Number,
-        flexShrink: Number,
-        minWidth: String,
         frozen: {
           type: Boolean,
           reflectToAttribute: true
@@ -53,7 +51,6 @@
         '_cellAttached(column, isAttached)',
         '_expandedChanged(expanded, instance)',
         '_flexGrowChanged(flexGrow)',
-        '_flexShrinkChanged(flexShrink)',
         '_indexChanged(index, instance)',
         '_itemChanged(item, instance)',
         '_instanceChanged(instance, target)',
@@ -62,13 +59,11 @@
         '_toggleInstance(isAttached, _templatizer, instance)',
         '_widthChanged(width)',
         '_visibleChildColumnsChanged(_visibleChildColumns)',
-        '_childColumnsChanged(_childColumns)',
-        '_minWidthChanged(minWidth)'
+        '_childColumnsChanged(_childColumns)'
       ],
 
       _columnChanged: function(column) {
         this.flexGrow = column.flexGrow;
-        this.flexShrink = column.flexShrink;
         this.frozen = column.frozen;
         this.lastFrozen = column._lastFrozen;
         this.headerTemplate = column.headerTemplate;
@@ -102,10 +97,6 @@
         }
       },
 
-      _minWidthChanged: function(minWidth) {
-        this.style.minWidth = minWidth;
-      },
-
       _expandedChanged: function(expanded, instance) {
         instance.__expanded__ = expanded;
         instance.expanded = expanded;
@@ -113,10 +104,6 @@
 
       _flexGrowChanged: function(flexGrow) {
         this.style.flexGrow = flexGrow;
-      },
-
-      _flexShrinkChanged: function(flexShrink) {
-        this.style.flexShrink = flexShrink;
       },
 
       _indexChanged: function(index, instance) {

--- a/vaadin-grid-table-cell.html
+++ b/vaadin-grid-table-cell.html
@@ -19,7 +19,9 @@
       properties: {
         column: Object,
         expanded: Boolean,
-        flex: Number,
+        flexGrow: Number,
+        flexShrink: Number,
+        minWidth: String,
         frozen: {
           type: Boolean,
           reflectToAttribute: true
@@ -50,7 +52,8 @@
       observers: ['_columnChanged(column)',
         '_cellAttached(column, isAttached)',
         '_expandedChanged(expanded, instance)',
-        '_flexChanged(flex)',
+        '_flexGrowChanged(flexGrow)',
+        '_flexShrinkChanged(flexShrink)',
         '_indexChanged(index, instance)',
         '_itemChanged(item, instance)',
         '_instanceChanged(instance, target)',
@@ -59,11 +62,13 @@
         '_toggleInstance(isAttached, _templatizer, instance)',
         '_widthChanged(width)',
         '_visibleChildColumnsChanged(_visibleChildColumns)',
-        '_childColumnsChanged(_childColumns)'
+        '_childColumnsChanged(_childColumns)',
+        '_minWidthChanged(minWidth)'
       ],
 
       _columnChanged: function(column) {
-        this.flex = column.flex;
+        this.flexGrow = column.flexGrow;
+        this.flexShrink = column.flexShrink;
         this.frozen = column.frozen;
         this.lastFrozen = column._lastFrozen;
         this.headerTemplate = column.headerTemplate;
@@ -97,13 +102,21 @@
         }
       },
 
+      _minWidthChanged: function(minWidth) {
+        this.style.minWidth = minWidth;
+      },
+
       _expandedChanged: function(expanded, instance) {
         instance.__expanded__ = expanded;
         instance.expanded = expanded;
       },
 
-      _flexChanged: function(flex) {
-        this.style.flexGrow = flex;
+      _flexGrowChanged: function(flexGrow) {
+        this.style.flexGrow = flexGrow;
+      },
+
+      _flexShrinkChanged: function(flexShrink) {
+        this.style.flexShrink = flexShrink;
       },
 
       _indexChanged: function(index, instance) {
@@ -147,7 +160,7 @@
       },
 
       _widthChanged: function(width) {
-        this.style.flexBasis = width;
+        this.style.width = width;
       },
 
       _templateChanged: function(template) {

--- a/vaadin-grid-table.html
+++ b/vaadin-grid-table.html
@@ -84,7 +84,7 @@
         padding: 0 !important;
         flex-shrink: 0;
         flex-grow: 1;
-        flex-basis: 100px;
+        width: 100px;
         box-sizing: border-box;
         display: flex;
         overflow: hidden;


### PR DESCRIPTION
Fixes #527

Support for `flex-shrink` was excluded from the implementation for now due to unforeseen problems with columnGroup cell -> column cell width mapping.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-grid/588)
<!-- Reviewable:end -->
