### PR TITLE
Defaul focus trap positioning to avoid a Safari rendering issue

### DIFF
--- a/vaadin-grid-table-focus-trap.html
+++ b/vaadin-grid-table-focus-trap.html
@@ -6,6 +6,7 @@
      :host {
        position: absolute;
        z-index: -3;
+       height: 0;
      }
 
      :host(:focus),

--- a/vaadin-grid-table.html
+++ b/vaadin-grid-table.html
@@ -315,7 +315,7 @@
       It needs to be injected/slotted back inside the shadow root in order to be focusable.
      -->
     <content select="#footerFocusTrap"></content>
-    <vaadin-grid-table-focus-trap id="footerFocusTrap" on-focus="_onFooterFocus" on-focusin="_onFooterFocus" on-focusout="_onFocusout" style="bottom: 0">
+    <vaadin-grid-table-focus-trap id="footerFocusTrap" on-focus="_onFooterFocus" on-focusin="_onFooterFocus" on-focusout="_onFocusout">
     </vaadin-grid-table-focus-trap>
   </template>
 </dom-module>


### PR DESCRIPTION
Fixes #853

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-grid/861)
<!-- Reviewable:end -->
