### PR TITLE
fix typo in 'sorting with data provider' demo

### DIFF
--- a/demo/sorting-filtering.html
+++ b/demo/sorting-filtering.html
@@ -77,7 +77,7 @@
     <p>
       When the data is fetched from a data provider, the responsibility
       of providing the correctly ordered data is on the data provider itself.
-      The data provider is ascked for fresh sorted data whenever the sorting
+      The data provider is asked for fresh sorted data whenever the sorting
       order is changed on any <code>&lt;vaadin-grid-sorter&gt;</code>.
     </p>
     <p>


### PR DESCRIPTION
fixes a typo in 'sorting with data provider' demo.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-grid/940)
<!-- Reviewable:end -->
