### PR TITLE
Listen to track event from header only

### DIFF
--- a/test/column-resizing.html
+++ b/test/column-resizing.html
@@ -100,6 +100,13 @@
         expect(headerCells[0].clientWidth).to.equal(200);
       });
 
+      it('should not listen to track event on scroller', function() {
+        var scroller = grid.$.scroller;
+        var spy = sinon.spy(scroller, '_onTrack');
+        Polymer.Base.fire('track', {state: 'start'}, {node: scroller});
+        expect(spy.called).to.be.false;
+      });
+
       it('should be behind the frozen columns', function(done) {
         grid.style.width = '100px';
         grid._columnTree[0][0].frozen = true;

--- a/vaadin-grid-table.html
+++ b/vaadin-grid-table.html
@@ -367,7 +367,7 @@
       'property-changed': '_columnPropChanged',
       'copy': '_onCopy',
       'animationend': '_onAnimationEnd',
-      'track': '_onTrack'
+      'header.track': '_onTrack'
     },
 
     _onTrack: function() {


### PR DESCRIPTION
This fixes scrolling on iOS9

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-grid/707)
<!-- Reviewable:end -->
