### PR TITLE
Set virtual focus to null async to work with async focus handling in IE11

### DIFF
--- a/test/keyboard-navigation.html
+++ b/test/keyboard-navigation.html
@@ -449,17 +449,21 @@
             expect(bodyTrap.focus.callCount).to.eql(1);
           });
 
-          it('should not move virtual focus from body to footer on tab when no footer rows exist', function() {
+          it('should not move virtual focus from body to footer on tab when no footer rows exist', function(done) {
             footer.children[0].hidden = true;
 
             bodyTrap.focus();
 
             tab();
 
-            expect(scroller._virtualFocus).to.be.null;
+            // needs to be async thanks to IE11.
+            grid.async(function() {
+              expect(scroller._virtualFocus).to.be.null;
+              done();
+            }, 1);
           });
 
-          it('should not move virtual focus to footer on shift-tab when no footer rows exist', function() {
+          it('should move virtual focus to body instead of footer on shift-tab when no footer rows exist', function() {
             footer.children[0].hidden = true;
             footerTrap.focus();
 

--- a/vaadin-grid-keyboard-navigation-behavior.html
+++ b/vaadin-grid-keyboard-navigation-behavior.html
@@ -208,7 +208,7 @@
     },
 
     _onTab: function(e) {
-      if (this.interacting) {
+      if (this.interacting || !this._virtualFocus) {
         return;
       }
 
@@ -225,7 +225,12 @@
               this._virtualFocus = this.$.footer;
               e.preventDefault();
             } else {
-              this._virtualFocus = null;
+              // IE11 doesn't handle the footer trap `focus` event above syncronously
+              // which means that virtualFocus gets set to null before the handler is run
+              // causing focus being transferred back to body focus trap.
+              this.async(function() {
+                this._virtualFocus = null;
+              }, 1);
             }
             break;
 


### PR DESCRIPTION
Fixes #832 

There a caveat with this fix: in IE11 user still needs to tab through the footer even if it's not visible. To fix this, the whole focus trapping system needs a rewrite, basically removing the body trap and having the focus in the footer trap while user is navigating either in the body or footer. 

Now, this requires some work and the focus trapping system has been rewritten in the branch for Polymer 2 support, so I'm leaning towards living with this caveat for now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-grid/833)
<!-- Reviewable:end -->
