### PR TITLE
Disable background color for selected rows. Fixes #582

### DIFF
--- a/demo/selection.html
+++ b/demo/selection.html
@@ -130,6 +130,11 @@
         <dom-module id="datasource-select-all">
           <template>
             <style>
+              #grid {
+                --vaadin-grid-body-row-selected-cell: {
+                  background-color: var(--primary-background-color);
+                };
+              }
             </style>
             <x-data-source data-source="{{dataSource}}"></x-data-source>
             <vaadin-grid id="grid" data-source="[[dataSource]]" size="200">

--- a/demo/selection.html
+++ b/demo/selection.html
@@ -129,15 +129,18 @@
         <datasource-select-all></datasource-select-all>
         <dom-module id="datasource-select-all">
           <template>
-            <style>
-              #grid {
+            <style is="custom-style">
+              #grid[inverted] {
+                --vaadin-grid-body-cell: {
+                  background-color: var(--paper-grey-100);
+                };
                 --vaadin-grid-body-row-selected-cell: {
                   background-color: var(--primary-background-color);
                 };
               }
             </style>
             <x-data-source data-source="{{dataSource}}"></x-data-source>
-            <vaadin-grid id="grid" data-source="[[dataSource]]" size="200">
+            <vaadin-grid id="grid" data-source="[[dataSource]]" inverted$="[[inverted]]" size="200">
               <vaadin-grid-column width="40px" flex-grow="0" >
                 <template class="header">
                   <input type="checkbox" checked="{{inverted::change}}" />
@@ -172,6 +175,7 @@
 
               _resetSelection: function(inverted) {
                 this.$.grid.selectedItems = [];
+                this.updateStyles();
               },
 
               _selectItem: function(e) {


### PR DESCRIPTION
After playing with different options, I ended with the simplest way, just disabling the background for selected rows, otherwise the demo gets more complicated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-grid/609)
<!-- Reviewable:end -->
