### PR TITLE
2.0 dev scrollbars

### DIFF
--- a/vaadin-grid-table-scroll-behavior.html
+++ b/vaadin-grid-table-scroll-behavior.html
@@ -121,6 +121,26 @@
 
     _onWheel: function(e) {
       var table = this.$.table;
+
+      /* Determine if the scroll target has an ancestor prior to this
+       * table/scroller that handles scrolling
+       */
+      var el  = e.target;
+      while (el && el !== table && el.scrollHeight === el.clientHeight) {
+        /* This element has a vertical scrollbar and so should receive and
+         * handle vertical scroll events.
+         */
+        el = el.parentElement;
+      }
+      if (el && el !== table) {
+        /* There is a scrollbar in an ancestor of the scroll target (el) that
+         * is a child of this table/scroller, so this scroll event is not
+         * intended for this component.
+         */
+        return;
+      }
+
+      // Handle scrolling
       var momentum = Math.abs(e.deltaX) + Math.abs(e.deltaY);
 
       if (

--- a/vaadin-grid-table.html
+++ b/vaadin-grid-table.html
@@ -135,6 +135,21 @@
 <dom-module id="vaadin-grid-table-themability-styles">
   <template>
     <style>
+      /* Scrollbars
+       *  @note Scrollbar styling is here at the top-most level so it properly
+       *        applies to the computed `scrollbarWidth` as well as the
+       *        functional scrollbar that will appear on the raw table element.
+       */
+      ::-webkit-scrollbar {
+        @apply --scrollbar-common;
+      }
+      ::-webkit-scrollbar-thumb {
+        @apply --scrollbar-thumb;
+      }
+      ::-webkit-scrollbar-thumb:window-inactive {
+        @apply --scrollbar-thumb-inactive;
+      }
+
 
       /* Default borders */
 


### PR DESCRIPTION
Update `vaadin-grid-table-scroll-behaviour:_onScroll` handler to determine if the scroll target has an ancestor prior to handling the scroll event directly.

Add scrollbar styling mixins to `vaadin-grid-table-themability-styles` in `vaadin-grid-table.html`.
Scrollbar styling is at this top-most level so it properly applies to the computed `scrollbarWidth` as well as the functional scrollbar that will appear on the raw table element.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-grid/640)
<!-- Reviewable:end -->
