### PR TITLE
Add missing vaadin-grid*.html files to code-coverage config

### DIFF
--- a/wct.conf.js
+++ b/wct.conf.js
@@ -9,18 +9,27 @@ module.exports = {
       'reporters': ['text-summary', 'lcov'],
       'include': [
         '/iron-list-behavior.html',
-        '/vaadin-grid-table-cell.html',
+        '/vaadin-grid-active-item-behavior.html',
+        '/vaadin-grid-array-data-source-behavior.html',
+        '/vaadin-grid-cell-click-behavior.html',
         '/vaadin-grid-column.html',
         '/vaadin-grid-data-source-behavior.html',
-        '/vaadin-grid-table-edge-behavior.html',
+        '/vaadin-grid-dynamic-columns-behavior.html',
+        // TODO: @limonte, revisit this in future, currently a weird istanbul bug here
+        // '/vaadin-grid-filter-behavior.html',
+        '/vaadin-grid-row-details-behavior.html',
+        '/vaadin-grid-selection-behavior.html',
+        '/vaadin-grid-selection-column.html',
+        '/vaadin-grid-sizer.html',
+        // TODO: @limonte, revisit this in future, currently a weird istanbul bug here
+        // '/vaadin-grid-sort-behavior.html',
+        '/vaadin-grid-table-cell.html',
         '/vaadin-grid-table-header-footer.html',
         '/vaadin-grid-table-outer-scroller.html',
-        '/vaadin-grid-row-details-behavior.html',
         '/vaadin-grid-table-row.html',
         '/vaadin-grid-table-scroll-behavior.html',
         '/vaadin-grid-table.html',
-        '/vaadin-grid-selection-behavior.html',
-        '/vaadin-grid-sizer.html',
+        '/vaadin-grid-templatizer.html',
         '/vaadin-grid.html'
       ],
       'exclude': []


### PR DESCRIPTION
Fixes #614

Unfortunately, there are two files which cause a strange issue with Istanbul, I haven't resolved it.

Before:

```
Statements   : 95.79% ( 728/760 )
Branches     : 85.57% ( 344/402 )
Functions    : 95.02% ( 210/221 )
Lines        : 95.79% ( 728/760 )
```

After:

```
Statements   : 96.17% ( 880/915 )
Branches     : 85.98% ( 460/535 )
Functions    : 95.91% ( 258/269 )
Lines        : 96.17% ( 880/915 )
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-grid/620)
<!-- Reviewable:end -->
