### PR TITLE
Fix typo in mixin docs

### DIFF
--- a/vaadin-grid.html
+++ b/vaadin-grid.html
@@ -92,7 +92,7 @@ Custom property | Description | Default
 `--vaadin-grid-body-cell` | Mixin applied to body cells | `{}`
 `--vaadin-grid-body-row-odd-cell` | Mixin applied to body cells on odd rows | `{}`
 `--vaadin-grid-cell-last-frozen` | Mixin applied to the last frozen column cells | `{}`
-`--vaadin-grid-body-row-hover-cell` | Mixin applied to body cells on on hovered row | `{}`
+`--vaadin-grid-body-row-hover-cell` | Mixin applied to body cells on hovered row | `{}`
 `--vaadin-grid-body-row-selected-cell` | Mixin applied to body cells on selected rows | `{}`
 `--vaadin-grid-body-row-active-cell` | Mixin applied to body cells on active row | `{}`
 `--vaadin-grid-body-row-details-cell` | Mixin applied to cells on details rows | `{}`


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-grid/903)
<!-- Reviewable:end -->
