### PR TITLE
Allow contained elements to be independently scrollable

### DIFF
--- a/vaadin-grid-table-scroll-behavior.html
+++ b/vaadin-grid-table-scroll-behavior.html
@@ -121,6 +121,26 @@
 
     _onWheel: function(e) {
       var table = this.$.table;
+
+      /* Determine if the scroll target has an ancestor prior to this
+       * table/scroller that handles scrolling
+       */
+      var el = e.target;
+      while (el && el !== table && el.scrollHeight === el.clientHeight) {
+        /* This element has a vertical scrollbar and so should receive and
+         * handle vertical scroll events.
+         */
+        el = el.parentElement;
+      }
+      if (el && el !== table) {
+        /* There is a scrollbar in an ancestor of the scroll target (el) that
+         * is a child of this table/scroller, so this scroll event is not
+         * intended for this component.
+         */
+        return;
+      }
+
+      // Handle scrolling
       var momentum = Math.abs(e.deltaX) + Math.abs(e.deltaY);
 
       if (


### PR DESCRIPTION
Update `_onWheel()` to  determine if the scroll target has an ancestor prior to the `vaadin-grid-table-scroll-behavior`  component that handles scrolling. In this case, do not handle the scroll event directly allowing it to continue to that ancestor.

This allows, for example, row-detail to contain a component that is scrollable. In this case, while the scroll target is that component, `vaadin-grid-table-scroll-behavior` will pass on handling the scroll event, allowing the event to be handles by that component.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-grid/641)
<!-- Reviewable:end -->
