### PR TITLE
Fix(keyboard): rows reordering removes focus after scrolling

### DIFF
--- a/test/basic.html
+++ b/test/basic.html
@@ -154,6 +154,35 @@
         });
       });
 
+      // The following could not be tested if window is not focused.
+      if (!window.document.hasFocus()) {
+        // Try to get window focus.
+        window.top && window.top.focus();
+        window.focus();
+      }
+      (window.document.hasFocus() ? it : it.skip)('reorder should keep focused row', function() {
+        grid.size = 1000;
+        getCell(grid, 10).focus();
+        [1, 1, 2, 3, 5, 8, 13, 21, 34, 55, 89, 144].forEach(function(steps) {
+          const activeElement = grid.shadowRoot.activeElement;
+          grid.$.table.scrollTop = 5000 + grid._physicalAverage * steps;
+          grid._scrollHandler();
+          grid._debounceScrolling.flush();
+
+          // Expect the physical rows to be in order after scrolling
+          var rows = Polymer.dom(grid.$.items).querySelectorAll('tr');
+
+          rows.forEach((row, index) => {
+            if (index > 0) {
+              expect(row.index).to.equal(rows[index - 1].index + 1);
+            }
+          });
+
+          expect(document.activeElement).to.equal(grid);
+          expect(grid.shadowRoot.activeElement).to.equal(activeElement);
+        });
+      });
+
       it('should warn about missing imports', function() {
         var _warn = console.warn;
         var spy = console.warn = sinon.spy();

--- a/vaadin-grid-keyboard-navigation-mixin.html
+++ b/vaadin-grid-keyboard-navigation-mixin.html
@@ -259,6 +259,12 @@ This program is available under Apache License Version 2.0, available at https:/
           .filter(el => el.matches('[part~="details-cell"]'))[0] :
         dstRow.children[dstColumnIndex];
       this._scrollHorizontallyToCell(dstCell);
+      if (activeRowGroup === this.$.items) {
+        // When scrolling with repeated keydown, sometimes FocusEvent listeners
+        // are too late to update _focusedItemIndex. Ensure next keydown
+        // listener invocation gets updated _focusedItemIndex value.
+        this._focusedItemIndex = dstRowIndex;
+      }
       this._focusCell(dstCell, activeRowGroup);
     }
 

--- a/vaadin-grid-scroll-mixin.html
+++ b/vaadin-grid-scroll-mixin.html
@@ -92,7 +92,9 @@ This program is available under Apache License Version 2.0, available at https:/
             document.body.removeChild(scrollDiv);
             return scrollbarWidth;
           }
-        }
+        },
+
+        _rowWithFocusedElement: Element
 
       };
     }
@@ -101,6 +103,12 @@ This program is available under Apache License Version 2.0, available at https:/
       super.ready();
       this.scrollTarget = this.$.table;
       this.addEventListener('wheel', this._onWheel.bind(this));
+
+      this.$.items.addEventListener('focusin', (e) => {
+        const itemsIndex = e.composedPath().indexOf(this.$.items);
+        this._rowWithFocusedElement = e.composedPath()[itemsIndex - 1];
+      });
+      this.$.items.addEventListener('focusout', () => this._rowWithFocusedElement = undefined);
     }
 
     _hasFixedSections(scrollbarWidth) {
@@ -192,19 +200,21 @@ This program is available under Apache License Version 2.0, available at https:/
 
       var _adjustedVirtualStart = this._virtualStart + this._vidxOffset;
 
-      // DOM index of the element with the lowest index
-      var physicalIndexOfFirst = items.length - (items[0].index - _adjustedVirtualStart);
+      // Which row to use as a target?
+      const targetRow = this._rowWithFocusedElement || items[0];
 
-      // Reorder the DOM elements
-      if (physicalIndexOfFirst < items.length / 2) {
-        // Append all the preceding elements after the last element
-        for (var i = 0; i < physicalIndexOfFirst; i++) {
+      // Where the target row should be?
+      const targetPhysicalIndex = targetRow.index - _adjustedVirtualStart;
+
+      // Reodrer the DOM elements to keep the target row at the target physical index
+      const delta = Array.from(items).indexOf(targetRow) - targetPhysicalIndex;
+      if (delta > 0) {
+        for (let i = 0; i < delta; i++) {
           body.appendChild(items[i]);
         }
-      } else {
-        // Prepend all the trailing elements before the first element
-        for (var j = physicalIndexOfFirst; j < items.length; j++) {
-          body.insertBefore(items[j], items[0]);
+      } else if (delta < 0) {
+        for (let i = items.length + delta; i < items.length; i++) {
+          body.insertBefore(items[i], items[0]);
         }
       }
     }


### PR DESCRIPTION
Connected to #878

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-grid/963)
<!-- Reviewable:end -->
