### PR TITLE
Minimize the amount of calls to _increasePool

### DIFF
--- a/iron-list-behavior.html
+++ b/iron-list-behavior.html
@@ -432,7 +432,17 @@
           Polymer.dom.addDebouncer(this.debounce('_debounceTemplate', this._increasePool.bind(this, this._itemsPerRow), 16));
         } else {
           // fill the rest of the pages
-          this._debounceTemplate(this._increasePool.bind(this, this._itemsPerRow));
+
+          // Count average item height
+          var itemHeight = this._physicalSize / this._physicalCount;
+          // Number of items in one page (to fill one viewport)
+          var itemsPerPage = this._viewportHeight / itemHeight;
+          // Amount of items needed in total
+          var totalNeededItems = this._maxPages * itemsPerPage;
+          // Estimated count of missing items
+          var missingItems = Math.ceil(totalNeededItems - this._physicalCount);
+
+          this._debounceTemplate(this._increasePool.bind(this, missingItems || 1));
         }
         this._lastPage = currentPage;
         return true;

--- a/test/physical-count.html
+++ b/test/physical-count.html
@@ -86,6 +86,28 @@
         scroller._update();
         expect(scroller._increasePoolIfNeeded()).to.be.false;
       });
+
+      it('should minimize increase pool iterations', function(done) {
+        var spy = sinon.spy(grid.$.scroller, '_increasePool');
+        grid.style.height = '1000px';
+
+        Polymer.RenderStatus.afterNextRender(grid, function() {
+          expect(spy.callCount).to.be.below(4);
+          done();
+        });
+      });
+
+      it('should minimize physical count', function(done) {
+        expect(grid.$.scroller._physicalCount).to.be.below(26);
+        grid.style.height = '1000px';
+
+        Polymer.RenderStatus.afterNextRender(grid, function() {
+          expect(grid.$.scroller._physicalCount).to.be.below(87);
+          done();
+        });
+      });
+
+
     });
   </script>
 


### PR DESCRIPTION
This will improve initial load time of `<vaadin-grid>`.

Measured the impact of this change to the [Patient portal demo](https://github.com/vaadin/patient-portal-demo-polymer) (amount of time it takes to get a fully rendered grid (with rows)):
- Before the change: 2.7s
- After the change: 1.7s

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-grid/867)
<!-- Reviewable:end -->
