### PR TITLE
Rename row details APIs to not use expand/collapse/expanded

### DIFF
--- a/analysis.json
+++ b/analysis.json
@@ -8,11 +8,11 @@
       "sourceRange": {
         "file": "vaadin-grid.html",
         "start": {
-          "line": 526,
+          "line": 561,
           "column": 4
         },
         "end": {
-          "line": 526,
+          "line": 561,
           "column": 40
         }
       },
@@ -5737,7 +5737,7 @@
                   "column": 8
                 },
                 "end": {
-                  "line": 238,
+                  "line": 240,
                   "column": 9
                 }
               },
@@ -5760,7 +5760,7 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 240,
+                  "line": 242,
                   "column": 8
                 },
                 "end": {
@@ -5785,12 +5785,33 @@
                   "column": 8
                 },
                 "end": {
-                  "line": 268,
+                  "line": 265,
                   "column": 9
                 }
               },
               "metadata": {},
               "params": []
+            },
+            {
+              "name": "_isColumnElement",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "start": {
+                  "line": 267,
+                  "column": 8
+                },
+                "end": {
+                  "line": 269,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "node"
+                }
+              ]
             }
           ],
           "staticMethods": [],
@@ -5802,7 +5823,7 @@
               "column": 6
             },
             "end": {
-              "line": 269,
+              "line": 270,
               "column": 7
             }
           },
@@ -10716,11 +10737,11 @@
               "privacy": "public",
               "sourceRange": {
                 "start": {
-                  "line": 147,
+                  "line": 137,
                   "column": 12
                 },
                 "end": {
-                  "line": 147,
+                  "line": 137,
                   "column": 24
                 }
               },
@@ -10735,11 +10756,11 @@
               "privacy": "public",
               "sourceRange": {
                 "start": {
-                  "line": 154,
+                  "line": 144,
                   "column": 12
                 },
                 "end": {
-                  "line": 159,
+                  "line": 149,
                   "column": 13
                 }
               },
@@ -10757,11 +10778,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 161,
+                  "line": 151,
                   "column": 12
                 },
                 "end": {
-                  "line": 164,
+                  "line": 154,
                   "column": 13
                 }
               },
@@ -10771,37 +10792,17 @@
               "defaultValue": "null"
             },
             {
-              "name": "_cellHasFocus",
-              "type": "boolean",
-              "description": "",
-              "privacy": "protected",
-              "sourceRange": {
-                "start": {
-                  "line": 166,
-                  "column": 12
-                },
-                "end": {
-                  "line": 169,
-                  "column": 13
-                }
-              },
-              "metadata": {
-                "polymer": {}
-              },
-              "defaultValue": "false"
-            },
-            {
               "name": "_isConnected",
               "type": "boolean",
               "description": "",
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 171,
+                  "line": 156,
                   "column": 12
                 },
                 "end": {
-                  "line": 174,
+                  "line": 159,
                   "column": 13
                 }
               },
@@ -10809,44 +10810,6 @@
                 "polymer": {}
               },
               "defaultValue": "false"
-            },
-            {
-              "name": "_boundOnCellContentFocusin",
-              "type": "Function",
-              "description": "",
-              "privacy": "protected",
-              "sourceRange": {
-                "start": {
-                  "line": 176,
-                  "column": 12
-                },
-                "end": {
-                  "line": 181,
-                  "column": 13
-                }
-              },
-              "metadata": {
-                "polymer": {}
-              }
-            },
-            {
-              "name": "_boundOnCellContentFocusout",
-              "type": "Function",
-              "description": "",
-              "privacy": "protected",
-              "sourceRange": {
-                "start": {
-                  "line": 183,
-                  "column": 12
-                },
-                "end": {
-                  "line": 188,
-                  "column": 13
-                }
-              },
-              "metadata": {
-                "polymer": {}
-              }
             }
           ],
           "methods": [
@@ -10856,11 +10819,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 200,
+                  "line": 170,
                   "column": 8
                 },
                 "end": {
-                  "line": 203,
+                  "line": 173,
                   "column": 9
                 }
               },
@@ -10873,11 +10836,11 @@
               "privacy": "public",
               "sourceRange": {
                 "start": {
-                  "line": 205,
+                  "line": 175,
                   "column": 8
                 },
                 "end": {
-                  "line": 213,
+                  "line": 178,
                   "column": 9
                 }
               },
@@ -10890,62 +10853,11 @@
               "privacy": "public",
               "sourceRange": {
                 "start": {
-                  "line": 215,
+                  "line": 180,
                   "column": 8
                 },
                 "end": {
-                  "line": 223,
-                  "column": 9
-                }
-              },
-              "metadata": {},
-              "params": []
-            },
-            {
-              "name": "_getClosestCellContent",
-              "description": "",
-              "privacy": "protected",
-              "sourceRange": {
-                "start": {
-                  "line": 225,
-                  "column": 8
-                },
-                "end": {
-                  "line": 237,
-                  "column": 9
-                }
-              },
-              "metadata": {},
-              "params": []
-            },
-            {
-              "name": "_onCellContentFocusin",
-              "description": "",
-              "privacy": "protected",
-              "sourceRange": {
-                "start": {
-                  "line": 239,
-                  "column": 8
-                },
-                "end": {
-                  "line": 241,
-                  "column": 9
-                }
-              },
-              "metadata": {},
-              "params": []
-            },
-            {
-              "name": "_onCellContentFocusout",
-              "description": "",
-              "privacy": "protected",
-              "sourceRange": {
-                "start": {
-                  "line": 243,
-                  "column": 8
-                },
-                "end": {
-                  "line": 245,
+                  "line": 183,
                   "column": 9
                 }
               },
@@ -10958,11 +10870,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 247,
+                  "line": 185,
                   "column": 8
                 },
                 "end": {
-                  "line": 255,
+                  "line": 193,
                   "column": 9
                 }
               },
@@ -10985,11 +10897,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 257,
+                  "line": 195,
                   "column": 8
                 },
                 "end": {
-                  "line": 259,
+                  "line": 197,
                   "column": 9
                 }
               },
@@ -11006,11 +10918,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 261,
+                  "line": 199,
                   "column": 8
                 },
                 "end": {
-                  "line": 276,
+                  "line": 214,
                   "column": 9
                 }
               },
@@ -11022,40 +10934,16 @@
               ]
             },
             {
-              "name": "_getAriaLabel",
-              "description": "",
-              "privacy": "protected",
-              "sourceRange": {
-                "start": {
-                  "line": 278,
-                  "column": 8
-                },
-                "end": {
-                  "line": 287,
-                  "column": 9
-                }
-              },
-              "metadata": {},
-              "params": [
-                {
-                  "name": "direction"
-                },
-                {
-                  "name": "order"
-                }
-              ]
-            },
-            {
               "name": "_directionOrOrderChanged",
               "description": "",
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 289,
+                  "line": 216,
                   "column": 8
                 },
                 "end": {
-                  "line": 313,
+                  "line": 230,
                   "column": 9
                 }
               },
@@ -11066,27 +10954,6 @@
                 },
                 {
                   "name": "order"
-                }
-              ]
-            },
-            {
-              "name": "_cellHasFocusChanged",
-              "description": "",
-              "privacy": "protected",
-              "sourceRange": {
-                "start": {
-                  "line": 315,
-                  "column": 8
-                },
-                "end": {
-                  "line": 328,
-                  "column": 9
-                }
-              },
-              "metadata": {},
-              "params": [
-                {
-                  "name": "cellHasFocus"
                 }
               ]
             }
@@ -11096,11 +10963,11 @@
           "metadata": {},
           "sourceRange": {
             "start": {
-              "line": 137,
+              "line": 127,
               "column": 6
             },
             "end": {
-              "line": 329,
+              "line": 231,
               "column": 7
             }
           },
@@ -11113,11 +10980,11 @@
               "description": "JS Path of the property in the item used for sorting the data.",
               "sourceRange": {
                 "start": {
-                  "line": 147,
+                  "line": 137,
                   "column": 12
                 },
                 "end": {
-                  "line": 147,
+                  "line": 137,
                   "column": 24
                 }
               },
@@ -11129,11 +10996,11 @@
               "description": "How to sort the data.\nPossible values are `asc` to use an ascending algorithm, `desc` to sort the data in\ndescending direction, or `null` for not sorting the data.",
               "sourceRange": {
                 "start": {
-                  "line": 154,
+                  "line": 144,
                   "column": 12
                 },
                 "end": {
-                  "line": 159,
+                  "line": 149,
                   "column": 13
                 }
               },
@@ -11160,11 +11027,11 @@
               "range": {
                 "file": "vaadin-grid-sorter.html",
                 "start": {
-                  "line": 93,
+                  "line": 86,
                   "column": 6
                 },
                 "end": {
-                  "line": 93,
+                  "line": 86,
                   "column": 19
                 }
               }
@@ -11173,7 +11040,7 @@
           "tagname": "vaadin-grid-sorter"
         },
         {
-          "description": "`<vaadin-grid>` is a free, high quality data grid / data table Polymer element.\n\n### Quick Start\n\n- Use the [`<vaadin-grid-column>`](#/elements/vaadin-grid-column) element to configure the grid columns.\n\n- Then assign an array to the [`items`](#/elements/vaadin-grid#property-items) property to visualize your data.\n\n#### Example:\n```html\n<vaadin-grid items='[{\"name\": \"John\", \"surname\": \"Lennon\", \"role\": \"singer\"},\n{\"name\": \"Ringo\", \"surname\": \"Starr\", \"role\": \"drums\"}]'>\n  <vaadin-grid-column>\n    <template class=\"header\">Name</template>\n    <template>[[item.name]]</template>\n  </vaadin-grid-column>\n  <vaadin-grid-column>\n    <template class=\"header\">Surname</template>\n    <template>[[item.surname]]</template>\n  </vaadin-grid-column>\n  <vaadin-grid-column>\n    <template class=\"header\">Role</template>\n    <template>[[item.role]]</template>\n  </vaadin-grid-column>\n</vaadin-grid>\n```\n\n- The following helper elements can be used for further customization:\n - [`<vaadin-grid-column-group>`](#/elements/vaadin-grid-column-group)\n - [`<vaadin-grid-filter>`](#/elements/vaadin-grid-filter)\n - [`<vaadin-grid-sorter>`](#/elements/vaadin-grid-sorter)\n - [`<vaadin-grid-selection-column>`](#/elements/vaadin-grid-selection-column)\n\n__Note that the helper elements must be explicitly imported.__\nIf you want to import everything at once you can use the `all-imports.html` bundle.\n\n- A column template can be decorated with one the following class names to specify its purpose\n - \"header\": Marks a header template\n - \"footer\": Marks a footer template\n - \"row-details\": Marks a row details template\n\n- The following built-in template variables can be bound to inside the column templates\n - \"index\": Number representing the row index\n - \"item\" and it's sub-properties: Data object (provided by a data provider / items array)\n - \"selected\": True if the item is selected (can be two-way bound)\n - \"expanded\": True if the item is expanded for row details (can be two-way bound)\n\n### Lazy Loading with Function Data Provider\n\nIn addition to assigning an array to the items property, you can alternatively\nprovide the `<vaadin-grid>` data through the\n[`dataProvider`](#/elements/vaadin-grid#property-dataProvider) function property.\nThe `<vaadin-grid>` calls this function lazily, only when it needs more data\nto be displayed.\n\nSee the [`dataProvider`](#/elements/vaadin-grid#property-dataProvider) in\nthe API reference below for the detailed data provider arguments description,\nand the “Assigning Data” page in the demos.\n\n__Note that when using function data providers, `size` always needs to be\nset manually.__\n\n```javascript\ngrid.size = 200; // The total number of items\ngrid.dataProvider = function(params, callback) {\n  var url = 'https://api.example/data' +\n      '?page=' + params.page +        // the requested page index\n      '&per_page=' + params.pageSize; // number of items on the page\n  var xhr = new XMLHttpRequest();\n  xhr.onload = function() {\n    var response = JSON.parse(xhr.responseText);\n    callback(response.employees);\n  };\n  xhr.open('GET', url, true);\n  xhr.send();\n};\n```\n\n### Styling\n\nThe following shadow DOM parts are available for styling:\n\nPart name | Description\n----------------|----------------\n`row` | Row in the internal table\n`cell` | Cell in the internal table\n`header-cell` | Header cell in the internal table\n`body-cell` | Body cell in the internal table\n`footer-cell` | Footer cell in the internal table\n`details-cell` | Row details cell in the internal table\n`resize-handle` | Handle for resizing the columns\n`reorder-ghost` | Ghost element of the header cell being dragged\n\nThe following state attributes are available for styling:\n\nAttribute    | Description | Part name\n-------------|-------------|------------\n`loading` | Set when the grid is loading data from data provider | :host\n`interacting` | Keyboad navigation in interaction mode | :host\n`navigating` | Keyboad navigation in navigation mode | :host\n`reordering` | Set when the grid's columns are being reordered | :host\n`reorder-status` | Reflects the status of a cell while columns are being reordered | cell\n`frozen` | Frozen cell | cell\n`last-frozen` | Last frozen cell | cell\n`last-column` | Last visible cell on a row | cell\n`selected` | Selected row | row\n`odd` | Odd row | row",
+          "description": "`<vaadin-grid>` is a free, high quality data grid / data table Polymer element.\n\n### Quick Start\n\nUse the [`<vaadin-grid-column>`](#/elements/vaadin-grid-column) element to configure the grid columns.\n\nThen assign an array to the [`items`](#/elements/vaadin-grid#property-items) property to visualize your data.\n\n#### Example:\n```html\n<vaadin-grid items='[{\"name\": \"John\", \"surname\": \"Lennon\", \"role\": \"singer\"},\n{\"name\": \"Ringo\", \"surname\": \"Starr\", \"role\": \"drums\"}]'>\n  <vaadin-grid-column>\n    <template class=\"header\">Name</template>\n    <template>[[item.name]]</template>\n  </vaadin-grid-column>\n  <vaadin-grid-column>\n    <template class=\"header\">Surname</template>\n    <template>[[item.surname]]</template>\n  </vaadin-grid-column>\n  <vaadin-grid-column>\n    <template class=\"header\">Role</template>\n    <template>[[item.role]]</template>\n  </vaadin-grid-column>\n</vaadin-grid>\n```\n\nThe following helper elements can be used for further customization:\n- [`<vaadin-grid-column-group>`](#/elements/vaadin-grid-column-group)\n- [`<vaadin-grid-filter>`](#/elements/vaadin-grid-filter)\n- [`<vaadin-grid-sorter>`](#/elements/vaadin-grid-sorter)\n- [`<vaadin-grid-selection-column>`](#/elements/vaadin-grid-selection-column)\n\n__Note that the helper elements must be explicitly imported.__\nIf you want to import everything at once you can use the `all-imports.html` bundle.\n\nA column template can be decorated with one the following class names to specify its purpose\n- `header`: Marks a header template\n- `footer`: Marks a footer template\n- `row-details`: Marks a row details template\n\nThe following built-in template variables can be bound to inside the column templates:\n- `[[index]]`: Number representing the row index\n- `[[item]]` and it's sub-properties: Data object (provided by a data provider / items array)\n- `{{selected}}`: True if the item is selected (can be two-way bound)\n- `{{detailsOpened}}`: True if the item has row details opened (can be two-way bound)\n\n### Lazy Loading with Function Data Provider\n\nIn addition to assigning an array to the items property, you can alternatively\nprovide the `<vaadin-grid>` data through the\n[`dataProvider`](#/elements/vaadin-grid#property-dataProvider) function property.\nThe `<vaadin-grid>` calls this function lazily, only when it needs more data\nto be displayed.\n\nSee the [`dataProvider`](#/elements/vaadin-grid#property-dataProvider) in\nthe API reference below for the detailed data provider arguments description,\nand the “Assigning Data” page in the demos.\n\n__Note that when using function data providers, `size` always needs to be\nset manually.__\n\n```javascript\ngrid.size = 200; // The total number of items\ngrid.dataProvider = function(params, callback) {\n  var url = 'https://api.example/data' +\n      '?page=' + params.page +        // the requested page index\n      '&per_page=' + params.pageSize; // number of items on the page\n  var xhr = new XMLHttpRequest();\n  xhr.onload = function() {\n    var response = JSON.parse(xhr.responseText);\n    callback(response.employees);\n  };\n  xhr.open('GET', url, true);\n  xhr.send();\n};\n```\n\n### Styling\n\nThe following shadow DOM parts are available for styling:\n\nPart name | Description\n----------------|----------------\n`row` | Row in the internal table\n`cell` | Cell in the internal table\n`header-cell` | Header cell in the internal table\n`body-cell` | Body cell in the internal table\n`footer-cell` | Footer cell in the internal table\n`details-cell` | Row details cell in the internal table\n`resize-handle` | Handle for resizing the columns\n`reorder-ghost` | Ghost element of the header cell being dragged\n\nThe following state attributes are available for styling:\n\nAttribute    | Description | Part name\n-------------|-------------|------------\n`loading` | Set when the grid is loading data from data provider | :host\n`interacting` | Keyboad navigation in interaction mode | :host\n`navigating` | Keyboad navigation in navigation mode | :host\n`reordering` | Set when the grid's columns are being reordered | :host\n`reorder-status` | Reflects the status of a cell while columns are being reordered | cell\n`frozen` | Frozen cell | cell\n`last-frozen` | Last frozen cell | cell\n`last-column` | Last visible cell on a row | cell\n`selected` | Selected row | row\n`odd` | Odd row | row",
           "summary": "",
           "path": "vaadin-grid.html",
           "properties": [
@@ -11492,9 +11359,9 @@
               "inheritedFrom": "Vaadin.Grid.SortMixin"
             },
             {
-              "name": "expandedItems",
+              "name": "detailsOpenedItems",
               "type": "Array",
-              "description": "An array containing references to expanded items.",
+              "description": "An array containing references to items with open row details.",
               "privacy": "public",
               "sourceRange": {
                 "file": "vaadin-grid-row-details-mixin.html",
@@ -11826,11 +11693,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 216,
+                  "line": 215,
                   "column": 10
                 },
                 "end": {
-                  "line": 219,
+                  "line": 218,
                   "column": 11
                 }
               },
@@ -11845,11 +11712,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 221,
+                  "line": 220,
                   "column": 10
                 },
                 "end": {
-                  "line": 226,
+                  "line": 225,
                   "column": 11
                 }
               },
@@ -11864,11 +11731,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 228,
+                  "line": 227,
                   "column": 10
                 },
                 "end": {
-                  "line": 233,
+                  "line": 232,
                   "column": 11
                 }
               },
@@ -11883,11 +11750,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 235,
+                  "line": 234,
                   "column": 10
                 },
                 "end": {
-                  "line": 240,
+                  "line": 239,
                   "column": 11
                 }
               },
@@ -11902,11 +11769,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 242,
+                  "line": 241,
                   "column": 10
                 },
                 "end": {
-                  "line": 247,
+                  "line": 246,
                   "column": 11
                 }
               },
@@ -11914,6 +11781,25 @@
                 "polymer": {}
               },
               "defaultValue": "false"
+            },
+            {
+              "name": "_firefox",
+              "type": "boolean",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "start": {
+                  "line": 248,
+                  "column": 10
+                },
+                "end": {
+                  "line": 253,
+                  "column": 11
+                }
+              },
+              "metadata": {
+                "polymer": {}
+              }
             }
           ],
           "methods": [
@@ -11923,11 +11809,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 510,
+                  "line": 545,
                   "column": 6
                 },
                 "end": {
-                  "line": 518,
+                  "line": 553,
                   "column": 7
                 }
               },
@@ -12014,7 +11900,7 @@
                   "column": 4
                 },
                 "end": {
-                  "line": 133,
+                  "line": 134,
                   "column": 5
                 }
               },
@@ -12036,11 +11922,11 @@
               "sourceRange": {
                 "file": "vaadin-grid-data-provider-mixin.html",
                 "start": {
-                  "line": 135,
+                  "line": 136,
                   "column": 4
                 },
                 "end": {
-                  "line": 137,
+                  "line": 138,
                   "column": 5
                 }
               },
@@ -12055,11 +11941,11 @@
               "sourceRange": {
                 "file": "vaadin-grid-data-provider-mixin.html",
                 "start": {
-                  "line": 139,
+                  "line": 140,
                   "column": 4
                 },
                 "end": {
-                  "line": 141,
+                  "line": 142,
                   "column": 5
                 }
               },
@@ -12074,11 +11960,11 @@
               "sourceRange": {
                 "file": "vaadin-grid-data-provider-mixin.html",
                 "start": {
-                  "line": 143,
+                  "line": 144,
                   "column": 4
                 },
                 "end": {
-                  "line": 155,
+                  "line": 156,
                   "column": 5
                 }
               },
@@ -12093,11 +11979,11 @@
               "sourceRange": {
                 "file": "vaadin-grid-data-provider-mixin.html",
                 "start": {
-                  "line": 157,
+                  "line": 158,
                   "column": 4
                 },
                 "end": {
-                  "line": 174,
+                  "line": 175,
                   "column": 5
                 }
               },
@@ -12112,11 +11998,11 @@
               "sourceRange": {
                 "file": "vaadin-grid-data-provider-mixin.html",
                 "start": {
-                  "line": 176,
+                  "line": 177,
                   "column": 4
                 },
                 "end": {
-                  "line": 192,
+                  "line": 193,
                   "column": 5
                 }
               },
@@ -12138,11 +12024,11 @@
               "sourceRange": {
                 "file": "vaadin-grid-data-provider-mixin.html",
                 "start": {
-                  "line": 194,
+                  "line": 195,
                   "column": 4
                 },
                 "end": {
-                  "line": 196,
+                  "line": 197,
                   "column": 5
                 }
               },
@@ -12157,11 +12043,11 @@
               "sourceRange": {
                 "file": "vaadin-grid-data-provider-mixin.html",
                 "start": {
-                  "line": 198,
+                  "line": 199,
                   "column": 4
                 },
                 "end": {
-                  "line": 224,
+                  "line": 225,
                   "column": 5
                 }
               },
@@ -12183,11 +12069,11 @@
               "sourceRange": {
                 "file": "vaadin-grid-data-provider-mixin.html",
                 "start": {
-                  "line": 226,
+                  "line": 227,
                   "column": 4
                 },
                 "end": {
-                  "line": 228,
+                  "line": 229,
                   "column": 5
                 }
               },
@@ -12206,11 +12092,11 @@
               "sourceRange": {
                 "file": "vaadin-grid-data-provider-mixin.html",
                 "start": {
-                  "line": 233,
+                  "line": 234,
                   "column": 4
                 },
                 "end": {
-                  "line": 247,
+                  "line": 248,
                   "column": 5
                 }
               },
@@ -12225,11 +12111,11 @@
               "sourceRange": {
                 "file": "vaadin-grid-data-provider-mixin.html",
                 "start": {
-                  "line": 249,
+                  "line": 250,
                   "column": 4
                 },
                 "end": {
-                  "line": 253,
+                  "line": 254,
                   "column": 5
                 }
               },
@@ -12244,11 +12130,11 @@
               "sourceRange": {
                 "file": "vaadin-grid-data-provider-mixin.html",
                 "start": {
-                  "line": 255,
+                  "line": 256,
                   "column": 4
                 },
                 "end": {
-                  "line": 259,
+                  "line": 260,
                   "column": 5
                 }
               },
@@ -12270,11 +12156,11 @@
               "sourceRange": {
                 "file": "vaadin-grid-data-provider-mixin.html",
                 "start": {
-                  "line": 261,
+                  "line": 262,
                   "column": 4
                 },
                 "end": {
-                  "line": 265,
+                  "line": 266,
                   "column": 5
                 }
               },
@@ -12289,11 +12175,11 @@
               "sourceRange": {
                 "file": "vaadin-grid-data-provider-mixin.html",
                 "start": {
-                  "line": 267,
+                  "line": 268,
                   "column": 4
                 },
                 "end": {
-                  "line": 289,
+                  "line": 290,
                   "column": 5
                 }
               },
@@ -12526,7 +12412,7 @@
                   "column": 4
                 },
                 "end": {
-                  "line": 35,
+                  "line": 33,
                   "column": 5
                 }
               },
@@ -12545,11 +12431,11 @@
               "sourceRange": {
                 "file": "vaadin-grid-dynamic-columns-mixin.html",
                 "start": {
-                  "line": 37,
+                  "line": 35,
                   "column": 4
                 },
                 "end": {
-                  "line": 47,
+                  "line": 45,
                   "column": 5
                 }
               },
@@ -12568,11 +12454,11 @@
               "sourceRange": {
                 "file": "vaadin-grid-dynamic-columns-mixin.html",
                 "start": {
-                  "line": 49,
+                  "line": 47,
                   "column": 4
                 },
                 "end": {
-                  "line": 64,
+                  "line": 60,
                   "column": 5
                 }
               },
@@ -12587,11 +12473,11 @@
               "sourceRange": {
                 "file": "vaadin-grid-dynamic-columns-mixin.html",
                 "start": {
-                  "line": 66,
+                  "line": 62,
                   "column": 4
                 },
                 "end": {
-                  "line": 71,
+                  "line": 67,
                   "column": 5
                 }
               },
@@ -12606,11 +12492,11 @@
               "sourceRange": {
                 "file": "vaadin-grid-dynamic-columns-mixin.html",
                 "start": {
-                  "line": 73,
+                  "line": 69,
                   "column": 4
                 },
                 "end": {
-                  "line": 95,
+                  "line": 88,
                   "column": 5
                 }
               },
@@ -12625,11 +12511,11 @@
               "sourceRange": {
                 "file": "vaadin-grid-dynamic-columns-mixin.html",
                 "start": {
-                  "line": 97,
+                  "line": 90,
                   "column": 4
                 },
                 "end": {
-                  "line": 114,
+                  "line": 107,
                   "column": 5
                 }
               },
@@ -12651,11 +12537,11 @@
               "sourceRange": {
                 "file": "vaadin-grid-dynamic-columns-mixin.html",
                 "start": {
-                  "line": 116,
+                  "line": 109,
                   "column": 4
                 },
                 "end": {
-                  "line": 128,
+                  "line": 121,
                   "column": 5
                 }
               },
@@ -12670,16 +12556,39 @@
               "sourceRange": {
                 "file": "vaadin-grid-dynamic-columns-mixin.html",
                 "start": {
-                  "line": 130,
+                  "line": 123,
                   "column": 4
                 },
                 "end": {
-                  "line": 139,
+                  "line": 132,
                   "column": 5
                 }
               },
               "metadata": {},
               "params": [],
+              "inheritedFrom": "Vaadin.Grid.DynamicColumnsMixin"
+            },
+            {
+              "name": "_isColumnElement",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "vaadin-grid-dynamic-columns-mixin.html",
+                "start": {
+                  "line": 134,
+                  "column": 4
+                },
+                "end": {
+                  "line": 136,
+                  "column": 5
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "node"
+                }
+              ],
               "inheritedFrom": "Vaadin.Grid.DynamicColumnsMixin"
             },
             {
@@ -12862,7 +12771,7 @@
                   "column": 4
                 },
                 "end": {
-                  "line": 148,
+                  "line": 155,
                   "column": 5
                 }
               },
@@ -12881,11 +12790,11 @@
               "sourceRange": {
                 "file": "vaadin-grid-scroll-mixin.html",
                 "start": {
-                  "line": 151,
+                  "line": 158,
                   "column": 4
                 },
                 "end": {
-                  "line": 177,
+                  "line": 184,
                   "column": 5
                 }
               },
@@ -12900,11 +12809,11 @@
               "sourceRange": {
                 "file": "vaadin-grid-scroll-mixin.html",
                 "start": {
-                  "line": 179,
+                  "line": 186,
                   "column": 4
                 },
                 "end": {
-                  "line": 190,
+                  "line": 197,
                   "column": 5
                 }
               },
@@ -12919,11 +12828,11 @@
               "sourceRange": {
                 "file": "vaadin-grid-scroll-mixin.html",
                 "start": {
-                  "line": 192,
+                  "line": 199,
                   "column": 4
                 },
                 "end": {
-                  "line": 208,
+                  "line": 215,
                   "column": 5
                 }
               },
@@ -12938,11 +12847,11 @@
               "sourceRange": {
                 "file": "vaadin-grid-scroll-mixin.html",
                 "start": {
-                  "line": 210,
+                  "line": 217,
                   "column": 4
                 },
                 "end": {
-                  "line": 226,
+                  "line": 233,
                   "column": 5
                 }
               },
@@ -12957,11 +12866,11 @@
               "sourceRange": {
                 "file": "vaadin-grid-scroll-mixin.html",
                 "start": {
-                  "line": 228,
+                  "line": 235,
                   "column": 4
                 },
                 "end": {
-                  "line": 230,
+                  "line": 237,
                   "column": 5
                 }
               },
@@ -12983,11 +12892,11 @@
               "sourceRange": {
                 "file": "vaadin-grid-scroll-mixin.html",
                 "start": {
-                  "line": 232,
+                  "line": 239,
                   "column": 4
                 },
                 "end": {
-                  "line": 234,
+                  "line": 241,
                   "column": 5
                 }
               },
@@ -13000,40 +12909,17 @@
               "inheritedFrom": "Vaadin.Grid.ScrollMixin"
             },
             {
-              "name": "_templateInstanceChangedSelection",
-              "description": "",
-              "privacy": "protected",
-              "sourceRange": {
-                "file": "vaadin-grid-selection-mixin.html",
-                "start": {
-                  "line": 39,
-                  "column": 4
-                },
-                "end": {
-                  "line": 55,
-                  "column": 5
-                }
-              },
-              "metadata": {},
-              "params": [
-                {
-                  "name": "e"
-                }
-              ],
-              "inheritedFrom": "Vaadin.Grid.SelectionMixin"
-            },
-            {
               "name": "_isSelected",
               "description": "",
               "privacy": "protected",
               "sourceRange": {
                 "file": "vaadin-grid-selection-mixin.html",
                 "start": {
-                  "line": 57,
+                  "line": 34,
                   "column": 4
                 },
                 "end": {
-                  "line": 59,
+                  "line": 36,
                   "column": 5
                 }
               },
@@ -13052,11 +12938,11 @@
               "sourceRange": {
                 "file": "vaadin-grid-selection-mixin.html",
                 "start": {
-                  "line": 67,
+                  "line": 44,
                   "column": 4
                 },
                 "end": {
-                  "line": 72,
+                  "line": 49,
                   "column": 5
                 }
               },
@@ -13077,11 +12963,11 @@
               "sourceRange": {
                 "file": "vaadin-grid-selection-mixin.html",
                 "start": {
-                  "line": 80,
+                  "line": 57,
                   "column": 4
                 },
                 "end": {
-                  "line": 86,
+                  "line": 63,
                   "column": 5
                 }
               },
@@ -13102,11 +12988,11 @@
               "sourceRange": {
                 "file": "vaadin-grid-selection-mixin.html",
                 "start": {
-                  "line": 94,
+                  "line": 71,
                   "column": 4
                 },
                 "end": {
-                  "line": 102,
+                  "line": 79,
                   "column": 5
                 }
               },
@@ -13127,11 +13013,11 @@
               "sourceRange": {
                 "file": "vaadin-grid-selection-mixin.html",
                 "start": {
-                  "line": 109,
+                  "line": 86,
                   "column": 4
                 },
                 "end": {
-                  "line": 114,
+                  "line": 91,
                   "column": 5
                 }
               },
@@ -13152,11 +13038,11 @@
               "sourceRange": {
                 "file": "vaadin-grid-selection-mixin.html",
                 "start": {
-                  "line": 116,
+                  "line": 93,
                   "column": 4
                 },
                 "end": {
-                  "line": 128,
+                  "line": 99,
                   "column": 5
                 }
               },
@@ -13175,11 +13061,11 @@
               "sourceRange": {
                 "file": "vaadin-grid-selection-mixin.html",
                 "start": {
-                  "line": 130,
+                  "line": 101,
                   "column": 4
                 },
                 "end": {
-                  "line": 139,
+                  "line": 110,
                   "column": 5
                 }
               },
@@ -13205,7 +13091,7 @@
                   "column": 4
                 },
                 "end": {
-                  "line": 93,
+                  "line": 95,
                   "column": 5
                 }
               },
@@ -13224,11 +13110,11 @@
               "sourceRange": {
                 "file": "vaadin-grid-sort-mixin.html",
                 "start": {
-                  "line": 95,
+                  "line": 97,
                   "column": 4
                 },
                 "end": {
-                  "line": 102,
+                  "line": 104,
                   "column": 5
                 }
               },
@@ -13243,11 +13129,11 @@
               "sourceRange": {
                 "file": "vaadin-grid-sort-mixin.html",
                 "start": {
-                  "line": 104,
+                  "line": 106,
                   "column": 4
                 },
                 "end": {
-                  "line": 109,
+                  "line": 111,
                   "column": 5
                 }
               },
@@ -13263,7 +13149,7 @@
               "inheritedFrom": "Vaadin.Grid.SortMixin"
             },
             {
-              "name": "_expandedItemsChanged",
+              "name": "_detailsOpenedItemsChanged",
               "description": "",
               "privacy": "protected",
               "sourceRange": {
@@ -13363,7 +13249,7 @@
               "inheritedFrom": "Vaadin.Grid.RowDetailsMixin"
             },
             {
-              "name": "_isExpanded",
+              "name": "_isDetailsOpened",
               "description": "",
               "privacy": "protected",
               "sourceRange": {
@@ -13386,8 +13272,8 @@
               "inheritedFrom": "Vaadin.Grid.RowDetailsMixin"
             },
             {
-              "name": "expandItem",
-              "description": "Expand the details row of a given item.",
+              "name": "openItemDetails",
+              "description": "Open the details row of a given item.",
               "privacy": "public",
               "sourceRange": {
                 "file": "vaadin-grid-row-details-mixin.html",
@@ -13409,8 +13295,8 @@
               "inheritedFrom": "Vaadin.Grid.RowDetailsMixin"
             },
             {
-              "name": "collapseItem",
-              "description": "Collapse the details row of a given item.",
+              "name": "closeItemDetails",
+              "description": "Close the details row of a given item.",
               "privacy": "public",
               "sourceRange": {
                 "file": "vaadin-grid-row-details-mixin.html",
@@ -13432,7 +13318,7 @@
               "inheritedFrom": "Vaadin.Grid.RowDetailsMixin"
             },
             {
-              "name": "_expandedInstanceChangedCallback",
+              "name": "_detailsOpenedInstanceChangedCallback",
               "description": "",
               "privacy": "protected",
               "sourceRange": {
@@ -13540,7 +13426,7 @@
                   "column": 4
                 },
                 "end": {
-                  "line": 295,
+                  "line": 309,
                   "column": 5
                 }
               },
@@ -13562,11 +13448,11 @@
               "sourceRange": {
                 "file": "vaadin-grid-keyboard-navigation-mixin.html",
                 "start": {
-                  "line": 297,
+                  "line": 311,
                   "column": 4
                 },
                 "end": {
-                  "line": 304,
+                  "line": 318,
                   "column": 5
                 }
               },
@@ -13585,11 +13471,11 @@
               "sourceRange": {
                 "file": "vaadin-grid-keyboard-navigation-mixin.html",
                 "start": {
-                  "line": 306,
+                  "line": 320,
                   "column": 4
                 },
                 "end": {
-                  "line": 344,
+                  "line": 358,
                   "column": 5
                 }
               },
@@ -13611,11 +13497,11 @@
               "sourceRange": {
                 "file": "vaadin-grid-keyboard-navigation-mixin.html",
                 "start": {
-                  "line": 346,
+                  "line": 360,
                   "column": 4
                 },
                 "end": {
-                  "line": 363,
+                  "line": 378,
                   "column": 5
                 }
               },
@@ -13637,11 +13523,11 @@
               "sourceRange": {
                 "file": "vaadin-grid-keyboard-navigation-mixin.html",
                 "start": {
-                  "line": 365,
+                  "line": 380,
                   "column": 4
                 },
                 "end": {
-                  "line": 392,
+                  "line": 412,
                   "column": 5
                 }
               },
@@ -13660,11 +13546,11 @@
               "sourceRange": {
                 "file": "vaadin-grid-keyboard-navigation-mixin.html",
                 "start": {
-                  "line": 394,
+                  "line": 414,
                   "column": 4
                 },
                 "end": {
-                  "line": 405,
+                  "line": 425,
                   "column": 5
                 }
               },
@@ -13683,11 +13569,11 @@
               "sourceRange": {
                 "file": "vaadin-grid-keyboard-navigation-mixin.html",
                 "start": {
-                  "line": 407,
+                  "line": 427,
                   "column": 4
                 },
                 "end": {
-                  "line": 420,
+                  "line": 447,
                   "column": 5
                 }
               },
@@ -13706,11 +13592,11 @@
               "sourceRange": {
                 "file": "vaadin-grid-keyboard-navigation-mixin.html",
                 "start": {
-                  "line": 422,
+                  "line": 449,
                   "column": 4
                 },
                 "end": {
-                  "line": 425,
+                  "line": 452,
                   "column": 5
                 }
               },
@@ -13729,11 +13615,11 @@
               "sourceRange": {
                 "file": "vaadin-grid-keyboard-navigation-mixin.html",
                 "start": {
-                  "line": 427,
+                  "line": 454,
                   "column": 4
                 },
                 "end": {
-                  "line": 445,
+                  "line": 472,
                   "column": 5
                 }
               },
@@ -13752,34 +13638,11 @@
               "sourceRange": {
                 "file": "vaadin-grid-keyboard-navigation-mixin.html",
                 "start": {
-                  "line": 447,
+                  "line": 474,
                   "column": 4
                 },
                 "end": {
-                  "line": 453,
-                  "column": 5
-                }
-              },
-              "metadata": {},
-              "params": [
-                {
-                  "name": "e"
-                }
-              ],
-              "inheritedFrom": "Vaadin.Grid.KeyboardNavigationMixin"
-            },
-            {
-              "name": "_onMouseCellFocus",
-              "description": "Mouse click focuses the cell",
-              "privacy": "protected",
-              "sourceRange": {
-                "file": "vaadin-grid-keyboard-navigation-mixin.html",
-                "start": {
-                  "line": 458,
-                  "column": 4
-                },
-                "end": {
-                  "line": 477,
+                  "line": 480,
                   "column": 5
                 }
               },
@@ -13798,11 +13661,11 @@
               "sourceRange": {
                 "file": "vaadin-grid-keyboard-navigation-mixin.html",
                 "start": {
-                  "line": 479,
+                  "line": 482,
                   "column": 4
                 },
                 "end": {
-                  "line": 481,
+                  "line": 484,
                   "column": 5
                 }
               },
@@ -13821,11 +13684,11 @@
               "sourceRange": {
                 "file": "vaadin-grid-keyboard-navigation-mixin.html",
                 "start": {
-                  "line": 483,
+                  "line": 486,
                   "column": 4
                 },
                 "end": {
-                  "line": 488,
+                  "line": 491,
                   "column": 5
                 }
               },
@@ -13844,11 +13707,11 @@
               "sourceRange": {
                 "file": "vaadin-grid-keyboard-navigation-mixin.html",
                 "start": {
-                  "line": 490,
+                  "line": 493,
                   "column": 4
                 },
                 "end": {
-                  "line": 501,
+                  "line": 504,
                   "column": 5
                 }
               },
@@ -13870,11 +13733,11 @@
               "sourceRange": {
                 "file": "vaadin-grid-keyboard-navigation-mixin.html",
                 "start": {
-                  "line": 503,
+                  "line": 506,
                   "column": 4
                 },
                 "end": {
-                  "line": 511,
+                  "line": 514,
                   "column": 5
                 }
               },
@@ -13896,11 +13759,11 @@
               "sourceRange": {
                 "file": "vaadin-grid-keyboard-navigation-mixin.html",
                 "start": {
-                  "line": 513,
+                  "line": 516,
                   "column": 4
                 },
                 "end": {
-                  "line": 529,
+                  "line": 535,
                   "column": 5
                 }
               },
@@ -13915,11 +13778,11 @@
               "sourceRange": {
                 "file": "vaadin-grid-keyboard-navigation-mixin.html",
                 "start": {
-                  "line": 531,
+                  "line": 537,
                   "column": 4
                 },
                 "end": {
-                  "line": 571,
+                  "line": 577,
                   "column": 5
                 }
               },
@@ -13938,11 +13801,11 @@
               "sourceRange": {
                 "file": "vaadin-grid-keyboard-navigation-mixin.html",
                 "start": {
-                  "line": 573,
+                  "line": 579,
                   "column": 4
                 },
                 "end": {
-                  "line": 577,
+                  "line": 583,
                   "column": 5
                 }
               },
@@ -14098,7 +13961,7 @@
                   "column": 4
                 },
                 "end": {
-                  "line": 103,
+                  "line": 117,
                   "column": 5
                 }
               },
@@ -14117,11 +13980,11 @@
               "sourceRange": {
                 "file": "vaadin-grid-column-reordering-mixin.html",
                 "start": {
-                  "line": 105,
+                  "line": 119,
                   "column": 4
                 },
                 "end": {
-                  "line": 130,
+                  "line": 144,
                   "column": 5
                 }
               },
@@ -14140,11 +14003,11 @@
               "sourceRange": {
                 "file": "vaadin-grid-column-reordering-mixin.html",
                 "start": {
-                  "line": 132,
+                  "line": 146,
                   "column": 4
                 },
                 "end": {
-                  "line": 151,
+                  "line": 165,
                   "column": 5
                 }
               },
@@ -14163,11 +14026,11 @@
               "sourceRange": {
                 "file": "vaadin-grid-column-reordering-mixin.html",
                 "start": {
-                  "line": 153,
+                  "line": 167,
                   "column": 4
                 },
                 "end": {
-                  "line": 165,
+                  "line": 179,
                   "column": 5
                 }
               },
@@ -14182,11 +14045,11 @@
               "sourceRange": {
                 "file": "vaadin-grid-column-reordering-mixin.html",
                 "start": {
-                  "line": 167,
+                  "line": 181,
                   "column": 4
                 },
                 "end": {
-                  "line": 185,
+                  "line": 199,
                   "column": 5
                 }
               },
@@ -14208,11 +14071,11 @@
               "sourceRange": {
                 "file": "vaadin-grid-column-reordering-mixin.html",
                 "start": {
-                  "line": 187,
+                  "line": 201,
                   "column": 4
                 },
                 "end": {
-                  "line": 199,
+                  "line": 213,
                   "column": 5
                 }
               },
@@ -14234,11 +14097,11 @@
               "sourceRange": {
                 "file": "vaadin-grid-column-reordering-mixin.html",
                 "start": {
-                  "line": 201,
+                  "line": 215,
                   "column": 4
                 },
                 "end": {
-                  "line": 217,
+                  "line": 223,
                   "column": 5
                 }
               },
@@ -14257,11 +14120,11 @@
               "sourceRange": {
                 "file": "vaadin-grid-column-reordering-mixin.html",
                 "start": {
-                  "line": 219,
+                  "line": 225,
                   "column": 4
                 },
                 "end": {
-                  "line": 226,
+                  "line": 232,
                   "column": 5
                 }
               },
@@ -14283,11 +14146,11 @@
               "sourceRange": {
                 "file": "vaadin-grid-column-reordering-mixin.html",
                 "start": {
-                  "line": 228,
+                  "line": 234,
                   "column": 4
                 },
                 "end": {
-                  "line": 232,
+                  "line": 238,
                   "column": 5
                 }
               },
@@ -14309,11 +14172,11 @@
               "sourceRange": {
                 "file": "vaadin-grid-column-reordering-mixin.html",
                 "start": {
-                  "line": 234,
+                  "line": 240,
                   "column": 4
                 },
                 "end": {
-                  "line": 250,
+                  "line": 256,
                   "column": 5
                 }
               },
@@ -14328,11 +14191,11 @@
               "sourceRange": {
                 "file": "vaadin-grid-column-reordering-mixin.html",
                 "start": {
-                  "line": 252,
+                  "line": 258,
                   "column": 4
                 },
                 "end": {
-                  "line": 259,
+                  "line": 265,
                   "column": 5
                 }
               },
@@ -14354,11 +14217,11 @@
               "sourceRange": {
                 "file": "vaadin-grid-column-reordering-mixin.html",
                 "start": {
-                  "line": 261,
+                  "line": 267,
                   "column": 4
                 },
                 "end": {
-                  "line": 271,
+                  "line": 277,
                   "column": 5
                 }
               },
@@ -14380,11 +14243,11 @@
               "sourceRange": {
                 "file": "vaadin-grid-column-reordering-mixin.html",
                 "start": {
-                  "line": 273,
+                  "line": 279,
                   "column": 4
                 },
                 "end": {
-                  "line": 279,
+                  "line": 285,
                   "column": 5
                 }
               },
@@ -14406,11 +14269,11 @@
               "sourceRange": {
                 "file": "vaadin-grid-column-reordering-mixin.html",
                 "start": {
-                  "line": 281,
+                  "line": 287,
                   "column": 4
                 },
                 "end": {
-                  "line": 293,
+                  "line": 299,
                   "column": 5
                 }
               },
@@ -14454,11 +14317,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 256,
+                  "line": 262,
                   "column": 6
                 },
                 "end": {
-                  "line": 277,
+                  "line": 283,
                   "column": 7
                 }
               },
@@ -14475,11 +14338,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 279,
+                  "line": 285,
                   "column": 6
                 },
                 "end": {
-                  "line": 281,
+                  "line": 287,
                   "column": 7
                 }
               },
@@ -14492,11 +14355,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 283,
+                  "line": 289,
                   "column": 6
                 },
                 "end": {
-                  "line": 315,
+                  "line": 334,
                   "column": 7
                 }
               },
@@ -14513,11 +14376,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 317,
+                  "line": 336,
                   "column": 6
                 },
                 "end": {
-                  "line": 397,
+                  "line": 412,
                   "column": 7
                 }
               },
@@ -14546,11 +14409,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 399,
+                  "line": 414,
                   "column": 6
                 },
                 "end": {
-                  "line": 413,
+                  "line": 429,
                   "column": 7
                 }
               },
@@ -14570,11 +14433,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 415,
+                  "line": 431,
                   "column": 6
                 },
                 "end": {
-                  "line": 448,
+                  "line": 466,
                   "column": 7
                 }
               },
@@ -14594,11 +14457,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 450,
+                  "line": 468,
                   "column": 6
                 },
                 "end": {
-                  "line": 471,
+                  "line": 485,
                   "column": 7
                 }
               },
@@ -14613,16 +14476,64 @@
               ]
             },
             {
+              "name": "_toggleRowDetailsOpened",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "start": {
+                  "line": 487,
+                  "column": 6
+                },
+                "end": {
+                  "line": 495,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "row"
+                },
+                {
+                  "name": "detailsOpened"
+                }
+              ]
+            },
+            {
+              "name": "_toggleRowSelected",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "start": {
+                  "line": 497,
+                  "column": 6
+                },
+                "end": {
+                  "line": 506,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "row"
+                },
+                {
+                  "name": "selected"
+                }
+              ]
+            },
+            {
               "name": "_resizeHandler",
               "description": "",
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 473,
+                  "line": 508,
                   "column": 6
                 },
                 "end": {
-                  "line": 477,
+                  "line": 512,
                   "column": 7
                 }
               },
@@ -14635,11 +14546,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 479,
+                  "line": 514,
                   "column": 6
                 },
                 "end": {
-                  "line": 492,
+                  "line": 527,
                   "column": 7
                 }
               },
@@ -14652,11 +14563,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 494,
+                  "line": 529,
                   "column": 6
                 },
                 "end": {
-                  "line": 500,
+                  "line": 535,
                   "column": 7
                 }
               },
@@ -14673,11 +14584,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 502,
+                  "line": 537,
                   "column": 6
                 },
                 "end": {
-                  "line": 508,
+                  "line": 543,
                   "column": 7
                 }
               },
@@ -14729,11 +14640,11 @@
           "metadata": {},
           "sourceRange": {
             "start": {
-              "line": 186,
+              "line": 184,
               "column": 4
             },
             "end": {
-              "line": 520,
+              "line": 555,
               "column": 5
             }
           },
@@ -14850,8 +14761,8 @@
               "inheritedFrom": "Vaadin.Grid.SortMixin"
             },
             {
-              "name": "expanded-items",
-              "description": "An array containing references to expanded items.",
+              "name": "details-opened-items",
+              "description": "An array containing references to items with open row details.",
               "sourceRange": {
                 "file": "vaadin-grid-row-details-mixin.html",
                 "start": {
@@ -14934,11 +14845,11 @@
               "range": {
                 "file": "vaadin-grid.html",
                 "start": {
-                  "line": 47,
+                  "line": 49,
                   "column": 4
                 },
                 "end": {
-                  "line": 47,
+                  "line": 49,
                   "column": 37
                 }
               }
@@ -16373,17 +16284,36 @@
           }
         },
         {
-          "name": "_touchDevice",
+          "name": "noScrollbars",
           "type": "boolean",
           "description": "",
-          "privacy": "protected",
+          "privacy": "public",
           "sourceRange": {
             "start": {
               "line": 63,
               "column": 10
             },
             "end": {
-              "line": 73,
+              "line": 63,
+              "column": 31
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          }
+        },
+        {
+          "name": "_touchDevice",
+          "type": "boolean",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 65,
+              "column": 10
+            },
+            "end": {
+              "line": 75,
               "column": 11
             }
           },
@@ -17054,11 +16984,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 77,
+              "line": 79,
               "column": 6
             },
             "end": {
-              "line": 91,
+              "line": 93,
               "column": 7
             }
           },
@@ -18298,11 +18228,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 93,
+              "line": 95,
               "column": 6
             },
             "end": {
-              "line": 98,
+              "line": 104,
               "column": 7
             }
           },
@@ -18319,11 +18249,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 100,
+              "line": 106,
               "column": 6
             },
             "end": {
-              "line": 107,
+              "line": 113,
               "column": 7
             }
           },
@@ -18336,11 +18266,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 109,
+              "line": 115,
               "column": 6
             },
             "end": {
-              "line": 117,
+              "line": 123,
               "column": 7
             }
           },
@@ -19052,7 +18982,7 @@
           "column": 4
         },
         "end": {
-          "line": 119,
+          "line": 125,
           "column": 5
         }
       },
@@ -19119,6 +19049,22 @@
             "end": {
               "line": 61,
               "column": 33
+            }
+          },
+          "metadata": {},
+          "type": "boolean"
+        },
+        {
+          "name": "no-scrollbars",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 63,
+              "column": 10
+            },
+            "end": {
+              "line": 63,
+              "column": 31
             }
           },
           "metadata": {},
@@ -19990,7 +19936,7 @@
               "column": 4
             },
             "end": {
-              "line": 35,
+              "line": 33,
               "column": 5
             }
           },
@@ -20007,11 +19953,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 37,
+              "line": 35,
               "column": 4
             },
             "end": {
-              "line": 47,
+              "line": 45,
               "column": 5
             }
           },
@@ -20028,11 +19974,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 49,
+              "line": 47,
               "column": 4
             },
             "end": {
-              "line": 64,
+              "line": 60,
               "column": 5
             }
           },
@@ -20045,11 +19991,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 66,
+              "line": 62,
               "column": 4
             },
             "end": {
-              "line": 71,
+              "line": 67,
               "column": 5
             }
           },
@@ -20062,11 +20008,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 73,
+              "line": 69,
               "column": 4
             },
             "end": {
-              "line": 95,
+              "line": 88,
               "column": 5
             }
           },
@@ -20079,11 +20025,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 97,
+              "line": 90,
               "column": 4
             },
             "end": {
-              "line": 114,
+              "line": 107,
               "column": 5
             }
           },
@@ -20103,11 +20049,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 116,
+              "line": 109,
               "column": 4
             },
             "end": {
-              "line": 128,
+              "line": 121,
               "column": 5
             }
           },
@@ -20120,16 +20066,37 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 130,
+              "line": 123,
               "column": 4
             },
             "end": {
-              "line": 139,
+              "line": 132,
               "column": 5
             }
           },
           "metadata": {},
           "params": []
+        },
+        {
+          "name": "_isColumnElement",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 134,
+              "column": 4
+            },
+            "end": {
+              "line": 136,
+              "column": 5
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "node"
+            }
+          ]
         }
       ],
       "staticMethods": [],
@@ -20141,7 +20108,7 @@
           "column": 2
         },
         "end": {
-          "line": 140,
+          "line": 137,
           "column": 3
         }
       },
@@ -20357,7 +20324,7 @@
               "column": 4
             },
             "end": {
-              "line": 133,
+              "line": 134,
               "column": 5
             }
           },
@@ -20377,11 +20344,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 135,
+              "line": 136,
               "column": 4
             },
             "end": {
-              "line": 137,
+              "line": 138,
               "column": 5
             }
           },
@@ -20394,11 +20361,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 139,
+              "line": 140,
               "column": 4
             },
             "end": {
-              "line": 141,
+              "line": 142,
               "column": 5
             }
           },
@@ -20411,11 +20378,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 143,
+              "line": 144,
               "column": 4
             },
             "end": {
-              "line": 155,
+              "line": 156,
               "column": 5
             }
           },
@@ -20428,11 +20395,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 157,
+              "line": 158,
               "column": 4
             },
             "end": {
-              "line": 174,
+              "line": 175,
               "column": 5
             }
           },
@@ -20445,11 +20412,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 176,
+              "line": 177,
               "column": 4
             },
             "end": {
-              "line": 192,
+              "line": 193,
               "column": 5
             }
           },
@@ -20469,11 +20436,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 194,
+              "line": 195,
               "column": 4
             },
             "end": {
-              "line": 196,
+              "line": 197,
               "column": 5
             }
           },
@@ -20486,11 +20453,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 198,
+              "line": 199,
               "column": 4
             },
             "end": {
-              "line": 224,
+              "line": 225,
               "column": 5
             }
           },
@@ -20510,11 +20477,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 226,
+              "line": 227,
               "column": 4
             },
             "end": {
-              "line": 228,
+              "line": 229,
               "column": 5
             }
           },
@@ -20531,11 +20498,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 233,
+              "line": 234,
               "column": 4
             },
             "end": {
-              "line": 247,
+              "line": 248,
               "column": 5
             }
           },
@@ -20548,11 +20515,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 249,
+              "line": 250,
               "column": 4
             },
             "end": {
-              "line": 253,
+              "line": 254,
               "column": 5
             }
           },
@@ -20565,11 +20532,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 255,
+              "line": 256,
               "column": 4
             },
             "end": {
-              "line": 259,
+              "line": 260,
               "column": 5
             }
           },
@@ -20589,11 +20556,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 261,
+              "line": 262,
               "column": 4
             },
             "end": {
-              "line": 265,
+              "line": 266,
               "column": 5
             }
           },
@@ -20606,11 +20573,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 267,
+              "line": 268,
               "column": 4
             },
             "end": {
-              "line": 289,
+              "line": 290,
               "column": 5
             }
           },
@@ -20634,7 +20601,7 @@
           "column": 2
         },
         "end": {
-          "line": 291,
+          "line": 292,
           "column": 3
         }
       },
@@ -21299,7 +21266,7 @@
               "column": 4
             },
             "end": {
-              "line": 148,
+              "line": 155,
               "column": 5
             }
           },
@@ -21316,11 +21283,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 151,
+              "line": 158,
               "column": 4
             },
             "end": {
-              "line": 177,
+              "line": 184,
               "column": 5
             }
           },
@@ -21333,11 +21300,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 179,
+              "line": 186,
               "column": 4
             },
             "end": {
-              "line": 190,
+              "line": 197,
               "column": 5
             }
           },
@@ -21350,11 +21317,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 192,
+              "line": 199,
               "column": 4
             },
             "end": {
-              "line": 208,
+              "line": 215,
               "column": 5
             }
           },
@@ -21367,11 +21334,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 210,
+              "line": 217,
               "column": 4
             },
             "end": {
-              "line": 226,
+              "line": 233,
               "column": 5
             }
           },
@@ -21384,11 +21351,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 228,
+              "line": 235,
               "column": 4
             },
             "end": {
-              "line": 230,
+              "line": 237,
               "column": 5
             }
           },
@@ -21408,11 +21375,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 232,
+              "line": 239,
               "column": 4
             },
             "end": {
-              "line": 234,
+              "line": 241,
               "column": 5
             }
           },
@@ -21433,7 +21400,7 @@
           "column": 2
         },
         "end": {
-          "line": 236,
+          "line": 243,
           "column": 3
         }
       },
@@ -21477,7 +21444,7 @@
       ],
       "methods": [
         {
-          "name": "ready",
+          "name": "_isSelected",
           "description": "",
           "privacy": "protected",
           "sourceRange": {
@@ -21486,45 +21453,7 @@
               "column": 4
             },
             "end": {
-              "line": 37,
-              "column": 5
-            }
-          },
-          "metadata": {},
-          "params": []
-        },
-        {
-          "name": "_templateInstanceChangedSelection",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "start": {
-              "line": 39,
-              "column": 4
-            },
-            "end": {
-              "line": 55,
-              "column": 5
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "e"
-            }
-          ]
-        },
-        {
-          "name": "_isSelected",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "start": {
-              "line": 57,
-              "column": 4
-            },
-            "end": {
-              "line": 59,
+              "line": 36,
               "column": 5
             }
           },
@@ -21541,11 +21470,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 67,
+              "line": 44,
               "column": 4
             },
             "end": {
-              "line": 72,
+              "line": 49,
               "column": 5
             }
           },
@@ -21564,11 +21493,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 80,
+              "line": 57,
               "column": 4
             },
             "end": {
-              "line": 86,
+              "line": 63,
               "column": 5
             }
           },
@@ -21587,11 +21516,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 94,
+              "line": 71,
               "column": 4
             },
             "end": {
-              "line": 102,
+              "line": 79,
               "column": 5
             }
           },
@@ -21610,11 +21539,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 109,
+              "line": 86,
               "column": 4
             },
             "end": {
-              "line": 114,
+              "line": 91,
               "column": 5
             }
           },
@@ -21633,11 +21562,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 116,
+              "line": 93,
               "column": 4
             },
             "end": {
-              "line": 128,
+              "line": 99,
               "column": 5
             }
           },
@@ -21654,11 +21583,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 130,
+              "line": 101,
               "column": 4
             },
             "end": {
-              "line": 139,
+              "line": 110,
               "column": 5
             }
           },
@@ -21682,7 +21611,7 @@
           "column": 2
         },
         "end": {
-          "line": 140,
+          "line": 111,
           "column": 3
         }
       },
@@ -21807,7 +21736,7 @@
               "column": 4
             },
             "end": {
-              "line": 93,
+              "line": 95,
               "column": 5
             }
           },
@@ -21824,11 +21753,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 95,
+              "line": 97,
               "column": 4
             },
             "end": {
-              "line": 102,
+              "line": 104,
               "column": 5
             }
           },
@@ -21841,11 +21770,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 104,
+              "line": 106,
               "column": 4
             },
             "end": {
-              "line": 109,
+              "line": 111,
               "column": 5
             }
           },
@@ -21869,7 +21798,7 @@
           "column": 2
         },
         "end": {
-          "line": 110,
+          "line": 112,
           "column": 3
         }
       },
@@ -21906,9 +21835,9 @@
       "path": "vaadin-grid-row-details-mixin.html",
       "properties": [
         {
-          "name": "expandedItems",
+          "name": "detailsOpenedItems",
           "type": "Array",
-          "description": "An array containing references to expanded items.",
+          "description": "An array containing references to items with open row details.",
           "privacy": "public",
           "sourceRange": {
             "start": {
@@ -21983,7 +21912,7 @@
           "params": []
         },
         {
-          "name": "_expandedItemsChanged",
+          "name": "_detailsOpenedItemsChanged",
           "description": "",
           "privacy": "protected",
           "sourceRange": {
@@ -22075,7 +22004,7 @@
           "params": []
         },
         {
-          "name": "_isExpanded",
+          "name": "_isDetailsOpened",
           "description": "",
           "privacy": "protected",
           "sourceRange": {
@@ -22096,8 +22025,8 @@
           ]
         },
         {
-          "name": "expandItem",
-          "description": "Expand the details row of a given item.",
+          "name": "openItemDetails",
+          "description": "Open the details row of a given item.",
           "privacy": "public",
           "sourceRange": {
             "start": {
@@ -22117,8 +22046,8 @@
           ]
         },
         {
-          "name": "collapseItem",
-          "description": "Collapse the details row of a given item.",
+          "name": "closeItemDetails",
+          "description": "Close the details row of a given item.",
           "privacy": "public",
           "sourceRange": {
             "start": {
@@ -22138,7 +22067,7 @@
           ]
         },
         {
-          "name": "_expandedInstanceChangedCallback",
+          "name": "_detailsOpenedInstanceChangedCallback",
           "description": "",
           "privacy": "protected",
           "sourceRange": {
@@ -22179,8 +22108,8 @@
       "name": "Vaadin.Grid.RowDetailsMixin",
       "attributes": [
         {
-          "name": "expanded-items",
-          "description": "An array containing references to expanded items.",
+          "name": "details-opened-items",
+          "description": "An array containing references to items with open row details.",
           "sourceRange": {
             "start": {
               "line": 21,
@@ -22463,7 +22392,7 @@
               "column": 4
             },
             "end": {
-              "line": 295,
+              "line": 309,
               "column": 5
             }
           },
@@ -22483,11 +22412,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 297,
+              "line": 311,
               "column": 4
             },
             "end": {
-              "line": 304,
+              "line": 318,
               "column": 5
             }
           },
@@ -22504,11 +22433,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 306,
+              "line": 320,
               "column": 4
             },
             "end": {
-              "line": 344,
+              "line": 358,
               "column": 5
             }
           },
@@ -22528,11 +22457,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 346,
+              "line": 360,
               "column": 4
             },
             "end": {
-              "line": 363,
+              "line": 378,
               "column": 5
             }
           },
@@ -22552,11 +22481,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 365,
+              "line": 380,
               "column": 4
             },
             "end": {
-              "line": 392,
+              "line": 412,
               "column": 5
             }
           },
@@ -22573,11 +22502,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 394,
+              "line": 414,
               "column": 4
             },
             "end": {
-              "line": 405,
+              "line": 425,
               "column": 5
             }
           },
@@ -22594,11 +22523,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 407,
+              "line": 427,
               "column": 4
             },
             "end": {
-              "line": 420,
+              "line": 447,
               "column": 5
             }
           },
@@ -22615,11 +22544,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 422,
+              "line": 449,
               "column": 4
             },
             "end": {
-              "line": 425,
+              "line": 452,
               "column": 5
             }
           },
@@ -22636,11 +22565,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 427,
+              "line": 454,
               "column": 4
             },
             "end": {
-              "line": 445,
+              "line": 472,
               "column": 5
             }
           },
@@ -22657,32 +22586,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 447,
+              "line": 474,
               "column": 4
             },
             "end": {
-              "line": 453,
-              "column": 5
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "e"
-            }
-          ]
-        },
-        {
-          "name": "_onMouseCellFocus",
-          "description": "Mouse click focuses the cell",
-          "privacy": "protected",
-          "sourceRange": {
-            "start": {
-              "line": 458,
-              "column": 4
-            },
-            "end": {
-              "line": 477,
+              "line": 480,
               "column": 5
             }
           },
@@ -22699,11 +22607,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 479,
+              "line": 482,
               "column": 4
             },
             "end": {
-              "line": 481,
+              "line": 484,
               "column": 5
             }
           },
@@ -22720,11 +22628,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 483,
+              "line": 486,
               "column": 4
             },
             "end": {
-              "line": 488,
+              "line": 491,
               "column": 5
             }
           },
@@ -22741,11 +22649,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 490,
+              "line": 493,
               "column": 4
             },
             "end": {
-              "line": 501,
+              "line": 504,
               "column": 5
             }
           },
@@ -22765,11 +22673,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 503,
+              "line": 506,
               "column": 4
             },
             "end": {
-              "line": 511,
+              "line": 514,
               "column": 5
             }
           },
@@ -22789,11 +22697,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 513,
+              "line": 516,
               "column": 4
             },
             "end": {
-              "line": 529,
+              "line": 535,
               "column": 5
             }
           },
@@ -22806,11 +22714,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 531,
+              "line": 537,
               "column": 4
             },
             "end": {
-              "line": 571,
+              "line": 577,
               "column": 5
             }
           },
@@ -22827,11 +22735,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 573,
+              "line": 579,
               "column": 4
             },
             "end": {
-              "line": 577,
+              "line": 583,
               "column": 5
             }
           },
@@ -22855,7 +22763,7 @@
           "column": 2
         },
         "end": {
-          "line": 578,
+          "line": 584,
           "column": 3
         }
       },
@@ -22895,6 +22803,273 @@
           "type": "boolean"
         }
       ],
+      "events": [],
+      "styling": {
+        "cssVariables": [],
+        "selectors": []
+      },
+      "slots": []
+    },
+    {
+      "description": "",
+      "summary": "",
+      "path": "vaadin-grid-a11y-mixin.html",
+      "properties": [],
+      "methods": [
+        {
+          "name": "_a11yGetHeaderRowCount",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 20,
+              "column": 4
+            },
+            "end": {
+              "line": 22,
+              "column": 5
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "_columnTree"
+            }
+          ]
+        },
+        {
+          "name": "_a11yGetFooterRowCount",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 24,
+              "column": 4
+            },
+            "end": {
+              "line": 26,
+              "column": 5
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "_columnTree"
+            }
+          ]
+        },
+        {
+          "name": "_a11yUpdateGridSize",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 28,
+              "column": 4
+            },
+            "end": {
+              "line": 40,
+              "column": 5
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "size"
+            },
+            {
+              "name": "_columnTree"
+            }
+          ]
+        },
+        {
+          "name": "_a11yUpdateHeaderRows",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 42,
+              "column": 4
+            },
+            "end": {
+              "line": 46,
+              "column": 5
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "_a11yUpdateFooterRows",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 48,
+              "column": 4
+            },
+            "end": {
+              "line": 55,
+              "column": 5
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "_a11yUpdateRowRowindex",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 57,
+              "column": 4
+            },
+            "end": {
+              "line": 59,
+              "column": 5
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "row"
+            },
+            {
+              "name": "index"
+            }
+          ]
+        },
+        {
+          "name": "_a11yUpdateRowSelected",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 61,
+              "column": 4
+            },
+            "end": {
+              "line": 67,
+              "column": 5
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "row"
+            },
+            {
+              "name": "selected"
+            }
+          ]
+        },
+        {
+          "name": "_a11yUpdateRowDetailsOpened",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 69,
+              "column": 4
+            },
+            "end": {
+              "line": 79,
+              "column": 5
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "row"
+            },
+            {
+              "name": "detailsOpened"
+            }
+          ]
+        },
+        {
+          "name": "_a11ySetRowDetailsCell",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 81,
+              "column": 4
+            },
+            "end": {
+              "line": 87,
+              "column": 5
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "row"
+            },
+            {
+              "name": "detailsCell"
+            }
+          ]
+        },
+        {
+          "name": "_a11yUpdateCellColspan",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 89,
+              "column": 4
+            },
+            "end": {
+              "line": 91,
+              "column": 5
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "cell"
+            },
+            {
+              "name": "colspan"
+            }
+          ]
+        },
+        {
+          "name": "_a11yUpdateSorters",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 93,
+              "column": 4
+            },
+            "end": {
+              "line": 107,
+              "column": 5
+            }
+          },
+          "metadata": {},
+          "params": []
+        }
+      ],
+      "staticMethods": [],
+      "demos": [],
+      "metadata": {},
+      "sourceRange": {
+        "start": {
+          "line": 13,
+          "column": 2
+        },
+        "end": {
+          "line": 108,
+          "column": 3
+        }
+      },
+      "privacy": "public",
+      "name": "Vaadin.Grid.A11yMixin",
+      "attributes": [],
       "events": [],
       "styling": {
         "cssVariables": [],
@@ -23181,7 +23356,7 @@
               "column": 4
             },
             "end": {
-              "line": 103,
+              "line": 117,
               "column": 5
             }
           },
@@ -23198,11 +23373,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 105,
+              "line": 119,
               "column": 4
             },
             "end": {
-              "line": 130,
+              "line": 144,
               "column": 5
             }
           },
@@ -23219,11 +23394,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 132,
+              "line": 146,
               "column": 4
             },
             "end": {
-              "line": 151,
+              "line": 165,
               "column": 5
             }
           },
@@ -23240,11 +23415,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 153,
+              "line": 167,
               "column": 4
             },
             "end": {
-              "line": 165,
+              "line": 179,
               "column": 5
             }
           },
@@ -23257,11 +23432,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 167,
+              "line": 181,
               "column": 4
             },
             "end": {
-              "line": 185,
+              "line": 199,
               "column": 5
             }
           },
@@ -23281,11 +23456,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 187,
+              "line": 201,
               "column": 4
             },
             "end": {
-              "line": 199,
+              "line": 213,
               "column": 5
             }
           },
@@ -23305,11 +23480,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 201,
+              "line": 215,
               "column": 4
             },
             "end": {
-              "line": 217,
+              "line": 223,
               "column": 5
             }
           },
@@ -23326,11 +23501,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 219,
+              "line": 225,
               "column": 4
             },
             "end": {
-              "line": 226,
+              "line": 232,
               "column": 5
             }
           },
@@ -23350,11 +23525,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 228,
+              "line": 234,
               "column": 4
             },
             "end": {
-              "line": 232,
+              "line": 238,
               "column": 5
             }
           },
@@ -23374,11 +23549,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 234,
+              "line": 240,
               "column": 4
             },
             "end": {
-              "line": 250,
+              "line": 256,
               "column": 5
             }
           },
@@ -23391,11 +23566,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 252,
+              "line": 258,
               "column": 4
             },
             "end": {
-              "line": 259,
+              "line": 265,
               "column": 5
             }
           },
@@ -23415,11 +23590,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 261,
+              "line": 267,
               "column": 4
             },
             "end": {
-              "line": 271,
+              "line": 277,
               "column": 5
             }
           },
@@ -23439,11 +23614,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 273,
+              "line": 279,
               "column": 4
             },
             "end": {
-              "line": 279,
+              "line": 285,
               "column": 5
             }
           },
@@ -23463,11 +23638,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 281,
+              "line": 287,
               "column": 4
             },
             "end": {
-              "line": 293,
+              "line": 299,
               "column": 5
             }
           },
@@ -23491,7 +23666,7 @@
           "column": 2
         },
         "end": {
-          "line": 295,
+          "line": 301,
           "column": 3
         }
       },

--- a/demo/dev.html
+++ b/demo/dev.html
@@ -150,7 +150,7 @@
               </vaadin-grid-column>
               <vaadin-grid-column width="100px">
                 <template>
-                  <paper-checkbox checked="{{expanded}}">Details</paper-checkbox>
+                  <paper-checkbox checked="{{detailsOpened}}">Details</paper-checkbox>
                 </template>
                 <template class="header">
                   TC6

--- a/demo/grid-row-details-demos.html
+++ b/demo/grid-row-details-demos.html
@@ -11,9 +11,9 @@
     <h3>Row Details</h3>
     <p>
       Row Details can be enabled by providing a <code>&lt;template class="row-details"&gt;</code>
-      and expanding/collapsing items by using <code>{{expanded}}</code> template variable,
-      <code>expandedItems</code> property or <code>expandItem(item)</code> and
-      <code>collapseItem(item)</code> methods.
+      and toggling item details by using <code>{{detailsOpened}}</code> template variable,
+      <code>detailsOpenedItems</code> property or <code>openItemDetails(item)</code> and
+      <code>closeItemDetails(item)</code> methods.
     </p>
     <vaadin-demo-snippet id='grid-row-details-demos-row-details'>
       <template preserve-content>
@@ -66,7 +66,7 @@
               <vaadin-grid-column width="100px">
                 <template class="header"></template>
                 <template>
-                  <paper-checkbox aria-label$="Show Details for [[item.name.first]]" checked="{{expanded}}">Show Details</paper-checkbox>
+                  <paper-checkbox aria-label$="Show Details for [[item.name.first]]" checked="{{detailsOpened}}">Show Details</paper-checkbox>
                 </template>
               </vaadin-grid-column>
 
@@ -77,17 +77,17 @@
     </vaadin-demo-snippet>
 
 
-    <h3>Expanding Items Without Data Binding</h3>
+    <h3>Toggling Details Without Data Binding</h3>
     <p>
-      In this example the grid's <code>activeItem</code> property is bound to <code>expandedItems</code> property.
+      In this example the grid's <code>activeItem</code> property is bound to <code>detailsOpenedItems</code> property.
     </p>
     <p>
       <b>Hint: </b>Click a row to toggle the active item.
     </p>
-    <vaadin-demo-snippet id='grid-row-details-demos-expanding-items-without-data-binding'>
+    <vaadin-demo-snippet id='grid-row-details-demos-toggling-details-without-data-binding'>
       <template preserve-content>
-        <bind-expanded-items></bind-expanded-items>
-        <dom-module id="bind-expanded-items">
+        <bind-details-opened-items></bind-details-opened-items>
+        <dom-module id="bind-details-opened-items">
           <template preserve-content>
             <style>
               :host {
@@ -112,7 +112,7 @@
 
             <x-data-provider data-provider="{{dataProvider}}"></x-data-provider>
 
-            <vaadin-grid on-active-item-changed="_onActiveItemChanged" id="grid" aria-label="Expanded Items Example" data-provider="[[dataProvider]]" size="200">
+            <vaadin-grid on-active-item-changed="_onActiveItemChanged" id="grid" aria-label="Details Opened Items Example" data-provider="[[dataProvider]]" size="200">
 
               <template class="row-details">
                 <div class="details">
@@ -140,17 +140,17 @@
 
           </template>
           <script>
-            window.addDemoReadyListener('#grid-row-details-demos-expanding-items-without-data-binding', function(document) {
-              class BindExpandedItems extends Polymer.Element {
+            window.addDemoReadyListener('#grid-row-details-demos-toggling-details-without-data-binding', function(document) {
+              class BindDetailsOpenedItems extends Polymer.Element {
                 static get is() {
-                  return 'bind-expanded-items';
+                  return 'bind-details-opened-items';
                 }
 
                 _onActiveItemChanged(e) {
-                  this.$.grid.expandedItems = [e.detail.value];
+                  this.$.grid.detailsOpenedItems = [e.detail.value];
                 }
               }
-              window.customElements.define(BindExpandedItems.is, BindExpandedItems);
+              window.customElements.define(BindDetailsOpenedItems.is, BindDetailsOpenedItems);
             });
           </script>
         </dom-module>

--- a/test/accessibility.html
+++ b/test/accessibility.html
@@ -294,8 +294,8 @@
             });
           });
 
-          it('should set aria-expended true on cells after row expanded', () => {
-            grid.expandItem(grid.items[0]);
+          it('should set aria-expended true on cells after row details opened', () => {
+            grid.openItemDetails(grid.items[0]);
 
             expect(uniqueAttrValues(
               grid.$.items.children[0].children,
@@ -308,9 +308,9 @@
             )).to.eql(['false']);
           });
 
-          it('should set aria-expanded false on cells after row collapsed', () => {
-            grid.expandItem(grid.items[0]);
-            grid.collapseItem(grid.items[0]);
+          it('should set aria-expanded false on cells after row details closed', () => {
+            grid.openItemDetails(grid.items[0]);
+            grid.closeItemDetails(grid.items[0]);
 
             expect(uniqueAttrValues(
               grid.$.items.children[0].children,

--- a/test/column-reordering.html
+++ b/test/column-reordering.html
@@ -343,7 +343,7 @@
         });
 
         it('should update last-column attribute (details open)', () => {
-          grid.expandItem(getRows(grid.$.items)[0].item);
+          grid.openItemDetails(getRows(grid.$.items)[0].item);
           dragOver(headerContent[2], headerContent[3]);
           let cell = getCellByCellContent(headerContent[2]);
           cell = getCellByCellContent(headerContent[2]);

--- a/test/keyboard-navigation.html
+++ b/test/keyboard-navigation.html
@@ -751,7 +751,7 @@
 
         describe('with row details', () => {
           beforeEach(() => {
-            grid.expandItem(grid.items[0]);
+            grid.openItemDetails(grid.items[0]);
 
             tabToBody();
           });

--- a/test/light-dom-observing.html
+++ b/test/light-dom-observing.html
@@ -267,13 +267,13 @@
     </template>
   </test-fixture>
 
-  <test-fixture id="dom-repeat-columns-expandable">
+  <test-fixture id="dom-repeat-columns-detailed">
     <template>
       <vaadin-grid id="grid" size="10">
         <template class="row-details"><div class="details">grid repeats column with detail detail [[item.value]]</div></template>
         <vaadin-grid-column frozen width="20px">
-          <template><x-boolean-toggle value={{expanded}}></x-boolean-toggle></template>
-          <template class="header">expander</template>
+          <template><x-boolean-toggle value={{detailsOpened}}></x-boolean-toggle></template>
+          <template class="header">detail toggle</template>
         </vaadin-grid-column>
         <dom-repeat as="column">
           <template is="dom-repeat" as="column">
@@ -674,19 +674,19 @@
 
         describe('with row detail', function() {
           beforeEach(function() {
-            init('dom-repeat-columns-expandable', {columns: columns});
+            init('dom-repeat-columns-detailed', {columns: columns});
           });
 
-          it('should obey the "expanded" template property', function(done) {
+          it('should obey the "detailsOpened" template property', function(done) {
             repeater.render();
             flush(function() {
               var row = getRows(grid.$.items)[0];
               var cell = getRowCells(row)[0];
               var toggle = getCellContent(cell).children[0];
-              // expand row details
+              // open row details
               toggle.value = true;
 
-              expect(grid.expandedItems).to.contain(row._item);
+              expect(grid.detailsOpenedItems).to.contain(row._item);
               done();
             });
 

--- a/test/resizing.html
+++ b/test/resizing.html
@@ -100,7 +100,7 @@
         });
 
         it('should update details row height', () => {
-          grid.expandItem(grid._cache[0][0]);
+          grid.openItemDetails(grid._cache[0][0]);
           const bodyRows = getRows(grid.$.items);
           const cells = getRowCells(bodyRows[0]);
           const detailsCell = cells.pop();

--- a/test/row-details.html
+++ b/test/row-details.html
@@ -74,8 +74,8 @@
 
       describe('simple', () => {
 
-        function expandRow(index) {
-          grid.expandItem(grid._cache[0][index]);
+        function openRowDetails(index) {
+          grid.openItemDetails(grid._cache[0][index]);
         }
 
         beforeEach(done => {
@@ -87,25 +87,25 @@
           animationFrameFlush(() => done());
         });
 
-        function collapseRow(index) {
-          grid.collapseItem(grid._cache[0][index]);
+        function closeRowDetails(index) {
+          grid.closeItemDetails(grid._cache[0][index]);
         }
 
-        it('should expand a row', () => {
+        it('should open details row', () => {
           const cells = getRowCells(bodyRows[1]);
           expect(cells[1].hidden).to.be.true;
-          expandRow(1);
+          openRowDetails(1);
           expect(cells[1].hidden).to.be.false;
         });
 
-        it('should collapse a row', () => {
-          expandRow(1);
-          collapseRow(1);
+        it('should close details row', () => {
+          openRowDetails(1);
+          closeRowDetails(1);
           expect(getRowCells(bodyRows[1])[1].hidden).to.be.true;
         });
 
         it('should stamp the details template', () => {
-          expandRow(1);
+          openRowDetails(1);
           const cells = getRowCells(bodyRows[1]);
           expect(getCellContent(cells[1]).textContent.trim()).to.equal('1-details');
         });
@@ -116,7 +116,7 @@
         });
 
         it('should have correct bounds', () => {
-          expandRow(1);
+          openRowDetails(1);
           const cells = getRowCells(bodyRows[1]);
           const bounds = cells[1].getBoundingClientRect();
           expect(bounds.top).to.be.closeTo(cells[0].getBoundingClientRect().bottom, 1);
@@ -127,14 +127,14 @@
         });
 
         it('should hide the details cell', () => {
-          expandRow(1);
+          openRowDetails(1);
           const row = bodyRows[1];
           scrollToEnd(grid);
           expect(getRowCells(row)[1].hidden).to.be.true;
         });
 
         it('should add details to fixed cells cache', () => {
-          expandRow(1);
+          openRowDetails(1);
 
           flushGrid(grid);
           bodyRows = getRows(grid.$.items);
@@ -153,11 +153,11 @@
         });
 
         it('should have the correct index on details template', () => {
-          // expand item 0
-          grid.expandItem('foo');
+          // open details for item 0
+          grid.openItemDetails('foo');
 
-          // expand item 1
-          grid.expandItem('bar');
+          // open details for item 1
+          grid.openItemDetails('bar');
 
           const firstRowCells = getRowCells(bodyRows[0]);
           const secondRowCells = getRowCells(bodyRows[1]);
@@ -176,7 +176,7 @@
         beforeEach(() => grid = fixture('repeat'));
 
         it('should have correct height', done => {
-          grid.expandItem(items[0]);
+          grid.openItemDetails(items[0]);
 
           grid.dataProvider = (params, callback) => callback(items);
           flushGrid(grid);

--- a/test/visual/test.js
+++ b/test/visual/test.js
@@ -55,7 +55,7 @@ gemini.suite('vaadin-grid', (rootSuite) => {
       .capture('row-details-visible', {}, (actions, find) => {
         actions.executeJS(function(window) {
           var grid = window.document.querySelector('vaadin-grid');
-          grid.expandItem(grid.items[0]);
+          grid.openItemDetails(grid.items[0]);
         });
       });
   });

--- a/vaadin-grid-a11y-mixin.html
+++ b/vaadin-grid-a11y-mixin.html
@@ -67,10 +67,10 @@ This program is available under Apache License Version 2.0, available at https:/
       );
     }
 
-    _a11yUpdateRowExpanded(row, expanded) {
+    _a11yUpdateRowDetailsOpened(row, detailsOpened) {
       Array.from(row.children).forEach(cell => {
-        if (typeof expanded === 'boolean') {
-          cell.setAttribute('aria-expanded', expanded);
+        if (typeof detailsOpened === 'boolean') {
+          cell.setAttribute('aria-expanded', detailsOpened);
         } else {
           if (cell.hasAttribute('aria-expanded')) {
             cell.removeAttribute('aria-expanded');

--- a/vaadin-grid-keyboard-navigation-mixin.html
+++ b/vaadin-grid-keyboard-navigation-mixin.html
@@ -202,8 +202,8 @@ This program is available under Apache License Version 2.0, available at https:/
         if (isRowDetails) {
           dstIsRowDetails = dy === 0;
         } else {
-          dstIsRowDetails = dy === 1 && this._isExpanded(item) ||
-            dy === -1 && dstRowIndex !== rowIndex && this._isExpanded(dstItem);
+          dstIsRowDetails = dy === 1 && this._isDetailsOpened(item) ||
+            dy === -1 && dstRowIndex !== rowIndex && this._isDetailsOpened(dstItem);
         }
         // Should we navigate between details and regular cells of the same row?
         if (dstIsRowDetails !== isRowDetails &&

--- a/vaadin-grid-row-details-mixin.html
+++ b/vaadin-grid-row-details-mixin.html
@@ -17,9 +17,9 @@ This program is available under Apache License Version 2.0, available at https:/
     static get properties() {
       return {
         /**
-        * An array containing references to expanded items.
+        * An array containing references to items with open row details.
         */
-        expandedItems: {
+        detailsOpenedItems: {
           type: Array,
           value: function() {
             return [];
@@ -36,7 +36,7 @@ This program is available under Apache License Version 2.0, available at https:/
 
     static get observers() {
       return [
-        '_expandedItemsChanged(expandedItems.*, dataProvider, _rowDetailsTemplate, _physicalCountVal)'
+        '_detailsOpenedItemsChanged(detailsOpenedItems.*, dataProvider, _rowDetailsTemplate, _physicalCountVal)'
       ];
     }
 
@@ -52,24 +52,24 @@ This program is available under Apache License Version 2.0, available at https:/
       }
     }
 
-    _expandedItemsChanged(changeRecord, dataProvider, rowDetailsTemplate, physicalCount) {
+    _detailsOpenedItemsChanged(changeRecord, dataProvider, rowDetailsTemplate, physicalCount) {
       if (dataProvider === undefined || !rowDetailsTemplate) {
         return;
       }
 
-      if (changeRecord.path === 'expandedItems.length') {
+      if (changeRecord.path === 'detailsOpenedItems.length') {
         // Let’s avoid duplicate work of both “.splices” and “.length” updates.
         return;
       }
 
       this._flushItemsDebouncer();
 
-      if (this._lastExpandedItems && physicalCount) {
+      if (this._lastDetailsOpenedItems && physicalCount) {
         this._physicalItems.forEach(this._toggleDetailsCell, this);
         this._render();
       }
 
-      this._lastExpandedItems = this.expandedItems;
+      this._lastDetailsOpenedItems = this.detailsOpenedItems;
     }
 
     _configureDetailsCell(cell) {
@@ -81,7 +81,7 @@ This program is available under Apache License Version 2.0, available at https:/
 
     _toggleDetailsCell(row, item) {
       const cell = row.querySelector('[part~="details-cell"]');
-      const detailsHidden = !this._isExpanded(item);
+      const detailsHidden = !this._isDetailsOpened(item);
       if (cell && cell.hidden !== detailsHidden) {
         cell.hidden = detailsHidden;
         if (detailsHidden) {
@@ -106,36 +106,36 @@ This program is available under Apache License Version 2.0, available at https:/
       });
     }
 
-    _isExpanded(item) {
-      return this.expandedItems && this.expandedItems.indexOf(item) !== -1;
+    _isDetailsOpened(item) {
+      return this.detailsOpenedItems && this.detailsOpenedItems.indexOf(item) !== -1;
     }
 
     /**
-     * Expand the details row of a given item.
+     * Open the details row of a given item.
      */
-    expandItem(item) {
-      if (!this._isExpanded(item)) {
-        this.push('expandedItems', item);
+    openItemDetails(item) {
+      if (!this._isDetailsOpened(item)) {
+        this.push('detailsOpenedItems', item);
       }
     }
 
     /**
-     * Collapse the details row of a given item.
+     * Close the details row of a given item.
      */
-    collapseItem(item) {
-      if (this._isExpanded(item)) {
-        this.splice('expandedItems', this.expandedItems.indexOf(item), 1);
+    closeItemDetails(item) {
+      if (this._isDetailsOpened(item)) {
+        this.splice('detailsOpenedItems', this.detailsOpenedItems.indexOf(item), 1);
       }
     }
 
-    _expandedInstanceChangedCallback(instance, value) {
-      if (super._expandedInstanceChangedCallback) {
-        super._expandedInstanceChangedCallback(instance, value);
+    _detailsOpenedInstanceChangedCallback(instance, value) {
+      if (super._detailsOpenedInstanceChangedCallback) {
+        super._detailsOpenedInstanceChangedCallback(instance, value);
       }
       if (value) {
-        this.expandItem(instance.item);
+        this.openItemDetails(instance.item);
       } else {
-        this.collapseItem(instance.item);
+        this.closeItemDetails(instance.item);
       }
     }
   };

--- a/vaadin-grid-templatizer.html
+++ b/vaadin-grid-templatizer.html
@@ -52,7 +52,7 @@ This program is available under Apache License Version 2.0, available at https:/
         super();
 
         this._instanceProps = {
-          expanded: true,
+          detailsOpened: true,
           index: true,
           item: true,
           selected: true
@@ -102,7 +102,7 @@ This program is available under Apache License Version 2.0, available at https:/
               const originalProp = `__${prop}__`;
 
               // Notify for only user-action changes, not for scrolling updates. E. g.,
-              // if `expanded` is different from `__expanded__`, which was set during render.
+              // if `detailsOpened` is different from `__detailsOpened__`, which was set during render.
               if (inst[originalProp] === value) {
                 return;
               }

--- a/vaadin-grid.html
+++ b/vaadin-grid.html
@@ -60,9 +60,9 @@ This program is available under Apache License Version 2.0, available at https:/
      *
      * ### Quick Start
      *
-     * - Use the [`<vaadin-grid-column>`](#/elements/vaadin-grid-column) element to configure the grid columns.
+     * Use the [`<vaadin-grid-column>`](#/elements/vaadin-grid-column) element to configure the grid columns.
      *
-     * - Then assign an array to the [`items`](#/elements/vaadin-grid#property-items) property to visualize your data.
+     * Then assign an array to the [`items`](#/elements/vaadin-grid#property-items) property to visualize your data.
      *
      * #### Example:
      * ```html
@@ -83,25 +83,25 @@ This program is available under Apache License Version 2.0, available at https:/
      * </vaadin-grid>
      * ```
      *
-     * - The following helper elements can be used for further customization:
-     *  - [`<vaadin-grid-column-group>`](#/elements/vaadin-grid-column-group)
-     *  - [`<vaadin-grid-filter>`](#/elements/vaadin-grid-filter)
-     *  - [`<vaadin-grid-sorter>`](#/elements/vaadin-grid-sorter)
-     *  - [`<vaadin-grid-selection-column>`](#/elements/vaadin-grid-selection-column)
+     * The following helper elements can be used for further customization:
+     * - [`<vaadin-grid-column-group>`](#/elements/vaadin-grid-column-group)
+     * - [`<vaadin-grid-filter>`](#/elements/vaadin-grid-filter)
+     * - [`<vaadin-grid-sorter>`](#/elements/vaadin-grid-sorter)
+     * - [`<vaadin-grid-selection-column>`](#/elements/vaadin-grid-selection-column)
      *
      * __Note that the helper elements must be explicitly imported.__
      * If you want to import everything at once you can use the `all-imports.html` bundle.
      *
-     * - A column template can be decorated with one the following class names to specify its purpose
-     *  - "header": Marks a header template
-     *  - "footer": Marks a footer template
-     *  - "row-details": Marks a row details template
+     * A column template can be decorated with one the following class names to specify its purpose
+     * - `header`: Marks a header template
+     * - `footer`: Marks a footer template
+     * - `row-details`: Marks a row details template
      *
-     * - The following built-in template variables can be bound to inside the column templates
-     *  - "index": Number representing the row index
-     *  - "item" and it's sub-properties: Data object (provided by a data provider / items array)
-     *  - "selected": True if the item is selected (can be two-way bound)
-     *  - "expanded": True if the item is expanded for row details (can be two-way bound)
+     * The following built-in template variables can be bound to inside the column templates:
+     * - `[[index]]`: Number representing the row index
+     * - `[[item]]` and it's sub-properties: Data object (provided by a data provider / items array)
+     * - `{{selected}}`: True if the item is selected (can be two-way bound)
+     * - `{{detailsOpened}}`: True if the item has row details opened (can be two-way bound)
      *
      * ### Lazy Loading with Function Data Provider
      *
@@ -479,20 +479,20 @@ This program is available under Apache License Version 2.0, available at https:/
           }
         });
         this._toggleRowSelected(row, this._isSelected(item));
-        this._toggleRowExpanded(row, this._rowDetailsTemplate && this._isExpanded(item));
+        this._toggleRowDetailsOpened(row, this._rowDetailsTemplate && this._isDetailsOpened(item));
         if (this._rowDetailsTemplate) {
           this._toggleDetailsCell(row, item);
         }
       }
 
-      _toggleRowExpanded(row, expanded) {
+      _toggleRowDetailsOpened(row, detailsOpened) {
         Array.from(row.children).forEach(cell => {
           if (cell._instance) {
-            cell._instance.__expanded__ = expanded;
-            cell._instance.expanded = expanded;
+            cell._instance.__detailsOpened__ = detailsOpened;
+            cell._instance.detailsOpened = detailsOpened;
           }
         });
-        this._a11yUpdateRowExpanded(row, expanded);
+        this._a11yUpdateRowDetailsOpened(row, detailsOpened);
       }
 
       _toggleRowSelected(row, selected) {


### PR DESCRIPTION
Fixes #1041

APIs renamed:

- `expandItem(item)` → `openItemDetails(item)`
- `collapseItem(item)` → `closeItemDetails(item)`
- `{{expanded}}` → `{{detailsOpened}}`
- `expandedItems[]` → `detailsOpenedItems[]`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-grid/1042)
<!-- Reviewable:end -->
