### PR TITLE
Templatizer is converted to ES6

### DIFF
--- a/test/column.html
+++ b/test/column.html
@@ -238,7 +238,7 @@
           Polymer.dom(grid).appendChild(column);
           grid._observer.flush();
 
-          expect(template.templatizer._templatizerTemplate).to.eql(template);
+          expect(template.templatizer.template).to.eql(template);
           expect(column.template).to.eql(template);
         });
 
@@ -257,7 +257,7 @@
           column.appendChild(template2);
           column._templateObserver.flush();
 
-          expect(template2.templatizer._templatizerTemplate).to.eql(template2);
+          expect(template2.templatizer.template).to.eql(template2);
           expect(column.template).to.eql(template2);
         });
       });

--- a/vaadin-grid-column.html
+++ b/vaadin-grid-column.html
@@ -187,7 +187,7 @@ This program is available under Apache License Version 2.0, available at https:/
 
     _prepareTemplatizer(template, instanceProps) {
       if (template && !template.templatizer) {
-        const templatizer = new vaadin.elements.grid.Templatizer();
+        const templatizer = new Vaadin.GridTemplatizer();
         templatizer._grid = this._grid;
         templatizer.dataHost = this.dataHost;
         templatizer._instanceProps = instanceProps || templatizer._instanceProps;

--- a/vaadin-grid-column.html
+++ b/vaadin-grid-column.html
@@ -187,7 +187,7 @@ This program is available under Apache License Version 2.0, available at https:/
 
     _prepareTemplatizer(template, instanceProps) {
       if (template && !template.templatizer) {
-        const templatizer = new Vaadin.GridTemplatizer();
+        const templatizer = new Vaadin.Grid.Templatizer();
         templatizer._grid = this._grid;
         templatizer.dataHost = this.dataHost;
         templatizer._instanceProps = instanceProps || templatizer._instanceProps;

--- a/vaadin-grid-row-details-mixin.html
+++ b/vaadin-grid-row-details-mixin.html
@@ -44,7 +44,7 @@ This program is available under Apache License Version 2.0, available at https:/
       super.ready();
       this._rowDetailsTemplate = this.querySelector('template.row-details');
       if (this._rowDetailsTemplate) {
-        var templatizer = new Vaadin.GridTemplatizer();
+        var templatizer = new Vaadin.Grid.Templatizer();
         templatizer._grid = this;
         templatizer.dataHost = this.dataHost;
         templatizer.template = this._rowDetailsTemplate;

--- a/vaadin-grid-row-details-mixin.html
+++ b/vaadin-grid-row-details-mixin.html
@@ -44,7 +44,7 @@ This program is available under Apache License Version 2.0, available at https:/
       super.ready();
       this._rowDetailsTemplate = this.querySelector('template.row-details');
       if (this._rowDetailsTemplate) {
-        var templatizer = new vaadin.elements.grid.Templatizer();
+        var templatizer = new Vaadin.GridTemplatizer();
         templatizer._grid = this;
         templatizer.dataHost = this.dataHost;
         templatizer.template = this._rowDetailsTemplate;

--- a/vaadin-grid-templatizer.html
+++ b/vaadin-grid-templatizer.html
@@ -39,13 +39,13 @@ This program is available under Apache License Version 2.0, available at https:/
           },
 
           _grid: Object
-        }
+        };
       }
 
       static get observers() {
         return [
           '_templateInstancesChanged(_templateInstances.*, _parentPathValues.*)'
-        ]
+        ];
       }
 
       constructor() {
@@ -87,6 +87,12 @@ This program is available under Apache License Version 2.0, available at https:/
 
             forwardHostProp: function(prop, value) {
               this._forwardParentProp(prop, value);
+
+              if (this._templateInstances) {
+                this._templateInstances.forEach(function(inst) {
+                  inst.notifyPath(prop, value);
+                }, this);
+              }
             },
 
             notifyInstanceProp: function(inst, prop, value) {
@@ -128,7 +134,6 @@ This program is available under Apache License Version 2.0, available at https:/
           inst.set(prop, value);
         }, this);
       }
-
 
       _templateInstancesChanged(t, p) {
         var index, count;

--- a/vaadin-grid-templatizer.html
+++ b/vaadin-grid-templatizer.html
@@ -89,9 +89,9 @@ This program is available under Apache License Version 2.0, available at https:/
               this._forwardParentProp(prop, value);
 
               if (this._templateInstances) {
-                this._templateInstances.forEach(function(inst) {
+                this._templateInstances.forEach(inst => {
                   inst.notifyPath(prop, value);
-                }, this);
+                });
               }
             },
 
@@ -130,9 +130,9 @@ This program is available under Apache License Version 2.0, available at https:/
 
       _forwardParentProp(prop, value) {
         this._parentPathValues[prop] = value;
-        this._templateInstances.forEach(function(inst) {
+        this._templateInstances.forEach(inst => {
           inst.set(prop, value);
-        }, this);
+        });
       }
 
       _templateInstancesChanged(t, p) {
@@ -148,11 +148,11 @@ This program is available under Apache License Version 2.0, available at https:/
         } else {
           return;
         }
-        Object.keys(this._parentPathValues || {}).forEach(function(keyName) {
+        Object.keys(this._parentPathValues || {}).forEach(keyName => {
           for (var i = index; i < index + count; i++) {
             this._templateInstances[i].set(keyName, this._parentPathValues[keyName]);
           }
-        }, this);
+        });
       }
 
     }
@@ -163,6 +163,7 @@ This program is available under Apache License Version 2.0, available at https:/
      * @namespace Vaadin
      */
     window.Vaadin = window.Vaadin || {};
-    Vaadin.GridTemplatizer = GridTemplatizer;
+    window.Vaadin.Grid = window.Vaadin.Grid || {};
+    Vaadin.Grid.Templatizer = GridTemplatizer;
   }
 </script>

--- a/vaadin-grid-templatizer.html
+++ b/vaadin-grid-templatizer.html
@@ -4,7 +4,7 @@ Copyright (c) 2017 Vaadin Ltd.
 This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
 -->
 
-<link rel="import" href="../polymer/polymer.html">
+<link rel="import" href="../polymer/polymer-element.html">
 
 <script>
   {

--- a/vaadin-grid-templatizer.html
+++ b/vaadin-grid-templatizer.html
@@ -7,156 +7,157 @@ This program is available under Apache License Version 2.0, available at https:/
 <link rel="import" href="../polymer/polymer.html">
 
 <script>
-  window.vaadin = window.vaadin || {};
-  vaadin.elements = vaadin.elements || {};
-  vaadin.elements.grid = vaadin.elements.grid || {};
-  vaadin.elements.grid.Templatizer = Polymer({
-    is: 'vaadin-grid-templatizer',
+  {
+    /**
+     * `vaadin-grid-templatizer` is a helper element for the `vaadin-grid` that is preparing and
+     * stamping instances of cells and columns templates
+     *
+     * @memberof Vaadin
+     */
+    class GridTemplatizer extends Polymer.Element {
+      static get is() {
+        return 'vaadin-grid-templatizer';
+      }
 
-    behaviors: [Polymer.Templatizer],
+      static get properties() {
+        return {
+          dataHost: Object,
 
-    properties: {
-      dataHost: Object,
-      template: Object,
+          template: Object,
 
-      _templateInstances: {
-        type: Array,
-        value: function() {
-          return [];
+          _templateInstances: {
+            type: Array,
+            value: function() {
+              return [];
+            }
+          },
+
+          _parentPathValues: {
+            value: function() {
+              return {};
+            }
+          },
+
+          _grid: Object
         }
-      },
+      }
 
-      _parentPathValues: {
-        value: function() {
-          return {};
+      static get observers() {
+        return [
+          '_templateInstancesChanged(_templateInstances.*, _parentPathValues.*)'
+        ]
+      }
+
+      constructor() {
+        super();
+
+        this._instanceProps = {
+          expanded: true,
+          index: true,
+          item: true,
+          selected: true
+        };
+      }
+
+      createInstance() {
+        this._ensureTemplatized();
+        var instance = new this._TemplateClass({});
+        this.addInstance(instance);
+
+        return instance;
+      }
+
+      addInstance(instance) {
+        if (this._templateInstances.indexOf(instance) === -1) {
+          this._templateInstances.push(instance);
+          requestAnimationFrame(() => this.notifyPath('_templateInstances.*', this._templateInstances));
         }
-      },
-
-      _grid: Object
-    },
-
-    observers: [
-      '_templateInstancesChanged(_templateInstances.*, _parentPathValues.*)'
-    ],
-
-    created: function() {
-      // needed for V2 to enable event.model on declarative event listeners.
-      this._parentModel = true;
-
-      this._instanceProps = {
-        expanded: true,
-        index: true,
-        item: true,
-        selected: true
-      };
-    },
-
-    createInstance: function() {
-      this._ensureTemplatized();
-      var instance = this.stamp({});
-      this.addInstance(instance);
-
-      return instance;
-    },
-
-    addInstance: function(instance) {
-      if (this._templateInstances.indexOf(instance) === -1) {
-        this._templateInstances.push(instance);
-        requestAnimationFrame(() => this.notifyPath('_templateInstances.*', this._templateInstances));
-      }
-    },
-
-    removeInstance: function(instance) {
-      var index = this._templateInstances.indexOf(instance);
-      this.splice('_templateInstances', index, 1);
-    },
-
-    _ensureTemplatized: function() {
-      // Avoid multiple templatize for the template
-      if (!this.template._templatized) {
-        this.template._templatized = true;
-
-        this.templatize(this.template);
-
-        // TODO: hack to avoid: https://github.com/Polymer/polymer/issues/3307
-        this._parentProps = this._parentProps || {};
-      }
-    },
-
-    _notifyInstancePropV2: function(inst, prop, value) {
-      if (prop === 'index' || prop === 'item') {
-        // We don’t need a change notification for these.
-        return;
       }
 
-      var originalProp = `__${prop}__`;
-
-      // Notify for only user-action changes, not for scrolling updates. E. g.,
-      // if `expanded` is different from `__expanded__`, which was set during render.
-      if (inst[originalProp] === value) {
-        return;
-      }
-      inst[originalProp] = value;
-
-      const row = Array.from(this._grid.$.items.children).filter(row => row._item === inst.item)[0];
-      if (row) {
-        Array.from(row.children).forEach(cell => {
-          cell._instance[originalProp] = value;
-          cell._instance.notifyPath(prop, value);
-        });
+      removeInstance(instance) {
+        var index = this._templateInstances.indexOf(instance);
+        this.splice('_templateInstances', index, 1);
       }
 
-      var gridCallback = `_${prop}InstanceChangedCallback`;
-      if (this._grid && this._grid[gridCallback]) {
-        this._grid[gridCallback](inst, value);
+      _ensureTemplatized() {
+        if (!this._TemplateClass) {
+          this._TemplateClass = Polymer.Templatize.templatize(this.template, this, {
+            instanceProps: this._instanceProps,
+            parentModel: true,
+
+            forwardHostProp: function(prop, value) {
+              this._forwardParentProp(prop, value);
+            },
+
+            notifyInstanceProp: function(inst, prop, value) {
+              if (prop === 'index' || prop === 'item') {
+                // We don’t need a change notification for these.
+                return;
+              }
+
+              var originalProp = `__${prop}__`;
+
+              // Notify for only user-action changes, not for scrolling updates. E. g.,
+              // if `expanded` is different from `__expanded__`, which was set during render.
+              if (inst[originalProp] === value) {
+                return;
+              }
+              inst[originalProp] = value;
+
+              const row = Array.from(this._grid.$.items.children).filter(row => row._item === inst.item)[0];
+              if (row) {
+                Array.from(row.children).forEach(cell => {
+                  cell._instance[originalProp] = value;
+                  cell._instance.notifyPath(prop, value);
+                });
+              }
+
+              var gridCallback = `_${prop}InstanceChangedCallback`;
+              if (this._grid && this._grid[gridCallback]) {
+                this._grid[gridCallback](inst, value);
+              }
+            }
+
+          });
+        }
       }
-    },
 
-    _forwardParentProp: function(prop, value) {
-      this._parentPathValues[prop] = value;
-      this._templateInstances.forEach(function(inst) {
-        inst.set(prop, value);
-      }, this);
-    },
-
-    _forwardParentPath: function(path, value) {
-      this.set(['_parentPathValues', path], value);
-      this._templateInstances.forEach(function(inst) {
-        inst.notifyPath(path, value);
-      }, this);
-    },
-
-    _forwardHostPropV2: function(prop, value) {
-      this._forwardParentProp(prop, value);
-
-      // TODO: _forwardedParentPropsChanged isn't triggered for some reason in
-      // all cases in Hybrid mode. Try removing this after running pure P2.
-      if (this._templateInstances) {
+      _forwardParentProp(prop, value) {
+        this._parentPathValues[prop] = value;
         this._templateInstances.forEach(function(inst) {
-          inst.notifyPath(prop, value);
+          inst.set(prop, value);
         }, this);
       }
-    },
 
-    _templateInstancesChanged: function(t, p) {
-      var index, count;
-      if (t.path === '_templateInstances') {
-        // Iterate all instances
-        index = 0;
-        count = this._templateInstances.length;
-      } else if (t.path === '_templateInstances.splices') {
-        // Iterate only new instances
-        index = t.value.index;
-        count = t.value.addedCount;
-      } else {
-        return;
-      }
-      Object.keys(this._parentPathValues || {}).forEach(function(keyName) {
-        for (var i = index; i < index + count; i++) {
-          this._templateInstances[i].set(keyName, this._parentPathValues[keyName]);
+
+      _templateInstancesChanged(t, p) {
+        var index, count;
+        if (t.path === '_templateInstances') {
+          // Iterate all instances
+          index = 0;
+          count = this._templateInstances.length;
+        } else if (t.path === '_templateInstances.splices') {
+          // Iterate only new instances
+          index = t.value.index;
+          count = t.value.addedCount;
+        } else {
+          return;
         }
-      }, this);
+        Object.keys(this._parentPathValues || {}).forEach(function(keyName) {
+          for (var i = index; i < index + count; i++) {
+            this._templateInstances[i].set(keyName, this._parentPathValues[keyName]);
+          }
+        }, this);
+      }
+
     }
 
-  });
+    customElements.define(GridTemplatizer.is, GridTemplatizer);
+
+    /**
+     * @namespace Vaadin
+     */
+    window.Vaadin = window.Vaadin || {};
+    Vaadin.GridTemplatizer = GridTemplatizer;
+  }
 </script>


### PR DESCRIPTION
Connected to https://github.com/vaadin/vaadin-grid/issues/878

Templatizer is converted to ES6 with using new Polymer.Templatize module for preparing and stamping instances of templates utilizing Polymer 2 templating features.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-grid/982)
<!-- Reviewable:end -->
