### PR TITLE
Detect feature, not browser

### DIFF
--- a/test/index.html
+++ b/test/index.html
@@ -47,8 +47,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       'resizing.html',
       'doctype.html'
     ].reduce(function(suites, suite) {
-      var isChrome = /Chrome/.test(navigator.userAgent) && /Google Inc/.test(navigator.vendor);
-      if (isChrome) {
+      if (document.head.createShadowRoot || document.head.attachShadow) {
         // Full shadow polyfill isn't currently supported
         return suites.concat([suite, suite + '?dom=shadow']);
       } else {


### PR DESCRIPTION
Safari 10 also supports Shadow DOM:

![](https://i.imgur.com/TpQ1oSC.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-grid/811)
<!-- Reviewable:end -->
