### PR TITLE
Add missing types to properties

### DIFF
--- a/vaadin-grid-data-provider-behavior.html
+++ b/vaadin-grid-data-provider-behavior.html
@@ -86,6 +86,7 @@
        *
        */
       dataProvider: {
+        type: Object,
         notify: true,
         observer: '_dataProviderChanged'
       },
@@ -96,12 +97,14 @@
       _loading: Boolean,
 
       _cache: {
+        type: Object,
         value: function() {
           return {};
         }
       },
 
       _pendingRequests: {
+        type: Object,
         value: function() {
           return {};
         }

--- a/vaadin-grid-filter-behavior.html
+++ b/vaadin-grid-filter-behavior.html
@@ -10,6 +10,7 @@
     properties: {
 
       _filters: {
+        type: Array,
         value: function() {
           return [];
         }

--- a/vaadin-grid-row-details-behavior.html
+++ b/vaadin-grid-row-details-behavior.html
@@ -40,6 +40,7 @@
        * An array containing references to expanded items.
        */
       expandedItems: {
+        type: Array,
         value: function() {
           return [];
         }

--- a/vaadin-grid-table-outer-scroller.html
+++ b/vaadin-grid-table-outer-scroller.html
@@ -35,10 +35,12 @@
 
       properties: {
         scrollTarget: {
+          type: Object,
           observer: '_scrollTargetChanged'
         },
 
         passthrough: {
+          type: Boolean,
           reflectToAttribute: true,
           value: true
         }

--- a/vaadin-grid-table-scroll-behavior.html
+++ b/vaadin-grid-table-scroll-behavior.html
@@ -73,10 +73,12 @@
     properties: {
 
       _vidxOffset: {
+        type: Number,
         value: 0
       },
 
       ios: {
+        type: Boolean,
         value: navigator.userAgent.match(/iP(?:hone|ad;(?: U;)? CPU) OS (\d+)/),
         reflectToAttribute: true
       },

--- a/vaadin-grid-table.html
+++ b/vaadin-grid-table.html
@@ -349,10 +349,12 @@
       },
 
       safari: {
+        type: Boolean,
         value: /^((?!chrome|android).)*safari/i.test(navigator.userAgent)
       },
 
       scrollbarWidth: {
+        type: Number,
         value: function() {
           // Create the measurement node
           var scrollDiv = document.createElement('div');

--- a/vaadin-grid.html
+++ b/vaadin-grid.html
@@ -260,6 +260,7 @@ first element in the cell will be focused. You can override the behavior by appl
       _rowDetailsTemplate: Object,
 
       _bindData: {
+        type: Object,
         value: function() {
           return this._getItem.bind(this);
         }


### PR DESCRIPTION
In order for vaadin-grid to play nicely with the Closure Compiler, all Polymer properties must have their type specified.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-grid/866)
<!-- Reviewable:end -->
