### PR TITLE
Check for focusable elements in event path

### DIFF
--- a/demo/styling.html
+++ b/demo/styling.html
@@ -122,7 +122,7 @@
           <x-array-data-source items="{{items}}"></x-array-data-source>
           <vaadin-grid id="material" items="[[items]]" size="200">
 
-            <vaadin-grid-selection-column width="66px" flex="0" select-all="[[selectAll]]">
+            <vaadin-grid-selection-column width="66px" flex="0" select-all="{{selectAll}}">
               <template class="header">
                 <paper-checkbox checked="{{selectAll}}"></paper-checkbox>
               </template>

--- a/test/active-item.html
+++ b/test/active-item.html
@@ -21,6 +21,12 @@
           <template class="header"></template>
           <template>[[item]]</template>
         </vaadin-grid-column>
+        <vaadin-grid-column>
+          <template class="header"></template>
+          <template>
+            <button>OK</button>
+          </template>
+        </vaadin-grid-column>
       </vaadin-grid>
     </template>
   </test-fixture>
@@ -36,6 +42,10 @@
 
       function clickItem(rowIndex) {
         return grid.$.scroller.$.items.children[rowIndex].children[0].click();
+      }
+
+      function clickButton(rowIndex) {
+        return grid.querySelectorAll('button')[rowIndex].click();
       }
 
       it('should not have a default value', function() {
@@ -62,6 +72,12 @@
         clickItem(0);
 
         expect(grid.activeItem).to.be.null;
+      });
+
+      it('should not activate on a native button', function() {
+        clickButton(0);
+
+        expect(grid.activeItem).to.be.undefined;
       });
     });
   </script>

--- a/vaadin-grid-cell-click-behavior.html
+++ b/vaadin-grid-cell-click-behavior.html
@@ -17,32 +17,29 @@
     // yet at the point when tap event is being executed.
     _onClick: function(e) {
       // Prevent item action if cell itself is not focused.
-      if (!this._isFocusable(Polymer.dom(e).localTarget)) {
-        if (this._cellClick) {
-          this._cellClick(e);
-        }
-      }
-    },
-
-    _isFocusable: function(target) {
-      if (Polymer.Settings.useNativeShadow) {
-        // https://nemisj.com/focusable/
-        // tabIndex is not reliable in IE.
-        return target.tabIndex >= 0;
-      } else {
-        // unreliable with Shadow, document.activeElement doesn't go inside
-        // the shadow root.
-        // Also, atleast iOS doesn't seem to focus links or buttons.
-        var focusableElements = ['A', 'BUTTON'];
-
+      if (this._cellClick) {
+        var target = Polymer.dom(e).localTarget;
         // Polymer.dom(e).localTarget usually returns <content> element in shady
         // DOM. We'll get and use the cell-content wrapper in that case.
         if (target.getDistributedNodes) {
           target = Polymer.dom(target).getDistributedNodes()[0];
         }
 
-        return target.contains(Polymer.dom(document.activeElement).node) || focusableElements.indexOf(target.tagName) > -1;
+        var path = Polymer.dom(e).path;
+        var elementsClicked = Array.prototype.slice.call(path, 0, path.indexOf(target) + 1);
+        if (!target.contains(this.target && this.target.root.activeElement || document.activeElement) &&
+            !elementsClicked.some(this._isFocusable)) {
+          this._cellClick(e);
+        }
       }
+    },
+
+    _isFocusable: function(target) {
+      return target.matches &&
+             target.matches(':not([disabled])') &&
+             (target.matches('[tabindex]') ||
+             target.matches('button, input, select, textarea, object, iframe, label') ||
+             target.matches('a[href], area[href]'));
     }
   };
 </script>


### PR DESCRIPTION
Fixes #584 

Relying on document.activeElement is just too unreliable.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-grid/618)
<!-- Reviewable:end -->
