### PR TITLE
Replace loading backdrop with reduced opacity

### DIFF
--- a/vaadin-grid-data-provider-behavior.html
+++ b/vaadin-grid-data-provider-behavior.html
@@ -39,17 +39,8 @@
         animation: vaadin-grid-spin-360 400ms linear infinite;
       }
 
-      :host([loading]) #items::before {
-        content: "";
-        position: absolute;
-        top: 0;
-        left: 0;
-        width: 100%;
-        height: 100%;
-        background: rgba(255, 255, 255, 0.5);
-        pointer-events: none;
-        z-index: 1;
-        @apply(--vaadin-grid-loading-backdrop);
+      :host([loading]) #items {
+        opacity: 0.5;
       }
 
     </style>

--- a/vaadin-grid.html
+++ b/vaadin-grid.html
@@ -67,7 +67,6 @@ Custom property | Description | Default
 `--vaadin-grid-body-row-details-cell` | Mixin applied to cells on details rows | `{}`
 `--vaadin-grid-focused-cell` | Mixin applied to cells with keyboard focus | `{}`
 `--vaadin-grid-loading-spinner` | Mixin applied to the loading spinner | `{}`
-`--vaadin-grid-loading-backdrop` | Mixin applied to the loading backdrop | `{}`
 `--vaadin-grid-column-resize-handle` | Mixin applied to the column resize handle | `{}`
 
 ### Keyboard Navigation


### PR DESCRIPTION
As shown in the attached image, the current loading backdrop doesn't span over all the cells when scrolled horizontally. This PR suggest dropping the loading backdrop altogether and replacing it with `opacity: 0.5` applied to the `#items` instead.

<img width="777" alt="screenshot 2017-03-07 10 01 19" src="https://cloud.githubusercontent.com/assets/1222264/23648366/157c4768-0323-11e7-901a-3b278f692db0.png">

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-grid/778)
<!-- Reviewable:end -->
