### PR TITLE
Include subfolders of `demo` and `test` folders for linting

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -10,7 +10,7 @@ gulp.task('lint', ['lint:js', 'lint:html', 'lint:css']);
 gulp.task('lint:js', function() {
   return gulp.src([
     '*.js',
-    'test/*.js'
+    'test/**/*.js'
   ])
   .pipe(eslint())
   .pipe(eslint.format())
@@ -20,8 +20,8 @@ gulp.task('lint:js', function() {
 gulp.task('lint:html', function() {
   return gulp.src([
     '*.html',
-    'demo/*.html',
-    'test/*.html',
+    'demo/**/*.html',
+    'test/**/*.html',
     '!demo/x-data-provider.html'
   ])
   .pipe(htmlExtract({
@@ -35,8 +35,8 @@ gulp.task('lint:html', function() {
 gulp.task('lint:css', function() {
   return gulp.src([
     '*.html',
-    'demo/*.html',
-    'test/*.html'
+    'demo/**/*.html',
+    'test/**/*.html'
   ])
   .pipe(htmlExtract({
     sel: 'style'

--- a/test/.eslintrc.json
+++ b/test/.eslintrc.json
@@ -1,4 +1,7 @@
 {
+  "env": {
+    "es6": true
+  },
   "rules": {
     "no-unused-vars": 0
   },

--- a/test/keyboard-navigation.html
+++ b/test/keyboard-navigation.html
@@ -130,7 +130,7 @@
         }
 
         function tab() {
-          var event = MockInteractions.keyDownOn(grid, 9);
+          MockInteractions.keyDownOn(grid, 9);
         }
 
         function shiftTab() {


### PR DESCRIPTION
Related to https://github.com/vaadin/vaadin-element-skeleton/pull/29

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-grid/847)
<!-- Reviewable:end -->
