### PR TITLE
Prevent space click for focusable cell content from toggling activeItem

### DIFF
--- a/test/keyboard-navigation.html
+++ b/test/keyboard-navigation.html
@@ -1183,7 +1183,16 @@
         });
 
         it('should not activate when clicking on a native input', () => {
-          focusFirstBodyInput(0);
+          const input = focusFirstBodyInput(0);
+          input.click();
+
+          expect(grid.activeItem).to.be.null;
+        });
+
+        it('should not activate on space click on a native input', () => {
+          const input = focusFirstBodyInput(0);
+          escape(input);
+          space();
 
           expect(grid.activeItem).to.be.null;
         });

--- a/vaadin-grid-cell-click-mixin.html
+++ b/vaadin-grid-cell-click-mixin.html
@@ -36,7 +36,7 @@ This program is available under Apache License Version 2.0, available at https:/
       const cellContentHasFocus = cellContent.contains(activeElement) &&
         // MSIE bug: flex children receive focus. Make type & attributes check.
         (!this._ie || this._isFocusable(activeElement));
-      if (!cellContentHasFocus) {
+      if (!cellContentHasFocus && !this._isFocusable(e.target)) {
         this.dispatchEvent(new CustomEvent('cell-activate', {detail: {model: cell._instance}}));
       }
     }

--- a/vaadin-grid.html
+++ b/vaadin-grid.html
@@ -305,6 +305,9 @@ This program is available under Apache License Version 2.0, available at https:/
           if (window.chrome) {
             // Chrome bug: focusing before mouseup prevents text selection, see http://crbug.com/771903
             const mouseUpListener = () => {
+              if (!cellContent.contains(this.getRootNode().activeElement)) {
+                cell.focus();
+              }
               // If focus is in the cell content — respect it, do not change.
               document.removeEventListener('mouseup', mouseUpListener, true);
             };
@@ -312,7 +315,7 @@ This program is available under Apache License Version 2.0, available at https:/
           } else {
             // Focus on mouseup, on the other hand, removes selection on Safari.
             // Watch out sync focus removal issue, only async focus works here.
-            Polymer.Async.microTask.run(() => {
+            setTimeout(() => {
               if (!cellContent.contains(this.getRootNode().activeElement)) {
                 cell.focus();
               }


### PR DESCRIPTION
Depends on #1030 

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-grid/1031)
<!-- Reviewable:end -->
