### PR TITLE
Ensure cell content and insertion point have the same content id

### DIFF
--- a/vaadin-grid-table-cell.html
+++ b/vaadin-grid-table-cell.html
@@ -164,12 +164,12 @@
 
         this._cellContent = document.createElement('div');
         this._cellContent.setAttribute('class', 'cell-content');
-        target._contentIndex = target._contentIndex + 1 || 0;
-        this._cellContent.setAttribute('data-cell-content-id', target._contentIndex);
+        var contentId = target._contentIndex = target._contentIndex + 1 || 0;
+        this._cellContent.setAttribute('data-cell-content-id', contentId);
         Polymer.dom(this._cellContent).appendChild(this.instance.root);
 
         this._insertionPoint = document.createElement('content');
-        this._insertionPoint.setAttribute('select', '[data-cell-content-id="' + target._contentIndex + '"]');
+        this._insertionPoint.setAttribute('select', '[data-cell-content-id="' + contentId + '"]');
       },
     };
 


### PR DESCRIPTION
The issue can be reproduced on shadow dom (content cells may end up in header for example):

<img width="766" alt="screenshot 2017-01-06 10 36 34" src="https://cloud.githubusercontent.com/assets/1222264/21712244/39e62250-d3fc-11e6-9691-0c8d9a6b6be5.png">

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-grid/645)
<!-- Reviewable:end -->
