### PR TITLE
Add scrollbar mixins for webkit-based browsers.

### DIFF
--- a/vaadin-grid-table.html
+++ b/vaadin-grid-table.html
@@ -136,6 +136,25 @@
   <template>
     <style>
 
+      /* Scrollbars
+       *  @note Scrollbar styling is here at the top-most level so it properly
+       *        applies to the computed `scrollbarWidth` as well as the
+       *        functional scrollbar that will appear on the raw table element.
+       */
+
+      ::-webkit-scrollbar {
+        @apply(--scrollbar-common);
+      }
+
+      ::-webkit-scrollbar-thumb {
+        @apply(--scrollbar-thumb);
+      }
+
+      /* stylelint-disable selector-pseudo-class-no-unknown */
+      ::-webkit-scrollbar-thumb:window-inactive {
+        @apply(--scrollbar-thumb-inactive);
+      }
+
       /* Default borders */
 
       thead tr:last-child th ::content > .cell-content {


### PR DESCRIPTION
Scrollbar styling is added in the `vaadin-grid-table-themability-styles` shared styles at the top-most level so it properly applies to the computed `scrollbarWidth` as well as the functional scrollbar that will appear on the raw table element.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-grid/642)
<!-- Reviewable:end -->
