### PR TITLE
allow polymer 1.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 [![Coverage Status](https://coveralls.io/repos/github/vaadin/vaadin-grid/badge.svg?branch=master)](https://coveralls.io/github/vaadin/vaadin-grid?branch=master)
 [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/vaadin/vaadin-core-elements?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 
-# &lt;vaadin-grid&gt; v2
+# &lt;vaadin-grid&gt; v3
 
-[Live Demo ↗](https://cdn.vaadin.com/vaadin-grid/2.0.2/demo/)
+[Live Demo ↗](https://cdn.vaadin.com/vaadin-grid/3.0.1/demo/)
 
 > :eyes: Looking for &lt;vaadin-grid&gt; v1.x? Please see the [the v1 branch](https://github.com/vaadin/vaadin-grid/tree/1.x)
 

--- a/bower.json
+++ b/bower.json
@@ -47,7 +47,7 @@
     "app-localize-behavior": "^v2.0.0"
   },
   "dependencies": {
-    "polymer": "^2.0.0",
+    "polymer": "1.9 - 2",
     "iron-resizable-behavior": "PolymerElements/iron-resizable-behavior#^v2.0.0",
     "iron-scroll-target-behavior": "PolymerElements/iron-scroll-target-behavior#^v2.0.0",
     "iron-a11y-keys-behavior": "^v2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vaadin-grid",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "A free, flexible and high-quality Web Component for showing large amounts of tabular data",
   "author": "Vaadin Ltd",
   "license": "Apache-2.0",


### PR DESCRIPTION
Since the Hybrid Element is being used, the bower.json should allow Polymer 1.9 as a resolution.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-grid/946)
<!-- Reviewable:end -->
