### PR TITLE
Avoid unnecessary clearCache on init

### DIFF
--- a/vaadin-grid-sort-behavior.html
+++ b/vaadin-grid-sort-behavior.html
@@ -153,6 +153,7 @@ Custom property | Description | Default
 
     _onSorterChanged: function(e) {
       var sorter = e.target;
+      var _sortersBefore = this._mapSorters();
 
       this._removeArrayItem(this._sorters, sorter);
       if (sorter.direction) {
@@ -166,7 +167,10 @@ Custom property | Description | Default
 
       e.stopPropagation();
 
-      if (this.dataSource) {
+      if (JSON.stringify(_sortersBefore) === JSON.stringify(this._mapSorters())) {
+        // No need to clear cache if sorters didn't change
+        return;
+      } else if (this.dataSource) {
         this.clearCache();
       }
     },


### PR DESCRIPTION
This speeds up the start-up time for grids with sorters in them (halves the start-up time of dev.html for example)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-grid/646)
<!-- Reviewable:end -->
