### PR TITLE
Update the column tree with microtask timing

### DIFF
--- a/vaadin-grid-column-group.html
+++ b/vaadin-grid-column-group.html
@@ -5,6 +5,7 @@ This program is available under Apache License Version 2.0, available at https:/
 -->
 
 <link rel="import" href="../polymer/polymer.html">
+<link rel="import" href="../polymer/lib/utils/async.html">
 <link rel="import" href="vaadin-grid-column.html">
 
 <dom-module id="vaadin-grid-column-group">
@@ -258,7 +259,10 @@ This program is available under Apache License Version 2.0, available at https:/
               this._childColumns = this._rootColumns;
               this._preventHiddenCascade = false;
 
-              this._grid && this._grid._updateColumnTree && this._grid._updateColumnTree();
+              // Update the column tree with microtask timing to avoid shady style scope issues
+              Polymer.Async.microTask.run(() => {
+                this._grid && this._grid._updateColumnTree && this._grid._updateColumnTree();
+              });
             }
           });
           this._observer.flush();

--- a/wct.conf.js
+++ b/wct.conf.js
@@ -8,7 +8,7 @@ module.exports = {
     ];
 
     const saucelabsPlatformsPolyfilled = [
-      'Windows 10/microsoftedge@14',
+      'Windows 10/microsoftedge@15',
       'Windows 10/internet explorer@11'
     ];
 


### PR DESCRIPTION
Connects to https://github.com/vaadin/components-team-tasks/issues/283

Fixes the issue with `<vaadin-grid-column-group>`s causing all the header rows not to have a proper style scope on Firefox.

Reproducible in https://github.com/vaadin/vaadin-valo-theme/blob/master/demo/grids.html#L320

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-grid/1013)
<!-- Reviewable:end -->
