### PR TITLE
Update vaadin-grid-array-data-provider-behavior.html

### DIFF
--- a/vaadin-grid-array-data-provider-behavior.html
+++ b/vaadin-grid-array-data-provider-behavior.html
@@ -72,7 +72,7 @@
           continue;
         }
 
-        var parentProperty = path.replace(/\.[^\.]*/, ''); // a.b.c -> a.b
+        var parentProperty = path.replace(/\.[^\.]*$/, ''); // a.b.c -> a.b
         if (Polymer.Base.get(parentProperty, items[0]) === undefined) {
           console.warn(
             'Path "' + path + '" used for ' + action + ' does not exist in all of the items, ' + action + ' is disabled.'


### PR DESCRIPTION
Fix _checkPaths function.

The intention of line 75 is to remove the last level of the path. a.b.c -> a.b
Currently the regex matches and replaces the first occurrence of .X resulting in a.b.c -> a.c

Fixed by changing the regex to last last occurrence.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-grid/891)
<!-- Reviewable:end -->
