### PR TITLE
Cache column cells for reuse

### DIFF
--- a/test/light-dom-observing.html
+++ b/test/light-dom-observing.html
@@ -384,6 +384,25 @@
               done();
             });
           });
+
+          it('should reuse column cells', function() {
+            Polymer.dom.flush();
+            var content = getHeaderCellContent(grid, 0, 0);
+            Polymer.dom(grid).appendChild(grid._columnTree[0][0]);
+            Polymer.dom.flush();
+            expect(getHeaderCellContent(grid, 0, 1)).to.equal(content);
+          });
+
+          it('should not create new cells', function() {
+            var row = getRows(grid.$.scroller.$.items)[0];
+            var spy = sinon.spy(row, '_createCell');
+            Polymer.dom.flush();
+            var content = getHeaderCellContent(grid, 0, 0);
+            Polymer.dom(grid).appendChild(grid._columnTree[0][0]);
+            Polymer.dom.flush();
+            expect(spy.called).to.be.false;
+          });
+
         });
 
         describe('columns inside group', function() {

--- a/vaadin-grid-table-header-footer.html
+++ b/vaadin-grid-table-header-footer.html
@@ -16,6 +16,12 @@
       observers: ['_columnTreeChanged(columnTree, target)', '_rowsChanged(_rows)'],
 
       _columnTreeChanged: function(columnTree, target) {
+        if (this._rows) {
+          this._rows.forEach(function(row) {
+            Polymer.dom(row).innerHTML = '';
+          });
+        }
+
         var rows = [];
         for(var i = 0; i < columnTree.length; i++) {
           var row = this._createRow();

--- a/vaadin-grid-table-row.html
+++ b/vaadin-grid-table-row.html
@@ -122,7 +122,17 @@
         var cells = [];
 
         columns.forEach(function(column, columnIndex) {
-          var cell = this._createCell();
+          // Get a cached cell instance if one is available
+          var cacheName = '_' + this.is.replace(/-/g, '_') + '_cells';
+          var cache = column[cacheName] = column[cacheName] || [];
+          var cell = cache.filter(function(cell) {
+            return !Polymer.dom(cell).parentNode;
+          })[0];
+          if (!cell) {
+            cell = this._createCell();
+            cache.push(cell);
+          }
+
           cell.index = this.index;
           cell.target = this.target;
           cell._isColumnRow = this._isColumnRow;


### PR DESCRIPTION
This PR will cache all grid cells (including template instances) to the corresponding columns. And once the grid is asked for a refresh after light DOM change, instead of creating new cell instances for every column while populating a row, it looks for an available cached cell instance for re-use.

This will significantly increase rendering performance when columns are changed/reordered in the grid's light DOM.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-grid/676)
<!-- Reviewable:end -->
