### PR TITLE
Add screenreader support

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -53,6 +53,7 @@
     "polymer": "^1.6.1",
     "iron-resizable-behavior": "PolymerElements/iron-resizable-behavior#^1.0.5",
     "iron-scroll-target-behavior": "PolymerElements/iron-scroll-target-behavior#^1.1.0",
-    "iron-a11y-keys-behavior": "polymerelements/iron-a11y-keys-behavior#^1.1.9"
+    "iron-a11y-keys-behavior": "^1.1.9",
+    "iron-a11y-announcer": "^1.0.5"
   }
 }

--- a/demo/columns.html
+++ b/demo/columns.html
@@ -45,15 +45,17 @@
         <template is="dom-bind">
           <x-data-provider data-provider="{{dataProvider}}"></x-data-provider>
           <paper-checkbox checked="{{frozen}}">Freeze First Two Columns</paper-checkbox>
-          <vaadin-grid data-provider="[[dataProvider]]" size="200">
+          <vaadin-grid aria-label="Freezing Columns Example" data-provider="[[dataProvider]]" size="200">
             <vaadin-grid-column width="50px" frozen="[[frozen]]">
               <template class="header">#</template>
               <template>[[index]]</template>
             </vaadin-grid-column>
             <vaadin-grid-column width="50px" frozen="[[frozen]]">
-              <template class="header"></template>
+              <template class="header">
+                <div aria-label="Picture"></div>
+              </template>
               <template>
-                <iron-image src="[[item.user.picture.thumbnail]]"></iron-image>
+                <iron-image alt="[[item.user.name.first]] [[item.user.name.last]]" src="[[item.user.picture.thumbnail]]"></iron-image>
               </template>
             </vaadin-grid-column>
             <vaadin-grid-column width="33%">
@@ -80,15 +82,17 @@
           <x-data-provider data-provider="{{dataProvider}}"></x-data-provider>
           <paper-checkbox checked="{{hidden}}">Hide First Two Columns</paper-checkbox>
           <iron-media-query query-matches="{{hidden}}" query="(max-width: 700px)"></iron-media-query>
-          <vaadin-grid data-provider="[[dataProvider]]" size="200">
+          <vaadin-grid aria-label="Hiding Columns Example" data-provider="[[dataProvider]]" size="200">
             <vaadin-grid-column width="50px" hidden="[[hidden]]">
               <template class="header">#</template>
               <template>[[index]]</template>
             </vaadin-grid-column>
             <vaadin-grid-column width="50px" hidden="[[hidden]]">
-              <template class="header"></template>
+              <template class="header">
+                <div aria-label="Picture"></div>
+              </template>
               <template>
-                <iron-image src="[[item.user.picture.thumbnail]]"></iron-image>
+                <iron-image alt="[[item.user.name.first]] [[item.user.name.last]]" src="[[item.user.picture.thumbnail]]"></iron-image>
               </template>
             </vaadin-grid-column>
             <vaadin-grid-column width="33%">
@@ -113,15 +117,17 @@
       <template>
         <template is="dom-bind">
           <x-data-provider data-provider="{{dataProvider}}"></x-data-provider>
-          <vaadin-grid data-provider="[[dataProvider]]" size="200" column-reordering-allowed>
+          <vaadin-grid aria-label="Reordering and Resizing Columns Example" data-provider="[[dataProvider]]" size="200" column-reordering-allowed>
             <vaadin-grid-column width="30px" flex-grow="0" resizable>
               <template class="header">#</template>
               <template>[[index]]</template>
             </vaadin-grid-column>
             <vaadin-grid-column width="50px" flex-grow="0" resizable>
-              <template class="header"></template>
+              <template class="header">
+                <div aria-label="Picture"></div>
+              </template>
               <template>
-                <iron-image src="[[item.user.picture.thumbnail]]"></iron-image>
+                <iron-image alt="[[item.user.name.first]] [[item.user.name.last]]" src="[[item.user.picture.thumbnail]]"></iron-image>
               </template>
             </vaadin-grid-column>
             <vaadin-grid-column-group resizable>
@@ -163,7 +169,7 @@
         <dom-module id="x-dynamic-columns">
           <template>
             <x-data-provider data-provider="{{dataProvider}}"></x-data-provider>
-            <vaadin-grid id="grid" data-provider="[[dataProvider]]" size="200">
+            <vaadin-grid aria-label="Dynamic Columns Example" id="grid" data-provider="[[dataProvider]]" size="200">
               <template is="dom-repeat" items="[[columns]]" as="column">
                 <vaadin-grid-column>
                   <template class="header">[[column]]</template>

--- a/demo/index.html
+++ b/demo/index.html
@@ -77,7 +77,7 @@
               }
 
               input[readonly] {
-                border: none;
+                border: 2px solid transparent;
               }
 
               input {

--- a/demo/index.html
+++ b/demo/index.html
@@ -39,15 +39,17 @@
         <template is="dom-bind">
           <x-data-provider data-provider="{{dataProvider}}"></x-data-provider>
 
-          <vaadin-grid data-provider="[[dataProvider]]" size="200">
+          <vaadin-grid aria-label="Basic Binding Example" data-provider="[[dataProvider]]" size="200">
             <vaadin-grid-column width="50px">
               <template class="header">#</template>
               <template>[[index]]</template>
             </vaadin-grid-column>
             <vaadin-grid-column width="50px">
-              <template class="header"></template>
+              <template class="header">
+                <div aria-label="Picture"></div>
+              </template>
               <template>
-                <iron-image src="[[item.user.picture.thumbnail]]"></iron-image>
+                <iron-image alt="[[item.user.name.first]] [[item.user.name.last]]" src="[[item.user.picture.thumbnail]]"></iron-image>
               </template>
             </vaadin-grid-column>
             <vaadin-grid-column width="calc(50% - 100px)">
@@ -86,7 +88,7 @@
 
             <paper-checkbox checked="{{editing}}">Enable Editing</paper-checkbox>
 
-            <vaadin-grid on-item-changed="_log" data-provider="[[dataProvider]]" size="10000">
+            <vaadin-grid aria-label="Two-way Binding Example" on-item-changed="_log" data-provider="[[dataProvider]]" size="10000">
               <vaadin-grid-column>
                 <template class="header">First Name</template>
                 <template>
@@ -123,15 +125,17 @@
       <template>
         <template is="dom-bind">
           <x-data-provider data-provider="{{dataProvider}}"></x-data-provider>
-          <vaadin-grid data-provider="[[dataProvider]]" size="200">
+          <vaadin-grid aria-label="Column Grouping Example" data-provider="[[dataProvider]]" size="200">
             <vaadin-grid-column width="30px" flex-grow="0">
               <template class="header">#</template>
               <template>[[index]]</template>
             </vaadin-grid-column>
             <vaadin-grid-column width="50px" flex-grow="0">
-              <template class="header"></template>
+              <template class="header">
+                <div aria-label="Picture"></div>
+              </template>
               <template>
-                <iron-image src="[[item.user.picture.thumbnail]]"></iron-image>
+                <iron-image alt="[[item.user.name.first]] [[item.user.name.last]]" src="[[item.user.picture.thumbnail]]"></iron-image>
               </template>
             </vaadin-grid-column>
             <vaadin-grid-column-group>
@@ -196,7 +200,7 @@
           </style>
           <x-data-provider data-provider="{{dataProvider}}"></x-data-provider>
 
-          <vaadin-grid id="grid-row-details" data-provider="[[dataProvider]]" size="200">
+          <vaadin-grid aria-label="Row Details Example" id="grid-row-details" data-provider="[[dataProvider]]" size="200">
 
             <template class="row-details">
               <div class="details">
@@ -220,7 +224,7 @@
             <vaadin-grid-column width="100px">
               <template class="header"></template>
               <template>
-                <paper-checkbox checked="{{expanded}}">Show Details</paper-checkbox>
+                <paper-checkbox aria-label$="Show Details for [[item.user.name.first]]" checked="{{expanded}}">Show Details</paper-checkbox>
               </template>
             </vaadin-grid-column>
           </vaadin-grid>

--- a/demo/selection.html
+++ b/demo/selection.html
@@ -26,7 +26,7 @@
       <template>
         <template is="dom-bind">
           <x-array-data-provider items="{{items}}"></x-array-data-provider>
-          <vaadin-grid items="[[items]]">
+          <vaadin-grid aria-label="Multi-Selection Example" items="[[items]]">
             <vaadin-grid-selection-column auto-select>
             </vaadin-grid-selection-column>
             <vaadin-grid-column width="50px">
@@ -51,7 +51,7 @@
       <template>
         <template is="dom-bind">
           <x-data-provider data-provider="{{dataProvider}}"></x-data-provider>
-          <vaadin-grid data-provider="[[dataProvider]]" size="200">
+          <vaadin-grid aria-label="Selection using Templates Example" data-provider="[[dataProvider]]" size="200">
             <vaadin-grid-column width="50px">
               <template class="header">#</template>
               <template>[[index]]</template>
@@ -66,7 +66,7 @@
             </vaadin-grid-column>
             <vaadin-grid-column>
               <template>
-                <paper-button raised focused="{{selected}}">Select</paper-button>
+                <paper-button aria-label="Select Row" raised toggles active="{{selected}}">Select</paper-button>
               </template>
             </vaadin-grid-column>
           </vaadin-grid>
@@ -81,7 +81,7 @@
         <dom-module id="x-selection">
           <template>
             <x-data-provider data-provider="{{dataProvider}}"></x-data-provider>
-            <vaadin-grid id="grid" data-provider="[[dataProvider]]" active-item="{{activeItem}}" size="200">
+            <vaadin-grid aria-label="Selection using Active Item Example" id="grid" data-provider="[[dataProvider]]" active-item="{{activeItem}}" size="200">
               <vaadin-grid-column width="50px">
                 <template class="header">#</template>
                 <template>[[index]]</template>
@@ -132,13 +132,13 @@
               }
             </style>
             <x-data-provider data-provider="{{dataProvider}}"></x-data-provider>
-            <vaadin-grid id="grid" data-provider="[[dataProvider]]" inverted$="[[inverted]]" size="200">
+            <vaadin-grid  aria-label="Select All with Data Example" id="grid" data-provider="[[dataProvider]]" inverted$="[[inverted]]" size="200">
               <vaadin-grid-column width="40px" flex-grow="0" >
                 <template class="header">
-                  <input type="checkbox" on-click="_invert" checked="[[_isChecked(inverted, indeterminate)]]" indeterminate="[[indeterminate]]"/>
+                  <input aria-label="Select All" type="checkbox" on-click="_invert" checked="[[_isChecked(inverted, indeterminate)]]" indeterminate="[[indeterminate]]"/>
                 </template>
                 <template>
-                  <input type="checkbox" on-change="_selectItem" checked="[[_isSelected(inverted, selected)]]"/>
+                  <input aria-label="Select Row" type="checkbox" on-change="_selectItem" checked="[[_isSelected(inverted, selected)]]"/>
                 </template>
               </vaadin-grid-column>
               <vaadin-grid-column>

--- a/demo/sorting-filtering.html
+++ b/demo/sorting-filtering.html
@@ -25,7 +25,7 @@
       <template>
         <template is="dom-bind">
           <x-array-data-provider items="{{items}}"></x-array-data-provider>
-          <vaadin-grid items="[[items]]">
+          <vaadin-grid aria-label="Sorting Example" items="[[items]]">
             <vaadin-grid-column width="50px">
               <template class="header">#</template>
               <template>[[index]]</template>
@@ -52,14 +52,14 @@
       <template>
         <template is="dom-bind">
           <x-array-data-provider items="{{items}}"></x-array-data-provider>
-          <vaadin-grid items="[[items]]">
+          <vaadin-grid aria-label="Filtering Example" items="[[items]]">
             <vaadin-grid-column width="50px">
               <template class="header">#</template>
               <template>[[index]]</template>
             </vaadin-grid-column>
             <vaadin-grid-column>
               <template class="header">
-                <vaadin-grid-filter path="user.name.first" value="[[_filterFirstName]]">
+                <vaadin-grid-filter aria-label="First Name" path="user.name.first" value="[[_filterFirstName]]">
                   <input placeholder="First Name" value="{{_filterFirstName::input}}" focus-target>
                 </vaadin-grid-filter>
               </template>
@@ -67,7 +67,7 @@
             </vaadin-grid-column>
             <vaadin-grid-column>
               <template class="header">
-                <vaadin-grid-filter path="user.name.last" value="[[_filterLastName]]">
+                <vaadin-grid-filter aria-label="Last Name" path="user.name.last" value="[[_filterLastName]]">
                   <input placeholder="Last Name" value="{{_filterLastName::input}}" focus-target>
                 </vaadin-grid-filter>
               </template>

--- a/test/keyboard-navigation.html
+++ b/test/keyboard-navigation.html
@@ -237,7 +237,7 @@
           it('should disable navigation mode when blurred', function() {
             scroller.navigating = true;
 
-            scroller.fire('blur');
+            scroller.fire('focusout');
 
             expect(scroller.navigating).to.be.false;
           });
@@ -311,19 +311,17 @@
           });
 
           it('should have a focus trap as the very first child', function() {
-            expect(grid.tabIndex).not.to.eql(0);
-
-            // header focus trap needs to be the first element in Shadow DOM.
-            var trap = Polymer.dom(scroller.root).querySelector(':not(style)');
-
-            expect(trap.tabIndex).to.eql(0);
+            // header focus trap needs to be the first element
+            var trap = Polymer.dom(Polymer.Settings.useNativeShadow ? grid : scroller.root).querySelector(':not(style)');
+  
+            expect(trap.children[0].tabIndex).to.eql(0);
           });
 
           it('should have a focus trap as the very last child', function() {
-            // footer focus trap needs to be the last element in Light DOM.
+            // footer focus trap needs to be the last element
             var trap = Polymer.Settings.useNativeShadow ? grid.lastElementChild : scroller.lastElementChild;
 
-            expect(trap.tabIndex).to.eql(0);
+            expect(trap.children[0].tabIndex).to.eql(0);
           });
 
           it('should be possible to tab through grid', function() {
@@ -1141,7 +1139,7 @@
           it('should exit interaction mode when blurred', function() {
             scroller.interacting = true;
 
-            scroller.fire('blur');
+          scroller.fire('focusout');
 
             expect(scroller.interacting).to.be.false;
           });
@@ -1392,7 +1390,102 @@
           });
         });
       });
-    }
+
+      describe('a11y', function() {
+        it('should move focus when focused cell is changed', function() {
+          headerTrap.focus.restore();
+          headerTrap.focus.restore = sinon.spy();
+
+          var spy = sinon.spy();
+          headerTrap._primary.focus = spy;
+
+          headerTrap.activeTarget = 'foobar';
+
+          expect(spy.callCount).to.eql(1);
+        });
+
+        it('should set announce target when virtual focus changes to header', function() {
+          headerTrap.focus();
+
+          expect(headerTrap.activeTarget).not.to.be.empty;
+        });
+
+        it('should set announce target when virtual focus changes to body', function() {
+          bodyTrap.focus();
+
+          expect(bodyTrap.activeTarget).not.to.be.empty;
+        });
+
+        it('should set announce target when virtual focus changes to footer', function() {
+          footerTrap.focus();
+
+          expect(footerTrap.activeTarget).not.to.be.empty;
+        });
+
+        it('should announce row number on body when navigating with keys', function() {
+          var spy = sinon.spy();
+          grid.addEventListener('iron-announce', spy);
+
+          // simulate tab
+          bodyTrap.focus();
+
+          expect(spy.callCount).to.eql(1);
+          expect(spy.args[0][0].detail.text).to.eql('Row 1 of 2');
+        });
+
+        it('should announce selection using template variable', function() {
+          var spy = sinon.spy();
+          grid.addEventListener('iron-announce', spy);
+
+          getCell(0, 0).instance.selected = true;
+
+          expect(spy.callCount).to.eql(1);
+          expect(spy.args[0][0].detail.text).to.eql('Selected Row 1 of 2');
+        });
+
+        it('should announce deselection using template variable', function() {
+          var spy = sinon.spy();
+          grid.addEventListener('iron-announce', spy);
+
+          grid.selectItem(grid.items[0]);
+          getCell(0, 0).instance.selected = false;
+
+          expect(spy.callCount).to.eql(1);
+          expect(spy.args[0][0].detail.text).to.eql('Deselected Row 1 of 2');
+        });
+
+        it('should announce focused cell when focused', function(done) {
+          bodyTrap.focus();
+
+          var id = getCell(0, 0)._cellContent.id;
+
+          bodyTrap.async(function() {
+            expect(bodyTrap._primary.getAttribute('aria-labelledby') +
+              bodyTrap._secondary.getAttribute('aria-labelledby')).to.contain(id);
+            done();
+          });
+        });
+
+        it('should announce header cell when body cell is focused', function(done) {
+          bodyTrap.focus();
+
+          var id = getFirstHeaderCell(0)._cellContent.id;
+
+          bodyTrap.async(function() {
+            expect(bodyTrap._primary.getAttribute('aria-labelledby') +
+              bodyTrap._secondary.getAttribute('aria-labelledby')).to.contain(id);
+            done();
+          });
+        });
+
+        if (window.Polymer && Polymer.Settings.useNativeShadow) {
+          it('should have tabbable elements in the light DOM', function() {
+            expect(headerTrap.querySelector('.primary')).not.to.be.null;
+            expect(headerTrap.querySelector('.secondary')).not.to.be.null;
+          });
+        }
+      });
+    });
   </script>
 
 </body>

--- a/test/keyboard-navigation.html
+++ b/test/keyboard-navigation.html
@@ -174,8 +174,8 @@
           MockInteractions.keyDownOn(grid, 36, 'ctrl');
         }
 
-        function enter() {
-          MockInteractions.keyDownOn(grid, 13);
+        function enter(target) {
+          MockInteractions.keyDownOn(target || grid, 13);
         }
 
         function escape() {
@@ -313,7 +313,7 @@
           it('should have a focus trap as the very first child', function() {
             // header focus trap needs to be the first element
             var trap = Polymer.dom(Polymer.Settings.useNativeShadow ? grid : scroller.root).querySelector(':not(style)');
-  
+
             expect(trap.children[0].tabIndex).to.eql(0);
           });
 
@@ -1172,10 +1172,36 @@
             expect(input.focus.callCount).to.eql(1);
           });
 
-          it('should focus the first element when entering interaction mode with f2', function() {
-            var cell = getCell(0, 1);
-            var input = getCellContent(cell).children[0];
-            input.focus = sinon.spy();
+        it('should exit interaction mode from focused single-line input with enter', function() {
+          var cell = getCell(0, 1);
+          var input = getCellContent(cell).children[0];
+          input.type = 'text';
+
+          right(); // focus the cell with input.
+          enter();
+
+          enter(input);
+
+          expect(scroller.interacting).to.be.false;
+        });
+
+        it('should not exit interaction mode from focused non-single-line input with enter', function() {
+          var cell = getCell(0, 1);
+          var input = getCellContent(cell).children[0];
+          input.type = 'button';
+
+          right(); // focus the cell with input.
+          enter();
+
+          enter(input);
+
+          expect(scroller.interacting).to.be.true;
+        });
+
+        it('should focus the first element when entering interaction mode with f2', function() {
+          var cell = getCell(0, 1);
+          var input = getCellContent(cell).children[0];
+          input.focus = sinon.spy();
 
             right(); // focus the cell with input.
 
@@ -1389,103 +1415,103 @@
             expect(scroller.interacting).to.be.true;
           });
         });
+
+        describe('a11y', function() {
+          it('should move focus when focused cell is changed', function() {
+            headerTrap.focus.restore();
+            headerTrap.focus.restore = sinon.spy();
+
+            var spy = sinon.spy();
+            headerTrap._primary.focus = spy;
+
+            headerTrap.activeTarget = 'foobar';
+
+            expect(spy.callCount).to.eql(1);
+          });
+
+          it('should set announce target when virtual focus changes to header', function() {
+            headerTrap.focus();
+
+            expect(headerTrap.activeTarget).not.to.be.empty;
+          });
+
+          it('should set announce target when virtual focus changes to body', function() {
+            bodyTrap.focus();
+
+            expect(bodyTrap.activeTarget).not.to.be.empty;
+          });
+
+          it('should set announce target when virtual focus changes to footer', function() {
+            footerTrap.focus();
+
+            expect(footerTrap.activeTarget).not.to.be.empty;
+          });
+
+          it('should announce row number on body when navigating with keys', function() {
+            var spy = sinon.spy();
+            grid.addEventListener('iron-announce', spy);
+
+            // simulate tab
+            bodyTrap.focus();
+
+            expect(spy.callCount).to.eql(1);
+            expect(spy.args[0][0].detail.text).to.eql('Row 1 of 2');
+          });
+
+          it('should announce selection using template variable', function() {
+            var spy = sinon.spy();
+            grid.addEventListener('iron-announce', spy);
+
+            getCell(0, 0).instance.selected = true;
+
+            expect(spy.callCount).to.eql(1);
+            expect(spy.args[0][0].detail.text).to.eql('Selected Row 1 of 2');
+          });
+
+          it('should announce deselection using template variable', function() {
+            var spy = sinon.spy();
+            grid.addEventListener('iron-announce', spy);
+
+            grid.selectItem(grid.items[0]);
+            getCell(0, 0).instance.selected = false;
+
+            expect(spy.callCount).to.eql(1);
+            expect(spy.args[0][0].detail.text).to.eql('Deselected Row 1 of 2');
+          });
+
+          it('should announce focused cell when focused', function(done) {
+            bodyTrap.focus();
+
+            var id = getCell(0, 0)._cellContent.id;
+
+            bodyTrap.async(function() {
+              expect(bodyTrap._primary.getAttribute('aria-labelledby') +
+                bodyTrap._secondary.getAttribute('aria-labelledby')).to.contain(id);
+              done();
+            });
+          });
+
+          it('should announce header cell when body cell is focused', function(done) {
+            bodyTrap.focus();
+
+            var id = getFirstHeaderCell(0)._cellContent.id;
+
+            bodyTrap.async(function() {
+              expect(bodyTrap._primary.getAttribute('aria-labelledby') +
+                bodyTrap._secondary.getAttribute('aria-labelledby')).to.contain(id);
+              done();
+            });
+          });
+
+          if (window.Polymer && Polymer.Settings.useNativeShadow) {
+            it('should have tabbable elements in the light DOM', function() {
+              expect(headerTrap.querySelector('.primary')).not.to.be.null;
+              expect(headerTrap.querySelector('.secondary')).not.to.be.null;
+            });
+          }
+        });
       });
-
-      describe('a11y', function() {
-        it('should move focus when focused cell is changed', function() {
-          headerTrap.focus.restore();
-          headerTrap.focus.restore = sinon.spy();
-
-          var spy = sinon.spy();
-          headerTrap._primary.focus = spy;
-
-          headerTrap.activeTarget = 'foobar';
-
-          expect(spy.callCount).to.eql(1);
-        });
-
-        it('should set announce target when virtual focus changes to header', function() {
-          headerTrap.focus();
-
-          expect(headerTrap.activeTarget).not.to.be.empty;
-        });
-
-        it('should set announce target when virtual focus changes to body', function() {
-          bodyTrap.focus();
-
-          expect(bodyTrap.activeTarget).not.to.be.empty;
-        });
-
-        it('should set announce target when virtual focus changes to footer', function() {
-          footerTrap.focus();
-
-          expect(footerTrap.activeTarget).not.to.be.empty;
-        });
-
-        it('should announce row number on body when navigating with keys', function() {
-          var spy = sinon.spy();
-          grid.addEventListener('iron-announce', spy);
-
-          // simulate tab
-          bodyTrap.focus();
-
-          expect(spy.callCount).to.eql(1);
-          expect(spy.args[0][0].detail.text).to.eql('Row 1 of 2');
-        });
-
-        it('should announce selection using template variable', function() {
-          var spy = sinon.spy();
-          grid.addEventListener('iron-announce', spy);
-
-          getCell(0, 0).instance.selected = true;
-
-          expect(spy.callCount).to.eql(1);
-          expect(spy.args[0][0].detail.text).to.eql('Selected Row 1 of 2');
-        });
-
-        it('should announce deselection using template variable', function() {
-          var spy = sinon.spy();
-          grid.addEventListener('iron-announce', spy);
-
-          grid.selectItem(grid.items[0]);
-          getCell(0, 0).instance.selected = false;
-
-          expect(spy.callCount).to.eql(1);
-          expect(spy.args[0][0].detail.text).to.eql('Deselected Row 1 of 2');
-        });
-
-        it('should announce focused cell when focused', function(done) {
-          bodyTrap.focus();
-
-          var id = getCell(0, 0)._cellContent.id;
-
-          bodyTrap.async(function() {
-            expect(bodyTrap._primary.getAttribute('aria-labelledby') +
-              bodyTrap._secondary.getAttribute('aria-labelledby')).to.contain(id);
-            done();
-          });
-        });
-
-        it('should announce header cell when body cell is focused', function(done) {
-          bodyTrap.focus();
-
-          var id = getFirstHeaderCell(0)._cellContent.id;
-
-          bodyTrap.async(function() {
-            expect(bodyTrap._primary.getAttribute('aria-labelledby') +
-              bodyTrap._secondary.getAttribute('aria-labelledby')).to.contain(id);
-            done();
-          });
-        });
-
-        if (window.Polymer && Polymer.Settings.useNativeShadow) {
-          it('should have tabbable elements in the light DOM', function() {
-            expect(headerTrap.querySelector('.primary')).not.to.be.null;
-            expect(headerTrap.querySelector('.secondary')).not.to.be.null;
-          });
-        }
-      });
-    });
+}
   </script>
 
 </body>

--- a/test/keyboard-navigation.html
+++ b/test/keyboard-navigation.html
@@ -237,7 +237,7 @@
           it('should disable navigation mode when blurred', function() {
             scroller.navigating = true;
 
-            scroller.fire('focusout');
+            bodyTrap.fire('focusout');
 
             expect(scroller.navigating).to.be.false;
           });
@@ -1139,7 +1139,7 @@
           it('should exit interaction mode when blurred', function() {
             scroller.interacting = true;
 
-          scroller.fire('focusout');
+            bodyTrap.fire('focusout');
 
             expect(scroller.interacting).to.be.false;
           });
@@ -1172,36 +1172,36 @@
             expect(input.focus.callCount).to.eql(1);
           });
 
-        it('should exit interaction mode from focused single-line input with enter', function() {
-          var cell = getCell(0, 1);
-          var input = getCellContent(cell).children[0];
-          input.type = 'text';
+          it('should exit interaction mode from focused single-line input with enter', function() {
+            var cell = getCell(0, 1);
+            var input = getCellContent(cell).children[0];
+            input.type = 'text';
 
-          right(); // focus the cell with input.
-          enter();
+            right(); // focus the cell with input.
+            enter();
 
-          enter(input);
+            enter(input);
 
-          expect(scroller.interacting).to.be.false;
-        });
+            expect(scroller.interacting).to.be.false;
+          });
 
-        it('should not exit interaction mode from focused non-single-line input with enter', function() {
-          var cell = getCell(0, 1);
-          var input = getCellContent(cell).children[0];
-          input.type = 'button';
+          it('should not exit interaction mode from focused non-single-line input with enter', function() {
+            var cell = getCell(0, 1);
+            var input = getCellContent(cell).children[0];
+            input.type = 'button';
 
-          right(); // focus the cell with input.
-          enter();
+            right(); // focus the cell with input.
+            enter();
 
-          enter(input);
+            enter(input);
 
-          expect(scroller.interacting).to.be.true;
-        });
+            expect(scroller.interacting).to.be.true;
+          });
 
-        it('should focus the first element when entering interaction mode with f2', function() {
-          var cell = getCell(0, 1);
-          var input = getCellContent(cell).children[0];
-          input.focus = sinon.spy();
+          it('should focus the first element when entering interaction mode with f2', function() {
+            var cell = getCell(0, 1);
+            var input = getCellContent(cell).children[0];
+            input.focus = sinon.spy();
 
             right(); // focus the cell with input.
 
@@ -1511,7 +1511,7 @@
           }
         });
       });
-}
+    }
   </script>
 
 </body>

--- a/vaadin-grid-dynamic-columns-behavior.html
+++ b/vaadin-grid-dynamic-columns-behavior.html
@@ -74,6 +74,8 @@
         // to light children. We need to make sure footer focus trap is always
         // the very last element that can be tabbed into.
         if (Polymer.Settings.useNativeShadow) {
+          Polymer.dom(this).insertBefore(this.$.scroller.$.bodyFocusTrap, Polymer.dom(this).firstElementChild);
+          Polymer.dom(this).insertBefore(this.$.scroller.$.headerFocusTrap, Polymer.dom(this).firstElementChild);
           Polymer.dom(this).appendChild(this.$.scroller.$.footerFocusTrap);
         }
       }.bind(this));

--- a/vaadin-grid-focusable-cell-container-behavior.html
+++ b/vaadin-grid-focusable-cell-container-behavior.html
@@ -38,7 +38,8 @@
           var headerCell = lastHeaderRow.children[index];
 
           // note: having `cell.column.name` property for announcing would maybe be a good option here?
-          this.domHost.$.bodyFocusTrap.activeTarget = headerCell._cellContent.id + ' ' + cell._cellContent.id;
+          this.domHost.$.bodyFocusTrap.activeTarget = cell.hasAttribute('detailscell') ?
+            cell._cellContent.id : headerCell._cellContent.id + ' ' + cell._cellContent.id;
 
           break;
         case 'vaadin-grid-table-footer':

--- a/vaadin-grid-focusable-cell-container-behavior.html
+++ b/vaadin-grid-focusable-cell-container-behavior.html
@@ -18,7 +18,34 @@
       _focusedCellIndex: Number
     },
 
-    observers: ['_focusedCellChanged(_focusedRowIndex, _focusedCellIndex)'],
+    observers: ['_announceFocusedCell(_focusedCell, focused)', '_focusedCellChanged(_focusedRowIndex, _focusedCellIndex)'],
+
+    _announceFocusedCell: function(cell, focused) {
+      // changing activeTarget steals focus so we don't want to do that while interacting with
+      // cell contents.
+      // TODO: remember to change activeTarget when navigation mode is activated back.
+      if (!this.domHost.navigating || !focused) {
+        return;
+      }
+      // note: VoiceOver doesn't work with dynamic IDs.
+      switch(this.is) {
+        case 'vaadin-grid-table-header':
+          this.domHost.$.headerFocusTrap.activeTarget = cell._cellContent.id;
+          break;
+        case 'vaadin-grid-table-body':
+          var index = Polymer.dom(cell.parentElement).querySelectorAll('td').indexOf(cell);
+          var lastHeaderRow = this.domHost.$.header.lastElementChild;
+          var headerCell = lastHeaderRow.children[index];
+
+          // note: having `cell.column.name` property for announcing would maybe be a good option here?
+          this.domHost.$.bodyFocusTrap.activeTarget = headerCell._cellContent.id + ' ' + cell._cellContent.id;
+
+          break;
+        case 'vaadin-grid-table-footer':
+          this.domHost.$.footerFocusTrap.activeTarget = cell._cellContent.id;
+          break;
+      }
+    },
 
     _focusedCellChanged: function(rowIndex, cellIndex) {
       Polymer.dom(this).children.forEach(function(row, i) {

--- a/vaadin-grid-keyboard-navigation-behavior.html
+++ b/vaadin-grid-keyboard-navigation-behavior.html
@@ -50,17 +50,8 @@
       'up': '_onArrowUp'
     },
 
-    listeners: {
-      'focusout': '_onFocusout'
-    },
-
     attached: function() {
       Polymer.IronA11yAnnouncer.requestAvailability();
-    },
-
-    _onFocusout: function(e) {
-      this.$.scroller.navigating = false;
-      this.$.scroller.interacting = false;
     },
 
     _onEnd: function(e) {
@@ -167,6 +158,11 @@
       return this.$.footer._rows.filter(function(row) {
         return !row.hidden;
       }).length > 0;
+    },
+
+    _onFocusout: function(e) {
+      this.navigating = false;
+      this.interacting = false;
     },
 
     _onHeaderFocus: function(e) {

--- a/vaadin-grid-keyboard-navigation-behavior.html
+++ b/vaadin-grid-keyboard-navigation-behavior.html
@@ -1,12 +1,10 @@
 <link rel="import" href="../iron-a11y-keys-behavior/iron-a11y-keys-behavior.html">
+<link rel="import" href="../iron-a11y-announcer/iron-a11y-announcer.html">
 
 <dom-module id="vaadin-grid-navigation-themability-styles">
   <template>
     <style>
-      :host(:focus),
-      #headerFocusTrap:focus,
-      #bodyFocusTrap:focus,
-      #footerFocusTrap:focus {
+      :host(:focus) {
         outline: none;
       }
 
@@ -29,7 +27,8 @@
   vaadin.elements.grid.KeyboardNavigationBehaviorImpl = {
     hostAttributes: {
       // keys can be listened only when vaadin-grid is focusable
-      'tabindex': -1
+      'tabindex': -1,
+      'role': 'application'
     },
 
     keyBindings: {
@@ -51,15 +50,15 @@
       'up': '_onArrowUp'
     },
 
+    listeners: {
+      'focusout': '_onFocusout'
+    },
+
     attached: function() {
-      this.addEventListener('blur', this._onBlur, true);
+      Polymer.IronA11yAnnouncer.requestAvailability();
     },
 
-    detached: function() {
-      this.removeEventListener('blur', this._onBlur, true);
-    },
-
-    _onBlur: function(e) {
+    _onFocusout: function(e) {
       this.$.scroller.navigating = false;
       this.$.scroller.interacting = false;
     },
@@ -187,12 +186,16 @@
     },
 
     _onFooterFocus: function(e) {
-      this.navigating = true;
-      this.interacting = false;
-      var container = this._isFooterVisible() ? this.$.footer : this.$.items;
-      container._focusedCellIndex = container._focusedCellIndex || 0;
-      container._focusedRowIndex = container._focusedRowIndex || 0;
-      this._virtualFocus = container;
+      if (this._isFooterVisible()) {
+        this.navigating = true;
+        this.interacting = false;
+
+        this.$.footer._focusedCellIndex = this.$.footer._focusedCellIndex || 0;
+        this.$.footer._focusedRowIndex = this.$.footer._focusedRowIndex || 0;
+        this._virtualFocus = this.$.footer;
+      } else if (!this._virtualFocus) {
+        this.$.bodyFocusTrap.focus();
+      }
     },
 
     _virtualFocusChanged: function(virtualFocus, oldVirtualFocus) {
@@ -268,6 +271,7 @@
             e.preventDefault();
             break;
           case this.$.header:
+            this.$.headerFocusTrap.focus();
             this._virtualFocus = null;
             break;
         }
@@ -298,8 +302,8 @@
 
       e.preventDefault();
 
-      this._virtualFocus.focusDown();
       this.navigating = true;
+      this._virtualFocus.focusDown();
 
       this._ensureVirtualFocusInViewport();
     },
@@ -319,6 +323,7 @@
 
       e.preventDefault();
 
+      this.navigating = true;
       if (this._virtualFocus === this.$.items) {
         var prevLastVisible = this.lastVisibleIndex;
         this._scrollPageDown();
@@ -328,7 +333,6 @@
       } else {
         this._virtualFocus.focusPageDown();
       }
-      this.navigating = true;
     },
 
     _scrollPageUp: function() {
@@ -346,6 +350,7 @@
 
       e.preventDefault();
 
+      this.navigating = true;
       if (this._virtualFocus === this.$.items) {
         var prevLastVisibleIndex = this.lastVisibleIndex;
         this._scrollPageUp();
@@ -355,7 +360,6 @@
       } else {
         this._virtualFocus.focusPageUp();
       }
-      this.navigating = true;
     },
 
     _onArrowUp: function(e) {
@@ -365,8 +369,8 @@
 
       e.preventDefault();
 
-      this._virtualFocus.focusUp();
       this.navigating = true;
+      this._virtualFocus.focusUp();
 
       this._ensureVirtualFocusInViewport();
     },
@@ -378,8 +382,8 @@
 
       e.preventDefault();
 
-      this._virtualFocus.focusRight();
       this.navigating = true;
+      this._virtualFocus.focusRight();
 
       this._ensureVirtualFocusInViewport();
     },
@@ -391,8 +395,8 @@
 
       e.preventDefault();
 
-      this._virtualFocus.focusLeft();
       this.navigating = true;
+      this._virtualFocus.focusLeft();
 
       this._ensureVirtualFocusInViewport();
     },
@@ -404,8 +408,8 @@
 
       e.preventDefault();
 
-      this._virtualFocus.focusHome();
       this.navigating = true;
+      this._virtualFocus.focusHome();
 
       this._ensureVirtualFocusInViewport();
     },
@@ -417,8 +421,8 @@
 
       e.preventDefault();
 
-      this._virtualFocus.focusEnd();
       this.navigating = true;
+      this._virtualFocus.focusEnd();
 
       this._ensureVirtualFocusInViewport();
     },
@@ -465,8 +469,8 @@
 
       e.preventDefault();
 
-      this._virtualFocus.focusFirst();
       this.navigating = true;
+      this._virtualFocus.focusFirst();
 
       this._ensureVirtualFocusInViewport();
     },
@@ -478,8 +482,8 @@
 
       e.preventDefault();
 
-      this._virtualFocus.focusLast();
       this.navigating = true;
+      this._virtualFocus.focusLast();
 
       this._ensureVirtualFocusInViewport();
     },

--- a/vaadin-grid-keyboard-navigation-behavior.html
+++ b/vaadin-grid-keyboard-navigation-behavior.html
@@ -437,9 +437,13 @@
     },
 
     _onEnter: function(e) {
-      if(!this.interacting) {
+      if (!this.interacting) {
         e.preventDefault();
         this._moveFocusToFocusTarget();
+      } else if (e.detail.keyboardEvent.target.localName === 'input' &&
+                 e.detail.keyboardEvent.target.type === 'text') {
+        this.interacting = false;
+        this._onTab(e); // revert to navigation
       }
     },
 

--- a/vaadin-grid-selection-behavior.html
+++ b/vaadin-grid-selection-behavior.html
@@ -35,6 +35,10 @@
         var item = e.detail.inst.item;
         (this._isSelected(item) ? this.deselectItem : this.selectItem).bind(this)(item);
 
+        this.fire('iron-announce', {
+          text: (this._isSelected(item) ? 'Selected' : 'Deselected') + ' Row ' + (e.detail.inst.index + 1) + ' of ' + this.size
+        });
+
         // stop this internal event from propagating outside.
         e.stopPropagation();
       }

--- a/vaadin-grid-selection-column.html
+++ b/vaadin-grid-selection-column.html
@@ -19,10 +19,10 @@ When the grid is configured with an array of items as the data provider, it prov
 <dom-module id="vaadin-grid-selection-column">
   <template>
     <template class="header" id="defaultHeaderTemplate">
-      <input hidden$="[[_selectAllHidden]]" type="checkbox" on-click="_onSelectAll" checked="[[_isChecked(selectAll, _indeterminate)]]" indeterminate="[[_indeterminate]]"/>
+      <input aria-label="Select All" hidden$="[[_selectAllHidden]]" type="checkbox" on-click="_onSelectAll" checked="[[_isChecked(selectAll, _indeterminate)]]" indeterminate="[[_indeterminate]]"/>
     </template>
     <template>
-      <input type="checkbox" checked="{{selected::change}}" />
+      <input aria-label="Select Row" type="checkbox" checked="{{selected::change}}" />
     </template>
   </template>
 </dom-module>

--- a/vaadin-grid-table-cell.html
+++ b/vaadin-grid-table-cell.html
@@ -183,9 +183,13 @@
         this.style.height = '';
 
         this._cellContent = document.createElement('div');
+
         this._cellContent.setAttribute('class', 'cell-content');
-        var contentId = target._contentIndex = target._contentIndex + 1 || 0;
+        var contentId = vaadin.elements.grid._contentIndex = vaadin.elements.grid._contentIndex + 1 || 0;
         this._cellContent.setAttribute('data-cell-content-id', contentId);
+        // TODO: maybe change data-cell-content-id attribute to ID with a prefix?
+        this._cellContent.setAttribute('id', 'vaadin-grid-cell-content-' + contentId);
+
         Polymer.dom(this._cellContent).appendChild(this.instance.root);
 
         this._insertionPoint = document.createElement('content');

--- a/vaadin-grid-table-focus-trap.html
+++ b/vaadin-grid-table-focus-trap.html
@@ -13,8 +13,8 @@
     </style>
 
     <!-- trap needs to have content in order for Safari to scroll the page when focused -->
-    <div class="primary" tabindex="0" role="gridcell"><div style="position:absolute;z-index:1;" aria-hidden="true">&nbsp;</div></div>
-    <div class="secondary" tabindex="-1" role="gridcell"><div style="position:absolute;z-index:1;" aria-hidden="true">&nbsp;</div></div>
+    <div class="primary" tabindex="0" role="gridcell" on-focus="_onFocusin" on-blur="_onFocusout"><div style="position:absolute;z-index:1;" aria-hidden="true">&nbsp;</div></div>
+    <div class="secondary" tabindex="-1" role="gridcell" on-focus="_onFocusin" on-blur="_onFocusout"><div style="position:absolute;z-index:1;" aria-hidden="true">&nbsp;</div></div>
 
     <slot></slot>
   </template>
@@ -28,8 +28,7 @@
       },
 
       listeners: {
-        'focus': '_onFocus',
-        'focusin': '_onFocusin'
+        'focus': '_onFocus'
       },
 
       properties: {
@@ -56,7 +55,17 @@
       },
 
       _onFocusin: function(e) {
+        // TODO: remove this custom event after FF52 with native focusin support
+        // is in use.
+        this.fire('focusin');
+
         this._focused = e.target;
+      },
+
+      _onFocusout: function(e) {
+        // TODO: remove this custom event after FF52 with native focusout support
+        // is in use.
+        this.fire('focusout');
       },
 
       _activeTargetChanged: function(target) {

--- a/vaadin-grid-table-focus-trap.html
+++ b/vaadin-grid-table-focus-trap.html
@@ -1,0 +1,70 @@
+<link rel="import" href="../polymer/polymer.html">
+
+<dom-module id="vaadin-grid-table-focus-trap">
+  <template>
+    <style>
+     :host(:focus),
+     .primary:focus,
+     ::content .primary:focus,
+     .secondary:focus,
+     ::content .secondary:focus {
+       outline: none;
+     }
+    </style>
+
+    <div class="primary" tabindex="0" role="gridcell"></div>
+    <div class="secondary" tabindex="-1" role="gridcell"></div>
+
+    <slot></slot>
+  </template>
+  <script>
+    Polymer({
+      is: 'vaadin-grid-table-focus-trap',
+
+      hostAttributes: {
+        'tabindex': -1,
+        'role': 'gridcell' // gridcell roles are for VoiceOver to announce "you're in a cell"
+      },
+
+      listeners: {
+        'focus': '_onFocus'
+      },
+
+      properties: {
+        activeTarget: {
+          type: String,
+          observer: '_activeTargetChanged'
+        }
+      },
+
+      ready: function() {
+        this._primary = Polymer.dom(this.root).querySelector('.primary');
+        this._secondary = Polymer.dom(this.root).querySelector('.secondary');
+
+        // In native shadow, focus traps need to be inside the same scope as
+        // the "labelled by" elements
+        if (Polymer.Settings.useNativeShadow) {
+          Polymer.dom(this).appendChild(this._primary);
+          Polymer.dom(this).appendChild(this._secondary);
+        }
+      },
+
+      _onFocus: function(e) {
+        this.parentElement.scrollIntoView();
+        this._primary.focus();
+      },
+
+      _activeTargetChanged: function(target) {
+        // moving focus seems to be the most reliable way to get different screenreaders
+        // to announce the "aria-labelledby" property
+        if (this._primary.matches(':focus')) {
+          this._secondary.setAttribute('aria-labelledby', target);
+          this._secondary.focus();
+        } else {
+          this._primary.setAttribute('aria-labelledby', target);
+          this._primary.focus();
+        }
+      }
+    });
+  </script>
+</dom-module>

--- a/vaadin-grid-table-focus-trap.html
+++ b/vaadin-grid-table-focus-trap.html
@@ -27,7 +27,8 @@
       },
 
       listeners: {
-        'focus': '_onFocus'
+        'focus': '_onFocus',
+        'focusin': '_onFocusin'
       },
 
       properties: {
@@ -54,10 +55,14 @@
         this._primary.focus();
       },
 
+      _onFocusin: function(e) {
+        this._focused = e.target;
+      },
+
       _activeTargetChanged: function(target) {
         // moving focus seems to be the most reliable way to get different screenreaders
         // to announce the "aria-labelledby" property
-        if (this._primary.matches(':focus')) {
+        if (this._focused === this._primary) {
           this._secondary.setAttribute('aria-labelledby', target);
           this._secondary.focus();
         } else {

--- a/vaadin-grid-table-focus-trap.html
+++ b/vaadin-grid-table-focus-trap.html
@@ -12,8 +12,9 @@
      }
     </style>
 
-    <div class="primary" tabindex="0" role="gridcell"></div>
-    <div class="secondary" tabindex="-1" role="gridcell"></div>
+    <!-- trap needs to have content in order for Safari to scroll the page when focused -->
+    <div class="primary" tabindex="0" role="gridcell"><div style="position:absolute;z-index:1;" aria-hidden="true">&nbsp;</div></div>
+    <div class="secondary" tabindex="-1" role="gridcell"><div style="position:absolute;z-index:1;" aria-hidden="true">&nbsp;</div></div>
 
     <slot></slot>
   </template>
@@ -51,7 +52,6 @@
       },
 
       _onFocus: function(e) {
-        this.parentElement.scrollIntoView();
         this._primary.focus();
       },
 

--- a/vaadin-grid-table-header-footer.html
+++ b/vaadin-grid-table-header-footer.html
@@ -59,6 +59,14 @@
       extends: 'tbody',
       behaviors: [vaadin.elements.grid.FocusableCellContainerBehavior],
 
+      observers: ['_announceFocusedRow(_focusedRow)'],
+
+      _announceFocusedRow: function(row) {
+        this.fire('iron-announce', {
+          text: 'Row ' + (row.index + 1) + ' of ' + this.domHost.size
+        });
+      },
+
       _moveFocusToDetailsCell: function() {
         this._focusedCell.focused = false;
         this._focusedRow._rowDetailsCell.focused = true;

--- a/vaadin-grid-table.html
+++ b/vaadin-grid-table.html
@@ -267,11 +267,11 @@
     <style include="vaadin-grid-column-reordering-themability-styles"></style>
 
     <!-- TODO: Shadow DOM doesn't let focusin events bubble, therefore on-focus also -->
-    <vaadin-grid-table-focus-trap id="headerFocusTrap" on-focus="_onHeaderFocus" on-focusin="_onHeaderFocus">
+    <vaadin-grid-table-focus-trap id="headerFocusTrap" on-focus="_onHeaderFocus" on-focusin="_onHeaderFocus" on-focusout="_onFocusout">
     </vaadin-grid-table-focus-trap>
     <content select="#headerFocusTrap"></content>
 
-    <vaadin-grid-table-focus-trap id="bodyFocusTrap" on-focus="_onBodyFocus" on-focusin="_onBodyFocus">
+    <vaadin-grid-table-focus-trap id="bodyFocusTrap" on-focus="_onBodyFocus" on-focusin="_onBodyFocus" on-focusout="_onFocusout">
     </vaadin-grid-table-focus-trap>
     <content select="#bodyFocusTrap"></content>
 
@@ -302,7 +302,7 @@
       It needs to be injected/slotted back inside the shadow root in order to be focusable.
      -->
     <content select="#footerFocusTrap"></content>
-    <vaadin-grid-table-focus-trap id="footerFocusTrap" on-focus="_onFooterFocus" on-focusin="_onFooterFocus">
+    <vaadin-grid-table-focus-trap id="footerFocusTrap" on-focus="_onFooterFocus" on-focusin="_onFooterFocus" on-focusout="_onFocusout">
     </vaadin-grid-table-focus-trap>
   </template>
 </dom-module>

--- a/vaadin-grid-table.html
+++ b/vaadin-grid-table.html
@@ -6,6 +6,7 @@
 <link rel="import" href="vaadin-grid-table-outer-scroller.html">
 <link rel="import" href="vaadin-grid-table-header-footer.html">
 <link rel="import" href="vaadin-grid-table-cell.html">
+<link rel="import" href="vaadin-grid-table-focus-trap.html">
 <link rel="import" href="vaadin-grid-table-row.html">
 <link rel="import" href="vaadin-grid-row-details-behavior.html">
 <link rel="import" href="vaadin-grid-data-provider-behavior.html">
@@ -265,10 +266,14 @@
     <style include="vaadin-grid-row-details-themability-styles"></style>
     <style include="vaadin-grid-column-reordering-themability-styles"></style>
 
+    <!-- TODO: Shadow DOM doesn't let focusin events bubble, therefore on-focus also -->
+    <vaadin-grid-table-focus-trap id="headerFocusTrap" on-focus="_onHeaderFocus" on-focusin="_onHeaderFocus">
+    </vaadin-grid-table-focus-trap>
+    <content select="#headerFocusTrap"></content>
 
-    <!-- trap needs to have content in order for Safari to scroll the page when focused -->
-    <div id="headerFocusTrap" tabindex="0" on-focus="_onHeaderFocus" style="position: absolute;z-index: -1">&nbsp;</div>
-    <div id="bodyFocusTrap" tabindex="-1" on-focus="_onBodyFocus" style="position: absolute;z-index: -1">&nbsp;</div>
+    <vaadin-grid-table-focus-trap id="bodyFocusTrap" on-focus="_onBodyFocus" on-focusin="_onBodyFocus">
+    </vaadin-grid-table-focus-trap>
+    <content select="#bodyFocusTrap"></content>
 
     <content select="vaadin-grid-column, vaadin-grid-selection-column, vaadin-grid-column-group"></content>
 
@@ -297,7 +302,8 @@
       It needs to be injected/slotted back inside the shadow root in order to be focusable.
      -->
     <content select="#footerFocusTrap"></content>
-    <div id="footerFocusTrap" tabindex="0" on-focus="_onFooterFocus" style="position: absolute;z-index: -1">&nbsp;</div>
+    <vaadin-grid-table-focus-trap id="footerFocusTrap" on-focus="_onFooterFocus" on-focusin="_onFooterFocus">
+    </vaadin-grid-table-focus-trap>
   </template>
 </dom-module>
 

--- a/vaadin-grid.html
+++ b/vaadin-grid.html
@@ -119,8 +119,7 @@ first element in the cell will be focused. You can override the behavior by appl
       -webkit-tap-highlight-color: transparent;
     }
 
-    :host(:focus),
-    ::content #footerFocusTrap:focus {
+    :host(:focus) {
       outline: none;
     }
 

--- a/wct.conf.js
+++ b/wct.conf.js
@@ -45,6 +45,7 @@ module.exports = {
           // TODO: @limonte, revisit this in future, currently a weird istanbul bug here
           // '/vaadin-grid-sort-behavior.html',
           '/vaadin-grid-table-cell.html',
+          '/vaadin-grid-table-focus-trap.html',
           '/vaadin-grid-table-header-footer.html',
           '/vaadin-grid-table-outer-scroller.html',
           '/vaadin-grid-table-row.html',


### PR DESCRIPTION
Closes #600 

#### Tested with
- Chrome + ChromeVox (OK)
- Chrome + VoiceOver (OK)
- Safari + VoiceOver (mostly OK, focus sometimes jumps to <body>)
- Firefox + VoiceOver (doesn't work at all, even iron-a11y-announcer doesn't work)
- Chrome + NVDA (OK)
- Firefox + NVDA (OK)
- Chrome + JAWS (OK)
- Firefox + JAWS (partly OK, iron-a11y-announcer doesn't work)
- Edge + NVDA (partly OK, iron-a11y-announcer doesn't work)
- Edge + JAWS (doesn't read anything, not even elements outside `<vaadin-grid>`)


#### Notes for future improvements
- the row number and selection announcements cannot be localized currently, we might want to revisit that later. So currently English only.
- in case we in the future decide to expose the cell elements in the light DOM, it might make sense to make them focusable and use native focus instead of the "focus trap" approach.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-grid/686)
<!-- Reviewable:end -->
