### PR TITLE
Don’t cancel wheel events when grid can’t be scrolled

### DIFF
--- a/test/scrolling-mode.html
+++ b/test/scrolling-mode.html
@@ -104,6 +104,13 @@
         expect(wheel(-1, 0).defaultPrevented).to.be.true;
       });
 
+      it('should not prevent wheel events when scrolled to max', function() {
+        scrollToEnd(grid);
+        grid.$.scroller.flushDebouncer('ignore-new-wheel');
+        expect(wheel(0, 1).defaultPrevented).to.be.false;
+        expect(wheel(0, 1).defaultPrevented).to.be.false;
+      });
+
       it('should prevent default during cancel period', function() {
         wheel(1, 0);
         wheel(-1, 0);

--- a/vaadin-grid-table-scroll-behavior.html
+++ b/vaadin-grid-table-scroll-behavior.html
@@ -152,12 +152,15 @@
         table.scrollTop += e.deltaY;
         table.scrollLeft += e.deltaX;
         this._scrollHandler();
+        this._hasResidualMomentum = true;
 
         this._ignoreNewWheel = this.debounce('ignore-new-wheel', function() {
           this._ignoreNewWheel = null;
         }, 500);
-      } else if (momentum <= this._previousMomentum || this._ignoreNewWheel) {
+      } else if (this._hasResidualMomentum && momentum <= this._previousMomentum || this._ignoreNewWheel) {
         e.preventDefault();
+      } else if (momentum > this._previousMomentum) {
+        this._hasResidualMomentum = false;
       }
       this._previousMomentum = momentum;
     },


### PR DESCRIPTION
Fixes #855 
Fixes #820

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-grid/860)
<!-- Reviewable:end -->
