### PR TITLE
Don’t update scroller unless it already has data

### DIFF
--- a/test/filtering.html
+++ b/test/filtering.html
@@ -195,6 +195,20 @@
       });
 
     });
+
+    describe('lazy init', function() {
+
+      it('should not filter if there is no data yet', function() {
+        var grid = fixture('grid');
+        grid.size = 100;
+        grid.dataProvider = function(params, callback) {
+          // Don't provide any data
+        };
+        Polymer.dom.flush();
+        expect(flushFilters.bind(this, grid)).to.not.throw(Error);
+      });
+
+    });
   </script>
 
 </body>

--- a/vaadin-grid-data-provider-behavior.html
+++ b/vaadin-grid-data-provider-behavior.html
@@ -264,7 +264,9 @@
     clearCache: function() {
       this._cache = {};
       this._pendingRequests = {};
-      this.$.scroller._update();
+      if (this.$.scroller.hasData) {
+        this.$.scroller._update();
+      }
       this._flushItemsDebouncer();
     },
 


### PR DESCRIPTION
Fixes an issue with lazy datasources. Invoking `clearCache()` when no data has yet been received caused an error (due to a premature call to `_update()`)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-grid/726)
<!-- Reviewable:end -->
