### PR TITLE
Don't support optional indexes in item APIs

### DIFF
--- a/analysis.json
+++ b/analysis.json
@@ -53,11 +53,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1151,
+                  "line": 1152,
                   "column": 8
                 },
                 "end": {
-                  "line": 1151,
+                  "line": 1152,
                   "column": 27
                 }
               },
@@ -145,11 +145,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1133,
+                  "line": 1134,
                   "column": 8
                 },
                 "end": {
-                  "line": 1133,
+                  "line": 1134,
                   "column": 20
                 }
               },
@@ -168,11 +168,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1135,
+                  "line": 1136,
                   "column": 8
                 },
                 "end": {
-                  "line": 1135,
+                  "line": 1136,
                   "column": 27
                 }
               },
@@ -191,11 +191,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1137,
+                  "line": 1138,
                   "column": 8
                 },
                 "end": {
-                  "line": 1137,
+                  "line": 1138,
                   "column": 23
                 }
               },
@@ -283,11 +283,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1115,
+                  "line": 1116,
                   "column": 8
                 },
                 "end": {
-                  "line": 1115,
+                  "line": 1116,
                   "column": 32
                 }
               },
@@ -306,11 +306,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1117,
+                  "line": 1118,
                   "column": 8
                 },
                 "end": {
-                  "line": 1117,
+                  "line": 1118,
                   "column": 34
                 }
               },
@@ -329,11 +329,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1119,
+                  "line": 1120,
                   "column": 8
                 },
                 "end": {
-                  "line": 1119,
+                  "line": 1120,
                   "column": 28
                 }
               },
@@ -352,11 +352,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1121,
+                  "line": 1122,
                   "column": 8
                 },
                 "end": {
-                  "line": 1121,
+                  "line": 1122,
                   "column": 31
                 }
               },
@@ -375,11 +375,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1123,
+                  "line": 1124,
                   "column": 8
                 },
                 "end": {
-                  "line": 1123,
+                  "line": 1124,
                   "column": 28
                 }
               },
@@ -398,11 +398,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1125,
+                  "line": 1126,
                   "column": 8
                 },
                 "end": {
-                  "line": 1125,
+                  "line": 1126,
                   "column": 35
                 }
               },
@@ -421,11 +421,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1127,
+                  "line": 1128,
                   "column": 8
                 },
                 "end": {
-                  "line": 1127,
+                  "line": 1128,
                   "column": 24
                 }
               },
@@ -444,11 +444,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1129,
+                  "line": 1130,
                   "column": 8
                 },
                 "end": {
-                  "line": 1129,
+                  "line": 1130,
                   "column": 24
                 }
               },
@@ -467,11 +467,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1131,
+                  "line": 1132,
                   "column": 8
                 },
                 "end": {
-                  "line": 1131,
+                  "line": 1132,
                   "column": 38
                 }
               },
@@ -490,11 +490,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1139,
+                  "line": 1140,
                   "column": 8
                 },
                 "end": {
-                  "line": 1139,
+                  "line": 1140,
                   "column": 30
                 }
               },
@@ -513,11 +513,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1141,
+                  "line": 1142,
                   "column": 8
                 },
                 "end": {
-                  "line": 1141,
+                  "line": 1142,
                   "column": 30
                 }
               },
@@ -536,11 +536,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1143,
+                  "line": 1144,
                   "column": 8
                 },
                 "end": {
-                  "line": 1143,
+                  "line": 1144,
                   "column": 29
                 }
               },
@@ -559,11 +559,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1145,
+                  "line": 1146,
                   "column": 8
                 },
                 "end": {
-                  "line": 1145,
+                  "line": 1146,
                   "column": 32
                 }
               },
@@ -582,11 +582,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1147,
+                  "line": 1148,
                   "column": 8
                 },
                 "end": {
-                  "line": 1147,
+                  "line": 1148,
                   "column": 30
                 }
               },
@@ -605,11 +605,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1149,
+                  "line": 1150,
                   "column": 8
                 },
                 "end": {
-                  "line": 1149,
+                  "line": 1150,
                   "column": 24
                 }
               },
@@ -628,11 +628,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1153,
+                  "line": 1154,
                   "column": 8
                 },
                 "end": {
-                  "line": 1153,
+                  "line": 1154,
                   "column": 28
                 }
               },
@@ -651,11 +651,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 549,
+                  "line": 519,
                   "column": 8
                 },
                 "end": {
-                  "line": 549,
+                  "line": 519,
                   "column": 23
                 }
               },
@@ -674,11 +674,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 551,
+                  "line": 521,
                   "column": 8
                 },
                 "end": {
-                  "line": 551,
+                  "line": 521,
                   "column": 25
                 }
               },
@@ -697,11 +697,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 553,
+                  "line": 523,
                   "column": 8
                 },
                 "end": {
-                  "line": 553,
+                  "line": 523,
                   "column": 22
                 }
               },
@@ -720,11 +720,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 555,
+                  "line": 525,
                   "column": 8
                 },
                 "end": {
-                  "line": 555,
+                  "line": 525,
                   "column": 24
                 }
               },
@@ -743,11 +743,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 557,
+                  "line": 527,
                   "column": 8
                 },
                 "end": {
-                  "line": 557,
+                  "line": 527,
                   "column": 18
                 }
               },
@@ -766,11 +766,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 559,
+                  "line": 529,
                   "column": 8
                 },
                 "end": {
-                  "line": 559,
+                  "line": 529,
                   "column": 15
                 }
               },
@@ -887,11 +887,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2319,
+                  "line": 2320,
                   "column": 6
                 },
                 "end": {
-                  "line": 2344,
+                  "line": 2345,
                   "column": 7
                 }
               },
@@ -916,11 +916,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/template-stamp.html",
                 "start": {
-                  "line": 448,
+                  "line": 451,
                   "column": 6
                 },
                 "end": {
-                  "line": 453,
+                  "line": 456,
                   "column": 7
                 }
               },
@@ -960,11 +960,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/template-stamp.html",
                 "start": {
-                  "line": 462,
+                  "line": 465,
                   "column": 6
                 },
                 "end": {
-                  "line": 464,
+                  "line": 467,
                   "column": 7
                 }
               },
@@ -995,11 +995,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/template-stamp.html",
                 "start": {
-                  "line": 473,
+                  "line": 476,
                   "column": 6
                 },
                 "end": {
-                  "line": 475,
+                  "line": 478,
                   "column": 7
                 }
               },
@@ -1030,11 +1030,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 715,
+                  "line": 723,
                   "column": 6
                 },
                 "end": {
-                  "line": 723,
+                  "line": 731,
                   "column": 7
                 }
               },
@@ -1065,11 +1065,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 573,
+                  "line": 543,
                   "column": 6
                 },
                 "end": {
-                  "line": 613,
+                  "line": 577,
                   "column": 7
                 }
               },
@@ -1084,11 +1084,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1183,
+                  "line": 1184,
                   "column": 6
                 },
                 "end": {
-                  "line": 1187,
+                  "line": 1188,
                   "column": 7
                 }
               },
@@ -1109,11 +1109,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1196,
+                  "line": 1197,
                   "column": 6
                 },
                 "end": {
-                  "line": 1205,
+                  "line": 1206,
                   "column": 7
                 }
               },
@@ -1391,11 +1391,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1472,
+                  "line": 1473,
                   "column": 6
                 },
                 "end": {
-                  "line": 1476,
+                  "line": 1477,
                   "column": 7
                 }
               },
@@ -1417,11 +1417,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1435,
+                  "line": 1436,
                   "column": 6
                 },
                 "end": {
-                  "line": 1464,
+                  "line": 1465,
                   "column": 7
                 }
               },
@@ -1485,11 +1485,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1486,
+                  "line": 1487,
                   "column": 6
                 },
                 "end": {
-                  "line": 1490,
+                  "line": 1491,
                   "column": 7
                 }
               },
@@ -1542,11 +1542,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 643,
+                  "line": 651,
                   "column": 6
                 },
                 "end": {
-                  "line": 649,
+                  "line": 657,
                   "column": 7
                 }
               },
@@ -1561,11 +1561,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1625,
+                  "line": 1626,
                   "column": 6
                 },
                 "end": {
-                  "line": 1658,
+                  "line": 1659,
                   "column": 7
                 }
               },
@@ -1629,11 +1629,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1219,
+                  "line": 1220,
                   "column": 6
                 },
                 "end": {
-                  "line": 1227,
+                  "line": 1228,
                   "column": 7
                 }
               },
@@ -1664,11 +1664,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1236,
+                  "line": 1237,
                   "column": 6
                 },
                 "end": {
-                  "line": 1242,
+                  "line": 1243,
                   "column": 7
                 }
               },
@@ -1699,11 +1699,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1253,
+                  "line": 1254,
                   "column": 6
                 },
                 "end": {
-                  "line": 1256,
+                  "line": 1257,
                   "column": 7
                 }
               },
@@ -1733,11 +1733,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1266,
+                  "line": 1267,
                   "column": 6
                 },
                 "end": {
-                  "line": 1268,
+                  "line": 1269,
                   "column": 7
                 }
               },
@@ -1762,11 +1762,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1278,
+                  "line": 1279,
                   "column": 6
                 },
                 "end": {
-                  "line": 1280,
+                  "line": 1281,
                   "column": 7
                 }
               },
@@ -1791,11 +1791,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1290,
+                  "line": 1291,
                   "column": 6
                 },
                 "end": {
-                  "line": 1292,
+                  "line": 1293,
                   "column": 7
                 }
               },
@@ -1820,11 +1820,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1302,
+                  "line": 1303,
                   "column": 6
                 },
                 "end": {
-                  "line": 1304,
+                  "line": 1305,
                   "column": 7
                 }
               },
@@ -1849,11 +1849,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1336,
+                  "line": 1337,
                   "column": 6
                 },
                 "end": {
-                  "line": 1368,
+                  "line": 1369,
                   "column": 7
                 }
               },
@@ -1893,11 +1893,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1390,
+                  "line": 1391,
                   "column": 6
                 },
                 "end": {
-                  "line": 1398,
+                  "line": 1399,
                   "column": 7
                 }
               },
@@ -1928,11 +1928,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1500,
+                  "line": 1501,
                   "column": 6
                 },
                 "end": {
-                  "line": 1505,
+                  "line": 1506,
                   "column": 7
                 }
               },
@@ -1953,11 +1953,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1513,
+                  "line": 1514,
                   "column": 6
                 },
                 "end": {
-                  "line": 1524,
+                  "line": 1525,
                   "column": 7
                 }
               },
@@ -1972,11 +1972,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1538,
+                  "line": 1539,
                   "column": 6
                 },
                 "end": {
-                  "line": 1551,
+                  "line": 1552,
                   "column": 7
                 }
               },
@@ -1991,11 +1991,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 660,
+                  "line": 668,
                   "column": 6
                 },
                 "end": {
-                  "line": 669,
+                  "line": 677,
                   "column": 7
                 }
               },
@@ -2010,11 +2010,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1578,
+                  "line": 1579,
                   "column": 6
                 },
                 "end": {
-                  "line": 1589,
+                  "line": 1590,
                   "column": 7
                 }
               },
@@ -2040,11 +2040,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1669,
+                  "line": 1670,
                   "column": 6
                 },
                 "end": {
-                  "line": 1679,
+                  "line": 1680,
                   "column": 7
                 }
               },
@@ -2075,11 +2075,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1689,
+                  "line": 1690,
                   "column": 6
                 },
                 "end": {
-                  "line": 1694,
+                  "line": 1695,
                   "column": 7
                 }
               },
@@ -2105,11 +2105,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1705,
+                  "line": 1706,
                   "column": 6
                 },
                 "end": {
-                  "line": 1710,
+                  "line": 1711,
                   "column": 7
                 }
               },
@@ -2125,16 +2125,16 @@
             },
             {
               "name": "notifySplices",
-              "description": "Notify that an array has changed.\n\nExample:\n\n    this.items = [ {name: 'Jim'}, {name: 'Todd'}, {name: 'Bill'} ];\n    ...\n    this.items.splice(1, 1, {name: 'Sam'});\n    this.items.push({name: 'Bob'});\n    this.notifySplices('items', [\n      { index: 1, removed: [{name: 'Todd'}], addedCount: 1, obect: this.items, type: 'splice' },\n      { index: 3, removed: [], addedCount: 1, object: this.items, type: 'splice'}\n    ]);",
+              "description": "Notify that an array has changed.\n\nExample:\n\n    this.items = [ {name: 'Jim'}, {name: 'Todd'}, {name: 'Bill'} ];\n    ...\n    this.items.splice(1, 1, {name: 'Sam'});\n    this.items.push({name: 'Bob'});\n    this.notifySplices('items', [\n      { index: 1, removed: [{name: 'Todd'}], addedCount: 1, object: this.items, type: 'splice' },\n      { index: 3, removed: [], addedCount: 1, object: this.items, type: 'splice'}\n    ]);",
               "privacy": "public",
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1741,
+                  "line": 1742,
                   "column": 6
                 },
                 "end": {
-                  "line": 1745,
+                  "line": 1746,
                   "column": 7
                 }
               },
@@ -2160,11 +2160,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1766,
+                  "line": 1767,
                   "column": 6
                 },
                 "end": {
-                  "line": 1768,
+                  "line": 1769,
                   "column": 7
                 }
               },
@@ -2194,11 +2194,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1790,
+                  "line": 1791,
                   "column": 6
                 },
                 "end": {
-                  "line": 1800,
+                  "line": 1801,
                   "column": 7
                 }
               },
@@ -2229,11 +2229,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1816,
+                  "line": 1817,
                   "column": 6
                 },
                 "end": {
-                  "line": 1825,
+                  "line": 1826,
                   "column": 7
                 }
               },
@@ -2261,11 +2261,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1840,
+                  "line": 1841,
                   "column": 6
                 },
                 "end": {
-                  "line": 1849,
+                  "line": 1850,
                   "column": 7
                 }
               },
@@ -2290,11 +2290,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1868,
+                  "line": 1869,
                   "column": 6
                 },
                 "end": {
-                  "line": 1885,
+                  "line": 1886,
                   "column": 7
                 }
               },
@@ -2332,11 +2332,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1900,
+                  "line": 1901,
                   "column": 6
                 },
                 "end": {
-                  "line": 1909,
+                  "line": 1910,
                   "column": 7
                 }
               },
@@ -2361,11 +2361,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1925,
+                  "line": 1926,
                   "column": 6
                 },
                 "end": {
-                  "line": 1933,
+                  "line": 1934,
                   "column": 7
                 }
               },
@@ -2393,11 +2393,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1947,
+                  "line": 1948,
                   "column": 6
                 },
                 "end": {
-                  "line": 1964,
+                  "line": 1965,
                   "column": 7
                 }
               },
@@ -2423,11 +2423,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1976,
+                  "line": 1977,
                   "column": 6
                 },
                 "end": {
-                  "line": 1983,
+                  "line": 1984,
                   "column": 7
                 }
               },
@@ -2453,11 +2453,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1996,
+                  "line": 1997,
                   "column": 6
                 },
                 "end": {
-                  "line": 2006,
+                  "line": 2007,
                   "column": 7
                 }
               },
@@ -2488,11 +2488,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2018,
+                  "line": 2019,
                   "column": 6
                 },
                 "end": {
-                  "line": 2024,
+                  "line": 2025,
                   "column": 7
                 }
               },
@@ -2518,11 +2518,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2034,
+                  "line": 2035,
                   "column": 6
                 },
                 "end": {
-                  "line": 2042,
+                  "line": 2043,
                   "column": 7
                 }
               },
@@ -2543,11 +2543,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2052,
+                  "line": 2053,
                   "column": 6
                 },
                 "end": {
-                  "line": 2065,
+                  "line": 2066,
                   "column": 7
                 }
               },
@@ -2568,11 +2568,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2078,
+                  "line": 2079,
                   "column": 6
                 },
                 "end": {
-                  "line": 2084,
+                  "line": 2085,
                   "column": 7
                 }
               },
@@ -2603,11 +2603,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2254,
+                  "line": 2255,
                   "column": 6
                 },
                 "end": {
-                  "line": 2277,
+                  "line": 2278,
                   "column": 7
                 }
               },
@@ -2637,11 +2637,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2354,
+                  "line": 2355,
                   "column": 6
                 },
                 "end": {
-                  "line": 2375,
+                  "line": 2376,
                   "column": 7
                 }
               },
@@ -2662,11 +2662,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 625,
+                  "line": 633,
                   "column": 6
                 },
                 "end": {
-                  "line": 630,
+                  "line": 638,
                   "column": 7
                 }
               },
@@ -2681,11 +2681,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 636,
+                  "line": 644,
                   "column": 6
                 },
                 "end": {
-                  "line": 636,
+                  "line": 644,
                   "column": 31
                 }
               },
@@ -2700,11 +2700,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 683,
+                  "line": 691,
                   "column": 6
                 },
                 "end": {
-                  "line": 699,
+                  "line": 707,
                   "column": 7
                 }
               },
@@ -2729,11 +2729,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 742,
+                  "line": 750,
                   "column": 6
                 },
                 "end": {
-                  "line": 746,
+                  "line": 754,
                   "column": 7
                 }
               },
@@ -2754,11 +2754,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 759,
+                  "line": 767,
                   "column": 6
                 },
                 "end": {
-                  "line": 764,
+                  "line": 772,
                   "column": 7
                 }
               },
@@ -2948,11 +2948,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 775,
+                  "line": 783,
                   "column": 6
                 },
                 "end": {
-                  "line": 778,
+                  "line": 786,
                   "column": 7
                 }
               },
@@ -2977,11 +2977,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2394,
+                  "line": 2395,
                   "column": 6
                 },
                 "end": {
-                  "line": 2408,
+                  "line": 2409,
                   "column": 7
                 }
               },
@@ -3020,7 +3020,7 @@
                   "column": 6
                 },
                 "end": {
-                  "line": 291,
+                  "line": 294,
                   "column": 7
                 }
               },
@@ -3051,11 +3051,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2479,
+                  "line": 2482,
                   "column": 6
                 },
                 "end": {
-                  "line": 2489,
+                  "line": 2492,
                   "column": 7
                 }
               },
@@ -3090,11 +3090,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/template-stamp.html",
                 "start": {
-                  "line": 329,
+                  "line": 332,
                   "column": 6
                 },
                 "end": {
-                  "line": 338,
+                  "line": 341,
                   "column": 7
                 }
               },
@@ -3129,11 +3129,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2427,
+                  "line": 2430,
                   "column": 6
                 },
                 "end": {
-                  "line": 2463,
+                  "line": 2466,
                   "column": 7
                 }
               },
@@ -3155,10 +3155,14 @@
                   "description": "Node metadata for current template node"
                 },
                 {
-                  "name": "name"
+                  "name": "name",
+                  "type": "string",
+                  "description": "Attribute name"
                 },
                 {
-                  "name": "value"
+                  "name": "value",
+                  "type": "string",
+                  "description": "Attribute value"
                 }
               ],
               "return": {
@@ -3174,11 +3178,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/template-stamp.html",
                 "start": {
-                  "line": 384,
+                  "line": 387,
                   "column": 6
                 },
                 "end": {
-                  "line": 387,
+                  "line": 390,
                   "column": 7
                 }
               },
@@ -3222,11 +3226,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2123,
+                  "line": 2124,
                   "column": 6
                 },
                 "end": {
-                  "line": 2125,
+                  "line": 2126,
                   "column": 7
                 }
               },
@@ -3257,11 +3261,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2136,
+                  "line": 2137,
                   "column": 6
                 },
                 "end": {
-                  "line": 2138,
+                  "line": 2139,
                   "column": 7
                 }
               },
@@ -3292,11 +3296,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2152,
+                  "line": 2153,
                   "column": 6
                 },
                 "end": {
-                  "line": 2154,
+                  "line": 2155,
                   "column": 7
                 }
               },
@@ -3322,11 +3326,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2163,
+                  "line": 2164,
                   "column": 6
                 },
                 "end": {
-                  "line": 2165,
+                  "line": 2166,
                   "column": 7
                 }
               },
@@ -3347,11 +3351,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2182,
+                  "line": 2183,
                   "column": 6
                 },
                 "end": {
-                  "line": 2184,
+                  "line": 2185,
                   "column": 7
                 }
               },
@@ -3377,11 +3381,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2193,
+                  "line": 2194,
                   "column": 6
                 },
                 "end": {
-                  "line": 2195,
+                  "line": 2196,
                   "column": 7
                 }
               },
@@ -3402,11 +3406,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2210,
+                  "line": 2211,
                   "column": 6
                 },
                 "end": {
-                  "line": 2212,
+                  "line": 2213,
                   "column": 7
                 }
               },
@@ -3437,11 +3441,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2226,
+                  "line": 2227,
                   "column": 6
                 },
                 "end": {
-                  "line": 2228,
+                  "line": 2229,
                   "column": 7
                 }
               },
@@ -3466,11 +3470,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2291,
+                  "line": 2292,
                   "column": 6
                 },
                 "end": {
-                  "line": 2297,
+                  "line": 2298,
                   "column": 7
                 }
               },
@@ -3501,11 +3505,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2524,
+                  "line": 2527,
                   "column": 6
                 },
                 "end": {
-                  "line": 2589,
+                  "line": 2592,
                   "column": 7
                 }
               },
@@ -3535,11 +3539,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2605,
+                  "line": 2608,
                   "column": 6
                 },
                 "end": {
-                  "line": 2622,
+                  "line": 2625,
                   "column": 7
                 }
               },
@@ -3589,16 +3593,85 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 471,
+                  "line": 441,
                   "column": 6
                 },
                 "end": {
-                  "line": 475,
+                  "line": 445,
                   "column": 7
                 }
               },
               "metadata": {},
               "params": [],
+              "inheritedFrom": "Polymer.ElementMixin"
+            },
+            {
+              "name": "_processStyleText",
+              "description": "Gather style text for the template",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+                "start": {
+                  "line": 588,
+                  "column": 6
+                },
+                "end": {
+                  "line": 591,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "is",
+                  "type": "string",
+                  "description": "Tag name for this element"
+                },
+                {
+                  "name": "template",
+                  "type": "!HTMLTemplateElement",
+                  "description": "Template to process"
+                },
+                {
+                  "name": "baseURI",
+                  "type": "string",
+                  "description": "Base URI to rebase CSS paths against"
+                }
+              ],
+              "return": {
+                "type": "string",
+                "desc": "The combined CSS text"
+              },
+              "inheritedFrom": "Polymer.ElementMixin"
+            },
+            {
+              "name": "_finalizeTemplate",
+              "description": "Configures an element `proto` to function with a given `template`.\nThe element name `is` and extends `ext` must be specified for ShadyCSS\nstyle scoping.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+                "start": {
+                  "line": 602,
+                  "column": 6
+                },
+                "end": {
+                  "line": 621,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "is",
+                  "type": "string",
+                  "description": "Tag name (or type extension name) for this element"
+                },
+                {
+                  "name": "ext",
+                  "type": "string=",
+                  "description": "For type extensions, the tag name that was extended"
+                }
+              ],
               "inheritedFrom": "Polymer.ElementMixin"
             }
           ],
@@ -5965,11 +6038,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1151,
+                  "line": 1152,
                   "column": 8
                 },
                 "end": {
-                  "line": 1151,
+                  "line": 1152,
                   "column": 27
                 }
               },
@@ -6057,11 +6130,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1133,
+                  "line": 1134,
                   "column": 8
                 },
                 "end": {
-                  "line": 1133,
+                  "line": 1134,
                   "column": 20
                 }
               },
@@ -6080,11 +6153,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1135,
+                  "line": 1136,
                   "column": 8
                 },
                 "end": {
-                  "line": 1135,
+                  "line": 1136,
                   "column": 27
                 }
               },
@@ -6103,11 +6176,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1137,
+                  "line": 1138,
                   "column": 8
                 },
                 "end": {
-                  "line": 1137,
+                  "line": 1138,
                   "column": 23
                 }
               },
@@ -6195,11 +6268,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1115,
+                  "line": 1116,
                   "column": 8
                 },
                 "end": {
-                  "line": 1115,
+                  "line": 1116,
                   "column": 32
                 }
               },
@@ -6218,11 +6291,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1117,
+                  "line": 1118,
                   "column": 8
                 },
                 "end": {
-                  "line": 1117,
+                  "line": 1118,
                   "column": 34
                 }
               },
@@ -6241,11 +6314,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1119,
+                  "line": 1120,
                   "column": 8
                 },
                 "end": {
-                  "line": 1119,
+                  "line": 1120,
                   "column": 28
                 }
               },
@@ -6264,11 +6337,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1121,
+                  "line": 1122,
                   "column": 8
                 },
                 "end": {
-                  "line": 1121,
+                  "line": 1122,
                   "column": 31
                 }
               },
@@ -6287,11 +6360,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1123,
+                  "line": 1124,
                   "column": 8
                 },
                 "end": {
-                  "line": 1123,
+                  "line": 1124,
                   "column": 28
                 }
               },
@@ -6310,11 +6383,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1125,
+                  "line": 1126,
                   "column": 8
                 },
                 "end": {
-                  "line": 1125,
+                  "line": 1126,
                   "column": 35
                 }
               },
@@ -6333,11 +6406,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1127,
+                  "line": 1128,
                   "column": 8
                 },
                 "end": {
-                  "line": 1127,
+                  "line": 1128,
                   "column": 24
                 }
               },
@@ -6356,11 +6429,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1129,
+                  "line": 1130,
                   "column": 8
                 },
                 "end": {
-                  "line": 1129,
+                  "line": 1130,
                   "column": 24
                 }
               },
@@ -6379,11 +6452,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1131,
+                  "line": 1132,
                   "column": 8
                 },
                 "end": {
-                  "line": 1131,
+                  "line": 1132,
                   "column": 38
                 }
               },
@@ -6402,11 +6475,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1139,
+                  "line": 1140,
                   "column": 8
                 },
                 "end": {
-                  "line": 1139,
+                  "line": 1140,
                   "column": 30
                 }
               },
@@ -6425,11 +6498,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1141,
+                  "line": 1142,
                   "column": 8
                 },
                 "end": {
-                  "line": 1141,
+                  "line": 1142,
                   "column": 30
                 }
               },
@@ -6448,11 +6521,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1143,
+                  "line": 1144,
                   "column": 8
                 },
                 "end": {
-                  "line": 1143,
+                  "line": 1144,
                   "column": 29
                 }
               },
@@ -6471,11 +6544,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1145,
+                  "line": 1146,
                   "column": 8
                 },
                 "end": {
-                  "line": 1145,
+                  "line": 1146,
                   "column": 32
                 }
               },
@@ -6494,11 +6567,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1147,
+                  "line": 1148,
                   "column": 8
                 },
                 "end": {
-                  "line": 1147,
+                  "line": 1148,
                   "column": 30
                 }
               },
@@ -6517,11 +6590,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1149,
+                  "line": 1150,
                   "column": 8
                 },
                 "end": {
-                  "line": 1149,
+                  "line": 1150,
                   "column": 24
                 }
               },
@@ -6540,11 +6613,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1153,
+                  "line": 1154,
                   "column": 8
                 },
                 "end": {
-                  "line": 1153,
+                  "line": 1154,
                   "column": 28
                 }
               },
@@ -6563,11 +6636,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 549,
+                  "line": 519,
                   "column": 8
                 },
                 "end": {
-                  "line": 549,
+                  "line": 519,
                   "column": 23
                 }
               },
@@ -6586,11 +6659,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 551,
+                  "line": 521,
                   "column": 8
                 },
                 "end": {
-                  "line": 551,
+                  "line": 521,
                   "column": 25
                 }
               },
@@ -6609,11 +6682,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 553,
+                  "line": 523,
                   "column": 8
                 },
                 "end": {
-                  "line": 553,
+                  "line": 523,
                   "column": 22
                 }
               },
@@ -6632,11 +6705,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 555,
+                  "line": 525,
                   "column": 8
                 },
                 "end": {
-                  "line": 555,
+                  "line": 525,
                   "column": 24
                 }
               },
@@ -6655,11 +6728,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 557,
+                  "line": 527,
                   "column": 8
                 },
                 "end": {
-                  "line": 557,
+                  "line": 527,
                   "column": 18
                 }
               },
@@ -6678,11 +6751,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 559,
+                  "line": 529,
                   "column": 8
                 },
                 "end": {
-                  "line": 559,
+                  "line": 529,
                   "column": 15
                 }
               },
@@ -6700,11 +6773,11 @@
               "privacy": "public",
               "sourceRange": {
                 "start": {
-                  "line": 55,
+                  "line": 56,
                   "column": 12
                 },
                 "end": {
-                  "line": 55,
+                  "line": 56,
                   "column": 24
                 }
               },
@@ -6719,11 +6792,11 @@
               "privacy": "public",
               "sourceRange": {
                 "start": {
-                  "line": 60,
+                  "line": 61,
                   "column": 12
                 },
                 "end": {
-                  "line": 63,
+                  "line": 64,
                   "column": 13
                 }
               },
@@ -6740,11 +6813,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 65,
+                  "line": 66,
                   "column": 12
                 },
                 "end": {
-                  "line": 65,
+                  "line": 66,
                   "column": 31
                 }
               },
@@ -6761,11 +6834,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2319,
+                  "line": 2320,
                   "column": 6
                 },
                 "end": {
-                  "line": 2344,
+                  "line": 2345,
                   "column": 7
                 }
               },
@@ -6790,11 +6863,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/template-stamp.html",
                 "start": {
-                  "line": 448,
+                  "line": 451,
                   "column": 6
                 },
                 "end": {
-                  "line": 453,
+                  "line": 456,
                   "column": 7
                 }
               },
@@ -6834,11 +6907,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/template-stamp.html",
                 "start": {
-                  "line": 462,
+                  "line": 465,
                   "column": 6
                 },
                 "end": {
-                  "line": 464,
+                  "line": 467,
                   "column": 7
                 }
               },
@@ -6869,11 +6942,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/template-stamp.html",
                 "start": {
-                  "line": 473,
+                  "line": 476,
                   "column": 6
                 },
                 "end": {
-                  "line": 475,
+                  "line": 478,
                   "column": 7
                 }
               },
@@ -6904,11 +6977,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 715,
+                  "line": 723,
                   "column": 6
                 },
                 "end": {
-                  "line": 723,
+                  "line": 731,
                   "column": 7
                 }
               },
@@ -6939,11 +7012,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 573,
+                  "line": 543,
                   "column": 6
                 },
                 "end": {
-                  "line": 613,
+                  "line": 577,
                   "column": 7
                 }
               },
@@ -6958,11 +7031,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1183,
+                  "line": 1184,
                   "column": 6
                 },
                 "end": {
-                  "line": 1187,
+                  "line": 1188,
                   "column": 7
                 }
               },
@@ -6983,11 +7056,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1196,
+                  "line": 1197,
                   "column": 6
                 },
                 "end": {
-                  "line": 1205,
+                  "line": 1206,
                   "column": 7
                 }
               },
@@ -7265,11 +7338,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1472,
+                  "line": 1473,
                   "column": 6
                 },
                 "end": {
-                  "line": 1476,
+                  "line": 1477,
                   "column": 7
                 }
               },
@@ -7291,11 +7364,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1435,
+                  "line": 1436,
                   "column": 6
                 },
                 "end": {
-                  "line": 1464,
+                  "line": 1465,
                   "column": 7
                 }
               },
@@ -7359,11 +7432,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1486,
+                  "line": 1487,
                   "column": 6
                 },
                 "end": {
-                  "line": 1490,
+                  "line": 1491,
                   "column": 7
                 }
               },
@@ -7415,11 +7488,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 78,
+                  "line": 79,
                   "column": 8
                 },
                 "end": {
-                  "line": 86,
+                  "line": 87,
                   "column": 9
                 }
               },
@@ -7433,11 +7506,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1625,
+                  "line": 1626,
                   "column": 6
                 },
                 "end": {
-                  "line": 1658,
+                  "line": 1659,
                   "column": 7
                 }
               },
@@ -7501,11 +7574,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1219,
+                  "line": 1220,
                   "column": 6
                 },
                 "end": {
-                  "line": 1227,
+                  "line": 1228,
                   "column": 7
                 }
               },
@@ -7536,11 +7609,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1236,
+                  "line": 1237,
                   "column": 6
                 },
                 "end": {
-                  "line": 1242,
+                  "line": 1243,
                   "column": 7
                 }
               },
@@ -7571,11 +7644,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1253,
+                  "line": 1254,
                   "column": 6
                 },
                 "end": {
-                  "line": 1256,
+                  "line": 1257,
                   "column": 7
                 }
               },
@@ -7605,11 +7678,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1266,
+                  "line": 1267,
                   "column": 6
                 },
                 "end": {
-                  "line": 1268,
+                  "line": 1269,
                   "column": 7
                 }
               },
@@ -7634,11 +7707,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1278,
+                  "line": 1279,
                   "column": 6
                 },
                 "end": {
-                  "line": 1280,
+                  "line": 1281,
                   "column": 7
                 }
               },
@@ -7663,11 +7736,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1290,
+                  "line": 1291,
                   "column": 6
                 },
                 "end": {
-                  "line": 1292,
+                  "line": 1293,
                   "column": 7
                 }
               },
@@ -7692,11 +7765,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1302,
+                  "line": 1303,
                   "column": 6
                 },
                 "end": {
-                  "line": 1304,
+                  "line": 1305,
                   "column": 7
                 }
               },
@@ -7721,11 +7794,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1336,
+                  "line": 1337,
                   "column": 6
                 },
                 "end": {
-                  "line": 1368,
+                  "line": 1369,
                   "column": 7
                 }
               },
@@ -7765,11 +7838,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1390,
+                  "line": 1391,
                   "column": 6
                 },
                 "end": {
-                  "line": 1398,
+                  "line": 1399,
                   "column": 7
                 }
               },
@@ -7800,11 +7873,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1500,
+                  "line": 1501,
                   "column": 6
                 },
                 "end": {
-                  "line": 1505,
+                  "line": 1506,
                   "column": 7
                 }
               },
@@ -7825,11 +7898,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1513,
+                  "line": 1514,
                   "column": 6
                 },
                 "end": {
-                  "line": 1524,
+                  "line": 1525,
                   "column": 7
                 }
               },
@@ -7844,11 +7917,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1538,
+                  "line": 1539,
                   "column": 6
                 },
                 "end": {
-                  "line": 1551,
+                  "line": 1552,
                   "column": 7
                 }
               },
@@ -7863,11 +7936,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 660,
+                  "line": 668,
                   "column": 6
                 },
                 "end": {
-                  "line": 669,
+                  "line": 677,
                   "column": 7
                 }
               },
@@ -7882,11 +7955,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1578,
+                  "line": 1579,
                   "column": 6
                 },
                 "end": {
-                  "line": 1589,
+                  "line": 1590,
                   "column": 7
                 }
               },
@@ -7912,11 +7985,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1669,
+                  "line": 1670,
                   "column": 6
                 },
                 "end": {
-                  "line": 1679,
+                  "line": 1680,
                   "column": 7
                 }
               },
@@ -7947,11 +8020,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1689,
+                  "line": 1690,
                   "column": 6
                 },
                 "end": {
-                  "line": 1694,
+                  "line": 1695,
                   "column": 7
                 }
               },
@@ -7977,11 +8050,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1705,
+                  "line": 1706,
                   "column": 6
                 },
                 "end": {
-                  "line": 1710,
+                  "line": 1711,
                   "column": 7
                 }
               },
@@ -7997,16 +8070,16 @@
             },
             {
               "name": "notifySplices",
-              "description": "Notify that an array has changed.\n\nExample:\n\n    this.items = [ {name: 'Jim'}, {name: 'Todd'}, {name: 'Bill'} ];\n    ...\n    this.items.splice(1, 1, {name: 'Sam'});\n    this.items.push({name: 'Bob'});\n    this.notifySplices('items', [\n      { index: 1, removed: [{name: 'Todd'}], addedCount: 1, obect: this.items, type: 'splice' },\n      { index: 3, removed: [], addedCount: 1, object: this.items, type: 'splice'}\n    ]);",
+              "description": "Notify that an array has changed.\n\nExample:\n\n    this.items = [ {name: 'Jim'}, {name: 'Todd'}, {name: 'Bill'} ];\n    ...\n    this.items.splice(1, 1, {name: 'Sam'});\n    this.items.push({name: 'Bob'});\n    this.notifySplices('items', [\n      { index: 1, removed: [{name: 'Todd'}], addedCount: 1, object: this.items, type: 'splice' },\n      { index: 3, removed: [], addedCount: 1, object: this.items, type: 'splice'}\n    ]);",
               "privacy": "public",
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1741,
+                  "line": 1742,
                   "column": 6
                 },
                 "end": {
-                  "line": 1745,
+                  "line": 1746,
                   "column": 7
                 }
               },
@@ -8032,11 +8105,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1766,
+                  "line": 1767,
                   "column": 6
                 },
                 "end": {
-                  "line": 1768,
+                  "line": 1769,
                   "column": 7
                 }
               },
@@ -8066,11 +8139,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1790,
+                  "line": 1791,
                   "column": 6
                 },
                 "end": {
-                  "line": 1800,
+                  "line": 1801,
                   "column": 7
                 }
               },
@@ -8101,11 +8174,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1816,
+                  "line": 1817,
                   "column": 6
                 },
                 "end": {
-                  "line": 1825,
+                  "line": 1826,
                   "column": 7
                 }
               },
@@ -8133,11 +8206,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1840,
+                  "line": 1841,
                   "column": 6
                 },
                 "end": {
-                  "line": 1849,
+                  "line": 1850,
                   "column": 7
                 }
               },
@@ -8162,11 +8235,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1868,
+                  "line": 1869,
                   "column": 6
                 },
                 "end": {
-                  "line": 1885,
+                  "line": 1886,
                   "column": 7
                 }
               },
@@ -8204,11 +8277,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1900,
+                  "line": 1901,
                   "column": 6
                 },
                 "end": {
-                  "line": 1909,
+                  "line": 1910,
                   "column": 7
                 }
               },
@@ -8233,11 +8306,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1925,
+                  "line": 1926,
                   "column": 6
                 },
                 "end": {
-                  "line": 1933,
+                  "line": 1934,
                   "column": 7
                 }
               },
@@ -8265,11 +8338,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1947,
+                  "line": 1948,
                   "column": 6
                 },
                 "end": {
-                  "line": 1964,
+                  "line": 1965,
                   "column": 7
                 }
               },
@@ -8295,11 +8368,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1976,
+                  "line": 1977,
                   "column": 6
                 },
                 "end": {
-                  "line": 1983,
+                  "line": 1984,
                   "column": 7
                 }
               },
@@ -8325,11 +8398,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1996,
+                  "line": 1997,
                   "column": 6
                 },
                 "end": {
-                  "line": 2006,
+                  "line": 2007,
                   "column": 7
                 }
               },
@@ -8360,11 +8433,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2018,
+                  "line": 2019,
                   "column": 6
                 },
                 "end": {
-                  "line": 2024,
+                  "line": 2025,
                   "column": 7
                 }
               },
@@ -8390,11 +8463,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2034,
+                  "line": 2035,
                   "column": 6
                 },
                 "end": {
-                  "line": 2042,
+                  "line": 2043,
                   "column": 7
                 }
               },
@@ -8415,11 +8488,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2052,
+                  "line": 2053,
                   "column": 6
                 },
                 "end": {
-                  "line": 2065,
+                  "line": 2066,
                   "column": 7
                 }
               },
@@ -8440,11 +8513,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2078,
+                  "line": 2079,
                   "column": 6
                 },
                 "end": {
-                  "line": 2084,
+                  "line": 2085,
                   "column": 7
                 }
               },
@@ -8475,11 +8548,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2254,
+                  "line": 2255,
                   "column": 6
                 },
                 "end": {
-                  "line": 2277,
+                  "line": 2278,
                   "column": 7
                 }
               },
@@ -8509,11 +8582,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2354,
+                  "line": 2355,
                   "column": 6
                 },
                 "end": {
-                  "line": 2375,
+                  "line": 2376,
                   "column": 7
                 }
               },
@@ -8533,11 +8606,11 @@
               "privacy": "private",
               "sourceRange": {
                 "start": {
-                  "line": 70,
+                  "line": 71,
                   "column": 8
                 },
                 "end": {
-                  "line": 72,
+                  "line": 73,
                   "column": 9
                 }
               },
@@ -8551,11 +8624,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 636,
+                  "line": 644,
                   "column": 6
                 },
                 "end": {
-                  "line": 636,
+                  "line": 644,
                   "column": 31
                 }
               },
@@ -8570,11 +8643,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 683,
+                  "line": 691,
                   "column": 6
                 },
                 "end": {
-                  "line": 699,
+                  "line": 707,
                   "column": 7
                 }
               },
@@ -8599,11 +8672,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 742,
+                  "line": 750,
                   "column": 6
                 },
                 "end": {
-                  "line": 746,
+                  "line": 754,
                   "column": 7
                 }
               },
@@ -8624,11 +8697,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 759,
+                  "line": 767,
                   "column": 6
                 },
                 "end": {
-                  "line": 764,
+                  "line": 772,
                   "column": 7
                 }
               },
@@ -8657,11 +8730,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 88,
+                  "line": 89,
                   "column": 8
                 },
                 "end": {
-                  "line": 99,
+                  "line": 100,
                   "column": 9
                 }
               },
@@ -8684,11 +8757,11 @@
               "privacy": "public",
               "sourceRange": {
                 "start": {
-                  "line": 101,
+                  "line": 102,
                   "column": 8
                 },
                 "end": {
-                  "line": 103,
+                  "line": 104,
                   "column": 9
                 }
               },
@@ -8738,11 +8811,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 775,
+                  "line": 783,
                   "column": 6
                 },
                 "end": {
-                  "line": 778,
+                  "line": 786,
                   "column": 7
                 }
               },
@@ -8767,11 +8840,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2394,
+                  "line": 2395,
                   "column": 6
                 },
                 "end": {
-                  "line": 2408,
+                  "line": 2409,
                   "column": 7
                 }
               },
@@ -8810,7 +8883,7 @@
                   "column": 6
                 },
                 "end": {
-                  "line": 291,
+                  "line": 294,
                   "column": 7
                 }
               },
@@ -8841,11 +8914,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2479,
+                  "line": 2482,
                   "column": 6
                 },
                 "end": {
-                  "line": 2489,
+                  "line": 2492,
                   "column": 7
                 }
               },
@@ -8880,11 +8953,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/template-stamp.html",
                 "start": {
-                  "line": 329,
+                  "line": 332,
                   "column": 6
                 },
                 "end": {
-                  "line": 338,
+                  "line": 341,
                   "column": 7
                 }
               },
@@ -8919,11 +8992,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2427,
+                  "line": 2430,
                   "column": 6
                 },
                 "end": {
-                  "line": 2463,
+                  "line": 2466,
                   "column": 7
                 }
               },
@@ -8945,10 +9018,14 @@
                   "description": "Node metadata for current template node"
                 },
                 {
-                  "name": "name"
+                  "name": "name",
+                  "type": "string",
+                  "description": "Attribute name"
                 },
                 {
-                  "name": "value"
+                  "name": "value",
+                  "type": "string",
+                  "description": "Attribute value"
                 }
               ],
               "return": {
@@ -8964,11 +9041,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/template-stamp.html",
                 "start": {
-                  "line": 384,
+                  "line": 387,
                   "column": 6
                 },
                 "end": {
-                  "line": 387,
+                  "line": 390,
                   "column": 7
                 }
               },
@@ -9012,11 +9089,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2123,
+                  "line": 2124,
                   "column": 6
                 },
                 "end": {
-                  "line": 2125,
+                  "line": 2126,
                   "column": 7
                 }
               },
@@ -9047,11 +9124,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2136,
+                  "line": 2137,
                   "column": 6
                 },
                 "end": {
-                  "line": 2138,
+                  "line": 2139,
                   "column": 7
                 }
               },
@@ -9082,11 +9159,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2152,
+                  "line": 2153,
                   "column": 6
                 },
                 "end": {
-                  "line": 2154,
+                  "line": 2155,
                   "column": 7
                 }
               },
@@ -9112,11 +9189,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2163,
+                  "line": 2164,
                   "column": 6
                 },
                 "end": {
-                  "line": 2165,
+                  "line": 2166,
                   "column": 7
                 }
               },
@@ -9137,11 +9214,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2182,
+                  "line": 2183,
                   "column": 6
                 },
                 "end": {
-                  "line": 2184,
+                  "line": 2185,
                   "column": 7
                 }
               },
@@ -9167,11 +9244,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2193,
+                  "line": 2194,
                   "column": 6
                 },
                 "end": {
-                  "line": 2195,
+                  "line": 2196,
                   "column": 7
                 }
               },
@@ -9192,11 +9269,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2210,
+                  "line": 2211,
                   "column": 6
                 },
                 "end": {
-                  "line": 2212,
+                  "line": 2213,
                   "column": 7
                 }
               },
@@ -9227,11 +9304,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2226,
+                  "line": 2227,
                   "column": 6
                 },
                 "end": {
-                  "line": 2228,
+                  "line": 2229,
                   "column": 7
                 }
               },
@@ -9256,11 +9333,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2291,
+                  "line": 2292,
                   "column": 6
                 },
                 "end": {
-                  "line": 2297,
+                  "line": 2298,
                   "column": 7
                 }
               },
@@ -9291,11 +9368,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2524,
+                  "line": 2527,
                   "column": 6
                 },
                 "end": {
-                  "line": 2589,
+                  "line": 2592,
                   "column": 7
                 }
               },
@@ -9325,11 +9402,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2605,
+                  "line": 2608,
                   "column": 6
                 },
                 "end": {
-                  "line": 2622,
+                  "line": 2625,
                   "column": 7
                 }
               },
@@ -9379,16 +9456,85 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 471,
+                  "line": 441,
                   "column": 6
                 },
                 "end": {
-                  "line": 475,
+                  "line": 445,
                   "column": 7
                 }
               },
               "metadata": {},
               "params": [],
+              "inheritedFrom": "Polymer.ElementMixin"
+            },
+            {
+              "name": "_processStyleText",
+              "description": "Gather style text for the template",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+                "start": {
+                  "line": 588,
+                  "column": 6
+                },
+                "end": {
+                  "line": 591,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "is",
+                  "type": "string",
+                  "description": "Tag name for this element"
+                },
+                {
+                  "name": "template",
+                  "type": "!HTMLTemplateElement",
+                  "description": "Template to process"
+                },
+                {
+                  "name": "baseURI",
+                  "type": "string",
+                  "description": "Base URI to rebase CSS paths against"
+                }
+              ],
+              "return": {
+                "type": "string",
+                "desc": "The combined CSS text"
+              },
+              "inheritedFrom": "Polymer.ElementMixin"
+            },
+            {
+              "name": "_finalizeTemplate",
+              "description": "Configures an element `proto` to function with a given `template`.\nThe element name `is` and extends `ext` must be specified for ShadyCSS\nstyle scoping.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+                "start": {
+                  "line": 602,
+                  "column": 6
+                },
+                "end": {
+                  "line": 621,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "is",
+                  "type": "string",
+                  "description": "Tag name (or type extension name) for this element"
+                },
+                {
+                  "name": "ext",
+                  "type": "string=",
+                  "description": "For type extensions, the tag name that was extended"
+                }
+              ],
               "inheritedFrom": "Polymer.ElementMixin"
             }
           ],
@@ -9396,11 +9542,11 @@
           "metadata": {},
           "sourceRange": {
             "start": {
-              "line": 43,
+              "line": 44,
               "column": 6
             },
             "end": {
-              "line": 105,
+              "line": 106,
               "column": 7
             }
           },
@@ -9413,11 +9559,11 @@
               "description": "JS Path of the property in the item used for filtering the data.",
               "sourceRange": {
                 "start": {
-                  "line": 55,
+                  "line": 56,
                   "column": 12
                 },
                 "end": {
-                  "line": 55,
+                  "line": 56,
                   "column": 24
                 }
               },
@@ -9429,11 +9575,11 @@
               "description": "Current filter value.",
               "sourceRange": {
                 "start": {
-                  "line": 60,
+                  "line": 61,
                   "column": 12
                 },
                 "end": {
-                  "line": 63,
+                  "line": 64,
                   "column": 13
                 }
               },
@@ -9460,11 +9606,11 @@
               "range": {
                 "file": "vaadin-grid-filter.html",
                 "start": {
-                  "line": 20,
+                  "line": 21,
                   "column": 4
                 },
                 "end": {
-                  "line": 22,
+                  "line": 23,
                   "column": 11
                 }
               }
@@ -9747,7 +9893,7 @@
               "metadata": {
                 "polymer": {}
               },
-              "defaultValue": "\"52px\""
+              "defaultValue": "\"56px\""
             },
             {
               "name": "flexGrow",
@@ -12602,7 +12748,7 @@
                   "column": 4
                 },
                 "end": {
-                  "line": 41,
+                  "line": 43,
                   "column": 5
                 }
               },
@@ -12621,11 +12767,11 @@
               "sourceRange": {
                 "file": "vaadin-grid-cell-click-mixin.html",
                 "start": {
-                  "line": 43,
+                  "line": 45,
                   "column": 4
                 },
                 "end": {
-                  "line": 53,
+                  "line": 55,
                   "column": 5
                 }
               },
@@ -12942,7 +13088,7 @@
                   "column": 4
                 },
                 "end": {
-                  "line": 49,
+                  "line": 48,
                   "column": 5
                 }
               },
@@ -12950,8 +13096,8 @@
               "params": [
                 {
                   "name": "item",
-                  "type": "(number|Object)",
-                  "description": "The item index or the item object"
+                  "type": "Object",
+                  "description": "The item object"
                 }
               ],
               "inheritedFrom": "Vaadin.Grid.SelectionMixin"
@@ -12963,11 +13109,11 @@
               "sourceRange": {
                 "file": "vaadin-grid-selection-mixin.html",
                 "start": {
-                  "line": 57,
+                  "line": 56,
                   "column": 4
                 },
                 "end": {
-                  "line": 63,
+                  "line": 61,
                   "column": 5
                 }
               },
@@ -12975,8 +13121,8 @@
               "params": [
                 {
                   "name": "item",
-                  "type": "(number|Object)",
-                  "description": "The item index or the item object"
+                  "type": "Object",
+                  "description": "The item object"
                 }
               ],
               "inheritedFrom": "Vaadin.Grid.SelectionMixin"
@@ -12988,11 +13134,11 @@
               "sourceRange": {
                 "file": "vaadin-grid-selection-mixin.html",
                 "start": {
-                  "line": 71,
+                  "line": 69,
                   "column": 4
                 },
                 "end": {
-                  "line": 79,
+                  "line": 76,
                   "column": 5
                 }
               },
@@ -13000,33 +13146,8 @@
               "params": [
                 {
                   "name": "item",
-                  "type": "(number|Object)",
-                  "description": "The item index or the item object"
-                }
-              ],
-              "inheritedFrom": "Vaadin.Grid.SelectionMixin"
-            },
-            {
-              "name": "_takeItem",
-              "description": "Returns item object itself or by the item index.",
-              "privacy": "protected",
-              "sourceRange": {
-                "file": "vaadin-grid-selection-mixin.html",
-                "start": {
-                  "line": 86,
-                  "column": 4
-                },
-                "end": {
-                  "line": 91,
-                  "column": 5
-                }
-              },
-              "metadata": {},
-              "params": [
-                {
-                  "name": "item",
-                  "type": "(number|Object)",
-                  "description": "The item index or the item object"
+                  "type": "Object",
+                  "description": "The item object"
                 }
               ],
               "inheritedFrom": "Vaadin.Grid.SelectionMixin"
@@ -13038,11 +13159,11 @@
               "sourceRange": {
                 "file": "vaadin-grid-selection-mixin.html",
                 "start": {
-                  "line": 93,
+                  "line": 78,
                   "column": 4
                 },
                 "end": {
-                  "line": 99,
+                  "line": 84,
                   "column": 5
                 }
               },
@@ -13061,11 +13182,11 @@
               "sourceRange": {
                 "file": "vaadin-grid-selection-mixin.html",
                 "start": {
-                  "line": 101,
+                  "line": 86,
                   "column": 4
                 },
                 "end": {
-                  "line": 110,
+                  "line": 95,
                   "column": 5
                 }
               },
@@ -13426,7 +13547,7 @@
                   "column": 4
                 },
                 "end": {
-                  "line": 309,
+                  "line": 313,
                   "column": 5
                 }
               },
@@ -13448,11 +13569,11 @@
               "sourceRange": {
                 "file": "vaadin-grid-keyboard-navigation-mixin.html",
                 "start": {
-                  "line": 311,
+                  "line": 315,
                   "column": 4
                 },
                 "end": {
-                  "line": 318,
+                  "line": 322,
                   "column": 5
                 }
               },
@@ -13471,11 +13592,11 @@
               "sourceRange": {
                 "file": "vaadin-grid-keyboard-navigation-mixin.html",
                 "start": {
-                  "line": 320,
+                  "line": 324,
                   "column": 4
                 },
                 "end": {
-                  "line": 358,
+                  "line": 362,
                   "column": 5
                 }
               },
@@ -13497,11 +13618,11 @@
               "sourceRange": {
                 "file": "vaadin-grid-keyboard-navigation-mixin.html",
                 "start": {
-                  "line": 360,
+                  "line": 364,
                   "column": 4
                 },
                 "end": {
-                  "line": 378,
+                  "line": 382,
                   "column": 5
                 }
               },
@@ -13523,11 +13644,11 @@
               "sourceRange": {
                 "file": "vaadin-grid-keyboard-navigation-mixin.html",
                 "start": {
-                  "line": 380,
+                  "line": 384,
                   "column": 4
                 },
                 "end": {
-                  "line": 412,
+                  "line": 416,
                   "column": 5
                 }
               },
@@ -13546,11 +13667,11 @@
               "sourceRange": {
                 "file": "vaadin-grid-keyboard-navigation-mixin.html",
                 "start": {
-                  "line": 414,
+                  "line": 418,
                   "column": 4
                 },
                 "end": {
-                  "line": 425,
+                  "line": 429,
                   "column": 5
                 }
               },
@@ -13569,11 +13690,11 @@
               "sourceRange": {
                 "file": "vaadin-grid-keyboard-navigation-mixin.html",
                 "start": {
-                  "line": 427,
+                  "line": 431,
                   "column": 4
                 },
                 "end": {
-                  "line": 447,
+                  "line": 451,
                   "column": 5
                 }
               },
@@ -13592,11 +13713,11 @@
               "sourceRange": {
                 "file": "vaadin-grid-keyboard-navigation-mixin.html",
                 "start": {
-                  "line": 449,
+                  "line": 453,
                   "column": 4
                 },
                 "end": {
-                  "line": 452,
+                  "line": 456,
                   "column": 5
                 }
               },
@@ -13615,11 +13736,11 @@
               "sourceRange": {
                 "file": "vaadin-grid-keyboard-navigation-mixin.html",
                 "start": {
-                  "line": 454,
+                  "line": 458,
                   "column": 4
                 },
                 "end": {
-                  "line": 472,
+                  "line": 476,
                   "column": 5
                 }
               },
@@ -13638,11 +13759,11 @@
               "sourceRange": {
                 "file": "vaadin-grid-keyboard-navigation-mixin.html",
                 "start": {
-                  "line": 474,
+                  "line": 478,
                   "column": 4
                 },
                 "end": {
-                  "line": 480,
+                  "line": 484,
                   "column": 5
                 }
               },
@@ -13661,11 +13782,11 @@
               "sourceRange": {
                 "file": "vaadin-grid-keyboard-navigation-mixin.html",
                 "start": {
-                  "line": 482,
+                  "line": 486,
                   "column": 4
                 },
                 "end": {
-                  "line": 484,
+                  "line": 488,
                   "column": 5
                 }
               },
@@ -13684,11 +13805,11 @@
               "sourceRange": {
                 "file": "vaadin-grid-keyboard-navigation-mixin.html",
                 "start": {
-                  "line": 486,
+                  "line": 490,
                   "column": 4
                 },
                 "end": {
-                  "line": 491,
+                  "line": 495,
                   "column": 5
                 }
               },
@@ -13707,11 +13828,11 @@
               "sourceRange": {
                 "file": "vaadin-grid-keyboard-navigation-mixin.html",
                 "start": {
-                  "line": 493,
+                  "line": 497,
                   "column": 4
                 },
                 "end": {
-                  "line": 504,
+                  "line": 508,
                   "column": 5
                 }
               },
@@ -13733,11 +13854,11 @@
               "sourceRange": {
                 "file": "vaadin-grid-keyboard-navigation-mixin.html",
                 "start": {
-                  "line": 506,
+                  "line": 510,
                   "column": 4
                 },
                 "end": {
-                  "line": 514,
+                  "line": 518,
                   "column": 5
                 }
               },
@@ -13759,11 +13880,11 @@
               "sourceRange": {
                 "file": "vaadin-grid-keyboard-navigation-mixin.html",
                 "start": {
-                  "line": 516,
+                  "line": 520,
                   "column": 4
                 },
                 "end": {
-                  "line": 535,
+                  "line": 539,
                   "column": 5
                 }
               },
@@ -13778,11 +13899,11 @@
               "sourceRange": {
                 "file": "vaadin-grid-keyboard-navigation-mixin.html",
                 "start": {
-                  "line": 537,
+                  "line": 541,
                   "column": 4
                 },
                 "end": {
-                  "line": 577,
+                  "line": 581,
                   "column": 5
                 }
               },
@@ -13801,11 +13922,11 @@
               "sourceRange": {
                 "file": "vaadin-grid-keyboard-navigation-mixin.html",
                 "start": {
-                  "line": 579,
+                  "line": 583,
                   "column": 4
                 },
                 "end": {
-                  "line": 583,
+                  "line": 587,
                   "column": 5
                 }
               },
@@ -14608,17 +14729,17 @@
           ],
           "staticMethods": [
             {
-              "name": "includeStyle",
+              "name": "_includeStyle",
               "description": "",
-              "privacy": "public",
+              "privacy": "private",
               "sourceRange": {
                 "file": "bower_components/vaadin-themable-mixin/vaadin-themable-mixin.html",
                 "start": {
-                  "line": 40,
+                  "line": 46,
                   "column": 4
                 },
                 "end": {
-                  "line": 44,
+                  "line": 50,
                   "column": 5
                 }
               },
@@ -15478,11 +15599,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1151,
+              "line": 1152,
               "column": 8
             },
             "end": {
-              "line": 1151,
+              "line": 1152,
               "column": 27
             }
           },
@@ -15570,11 +15691,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1133,
+              "line": 1134,
               "column": 8
             },
             "end": {
-              "line": 1133,
+              "line": 1134,
               "column": 20
             }
           },
@@ -15593,11 +15714,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1135,
+              "line": 1136,
               "column": 8
             },
             "end": {
-              "line": 1135,
+              "line": 1136,
               "column": 27
             }
           },
@@ -15616,11 +15737,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1137,
+              "line": 1138,
               "column": 8
             },
             "end": {
-              "line": 1137,
+              "line": 1138,
               "column": 23
             }
           },
@@ -15708,11 +15829,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1115,
+              "line": 1116,
               "column": 8
             },
             "end": {
-              "line": 1115,
+              "line": 1116,
               "column": 32
             }
           },
@@ -15731,11 +15852,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1117,
+              "line": 1118,
               "column": 8
             },
             "end": {
-              "line": 1117,
+              "line": 1118,
               "column": 34
             }
           },
@@ -15754,11 +15875,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1119,
+              "line": 1120,
               "column": 8
             },
             "end": {
-              "line": 1119,
+              "line": 1120,
               "column": 28
             }
           },
@@ -15777,11 +15898,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1121,
+              "line": 1122,
               "column": 8
             },
             "end": {
-              "line": 1121,
+              "line": 1122,
               "column": 31
             }
           },
@@ -15800,11 +15921,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1123,
+              "line": 1124,
               "column": 8
             },
             "end": {
-              "line": 1123,
+              "line": 1124,
               "column": 28
             }
           },
@@ -15823,11 +15944,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1125,
+              "line": 1126,
               "column": 8
             },
             "end": {
-              "line": 1125,
+              "line": 1126,
               "column": 35
             }
           },
@@ -15846,11 +15967,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1127,
+              "line": 1128,
               "column": 8
             },
             "end": {
-              "line": 1127,
+              "line": 1128,
               "column": 24
             }
           },
@@ -15869,11 +15990,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1129,
+              "line": 1130,
               "column": 8
             },
             "end": {
-              "line": 1129,
+              "line": 1130,
               "column": 24
             }
           },
@@ -15892,11 +16013,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1131,
+              "line": 1132,
               "column": 8
             },
             "end": {
-              "line": 1131,
+              "line": 1132,
               "column": 38
             }
           },
@@ -15915,11 +16036,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1139,
+              "line": 1140,
               "column": 8
             },
             "end": {
-              "line": 1139,
+              "line": 1140,
               "column": 30
             }
           },
@@ -15938,11 +16059,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1141,
+              "line": 1142,
               "column": 8
             },
             "end": {
-              "line": 1141,
+              "line": 1142,
               "column": 30
             }
           },
@@ -15961,11 +16082,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1143,
+              "line": 1144,
               "column": 8
             },
             "end": {
-              "line": 1143,
+              "line": 1144,
               "column": 29
             }
           },
@@ -15984,11 +16105,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1145,
+              "line": 1146,
               "column": 8
             },
             "end": {
-              "line": 1145,
+              "line": 1146,
               "column": 32
             }
           },
@@ -16007,11 +16128,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1147,
+              "line": 1148,
               "column": 8
             },
             "end": {
-              "line": 1147,
+              "line": 1148,
               "column": 30
             }
           },
@@ -16030,11 +16151,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1149,
+              "line": 1150,
               "column": 8
             },
             "end": {
-              "line": 1149,
+              "line": 1150,
               "column": 24
             }
           },
@@ -16053,11 +16174,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1153,
+              "line": 1154,
               "column": 8
             },
             "end": {
-              "line": 1153,
+              "line": 1154,
               "column": 28
             }
           },
@@ -16076,11 +16197,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/element-mixin.html",
             "start": {
-              "line": 549,
+              "line": 519,
               "column": 8
             },
             "end": {
-              "line": 549,
+              "line": 519,
               "column": 23
             }
           },
@@ -16099,11 +16220,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/element-mixin.html",
             "start": {
-              "line": 551,
+              "line": 521,
               "column": 8
             },
             "end": {
-              "line": 551,
+              "line": 521,
               "column": 25
             }
           },
@@ -16122,11 +16243,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/element-mixin.html",
             "start": {
-              "line": 553,
+              "line": 523,
               "column": 8
             },
             "end": {
-              "line": 553,
+              "line": 523,
               "column": 22
             }
           },
@@ -16145,11 +16266,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/element-mixin.html",
             "start": {
-              "line": 555,
+              "line": 525,
               "column": 8
             },
             "end": {
-              "line": 555,
+              "line": 525,
               "column": 24
             }
           },
@@ -16168,11 +16289,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/element-mixin.html",
             "start": {
-              "line": 557,
+              "line": 527,
               "column": 8
             },
             "end": {
-              "line": 557,
+              "line": 527,
               "column": 18
             }
           },
@@ -16191,11 +16312,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/element-mixin.html",
             "start": {
-              "line": 559,
+              "line": 529,
               "column": 8
             },
             "end": {
-              "line": 559,
+              "line": 529,
               "column": 15
             }
           },
@@ -16330,11 +16451,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 2319,
+              "line": 2320,
               "column": 6
             },
             "end": {
-              "line": 2344,
+              "line": 2345,
               "column": 7
             }
           },
@@ -16359,11 +16480,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/template-stamp.html",
             "start": {
-              "line": 448,
+              "line": 451,
               "column": 6
             },
             "end": {
-              "line": 453,
+              "line": 456,
               "column": 7
             }
           },
@@ -16403,11 +16524,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/template-stamp.html",
             "start": {
-              "line": 462,
+              "line": 465,
               "column": 6
             },
             "end": {
-              "line": 464,
+              "line": 467,
               "column": 7
             }
           },
@@ -16438,11 +16559,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/template-stamp.html",
             "start": {
-              "line": 473,
+              "line": 476,
               "column": 6
             },
             "end": {
-              "line": 475,
+              "line": 478,
               "column": 7
             }
           },
@@ -16473,11 +16594,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/element-mixin.html",
             "start": {
-              "line": 715,
+              "line": 723,
               "column": 6
             },
             "end": {
-              "line": 723,
+              "line": 731,
               "column": 7
             }
           },
@@ -16508,11 +16629,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/element-mixin.html",
             "start": {
-              "line": 573,
+              "line": 543,
               "column": 6
             },
             "end": {
-              "line": 613,
+              "line": 577,
               "column": 7
             }
           },
@@ -16527,11 +16648,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1183,
+              "line": 1184,
               "column": 6
             },
             "end": {
-              "line": 1187,
+              "line": 1188,
               "column": 7
             }
           },
@@ -16552,11 +16673,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1196,
+              "line": 1197,
               "column": 6
             },
             "end": {
-              "line": 1205,
+              "line": 1206,
               "column": 7
             }
           },
@@ -16834,11 +16955,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1472,
+              "line": 1473,
               "column": 6
             },
             "end": {
-              "line": 1476,
+              "line": 1477,
               "column": 7
             }
           },
@@ -16860,11 +16981,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1435,
+              "line": 1436,
               "column": 6
             },
             "end": {
-              "line": 1464,
+              "line": 1465,
               "column": 7
             }
           },
@@ -16928,11 +17049,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1486,
+              "line": 1487,
               "column": 6
             },
             "end": {
-              "line": 1490,
+              "line": 1491,
               "column": 7
             }
           },
@@ -17002,11 +17123,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1625,
+              "line": 1626,
               "column": 6
             },
             "end": {
-              "line": 1658,
+              "line": 1659,
               "column": 7
             }
           },
@@ -17070,11 +17191,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1219,
+              "line": 1220,
               "column": 6
             },
             "end": {
-              "line": 1227,
+              "line": 1228,
               "column": 7
             }
           },
@@ -17105,11 +17226,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1236,
+              "line": 1237,
               "column": 6
             },
             "end": {
-              "line": 1242,
+              "line": 1243,
               "column": 7
             }
           },
@@ -17140,11 +17261,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1253,
+              "line": 1254,
               "column": 6
             },
             "end": {
-              "line": 1256,
+              "line": 1257,
               "column": 7
             }
           },
@@ -17174,11 +17295,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1266,
+              "line": 1267,
               "column": 6
             },
             "end": {
-              "line": 1268,
+              "line": 1269,
               "column": 7
             }
           },
@@ -17203,11 +17324,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1278,
+              "line": 1279,
               "column": 6
             },
             "end": {
-              "line": 1280,
+              "line": 1281,
               "column": 7
             }
           },
@@ -17232,11 +17353,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1290,
+              "line": 1291,
               "column": 6
             },
             "end": {
-              "line": 1292,
+              "line": 1293,
               "column": 7
             }
           },
@@ -17261,11 +17382,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1302,
+              "line": 1303,
               "column": 6
             },
             "end": {
-              "line": 1304,
+              "line": 1305,
               "column": 7
             }
           },
@@ -17290,11 +17411,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1336,
+              "line": 1337,
               "column": 6
             },
             "end": {
-              "line": 1368,
+              "line": 1369,
               "column": 7
             }
           },
@@ -17334,11 +17455,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1390,
+              "line": 1391,
               "column": 6
             },
             "end": {
-              "line": 1398,
+              "line": 1399,
               "column": 7
             }
           },
@@ -17369,11 +17490,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1500,
+              "line": 1501,
               "column": 6
             },
             "end": {
-              "line": 1505,
+              "line": 1506,
               "column": 7
             }
           },
@@ -17394,11 +17515,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1513,
+              "line": 1514,
               "column": 6
             },
             "end": {
-              "line": 1524,
+              "line": 1525,
               "column": 7
             }
           },
@@ -17413,11 +17534,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1538,
+              "line": 1539,
               "column": 6
             },
             "end": {
-              "line": 1551,
+              "line": 1552,
               "column": 7
             }
           },
@@ -17432,11 +17553,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/element-mixin.html",
             "start": {
-              "line": 660,
+              "line": 668,
               "column": 6
             },
             "end": {
-              "line": 669,
+              "line": 677,
               "column": 7
             }
           },
@@ -17451,11 +17572,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1578,
+              "line": 1579,
               "column": 6
             },
             "end": {
-              "line": 1589,
+              "line": 1590,
               "column": 7
             }
           },
@@ -17481,11 +17602,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1669,
+              "line": 1670,
               "column": 6
             },
             "end": {
-              "line": 1679,
+              "line": 1680,
               "column": 7
             }
           },
@@ -17516,11 +17637,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1689,
+              "line": 1690,
               "column": 6
             },
             "end": {
-              "line": 1694,
+              "line": 1695,
               "column": 7
             }
           },
@@ -17546,11 +17667,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1705,
+              "line": 1706,
               "column": 6
             },
             "end": {
-              "line": 1710,
+              "line": 1711,
               "column": 7
             }
           },
@@ -17566,16 +17687,16 @@
         },
         {
           "name": "notifySplices",
-          "description": "Notify that an array has changed.\n\nExample:\n\n    this.items = [ {name: 'Jim'}, {name: 'Todd'}, {name: 'Bill'} ];\n    ...\n    this.items.splice(1, 1, {name: 'Sam'});\n    this.items.push({name: 'Bob'});\n    this.notifySplices('items', [\n      { index: 1, removed: [{name: 'Todd'}], addedCount: 1, obect: this.items, type: 'splice' },\n      { index: 3, removed: [], addedCount: 1, object: this.items, type: 'splice'}\n    ]);",
+          "description": "Notify that an array has changed.\n\nExample:\n\n    this.items = [ {name: 'Jim'}, {name: 'Todd'}, {name: 'Bill'} ];\n    ...\n    this.items.splice(1, 1, {name: 'Sam'});\n    this.items.push({name: 'Bob'});\n    this.notifySplices('items', [\n      { index: 1, removed: [{name: 'Todd'}], addedCount: 1, object: this.items, type: 'splice' },\n      { index: 3, removed: [], addedCount: 1, object: this.items, type: 'splice'}\n    ]);",
           "privacy": "public",
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1741,
+              "line": 1742,
               "column": 6
             },
             "end": {
-              "line": 1745,
+              "line": 1746,
               "column": 7
             }
           },
@@ -17601,11 +17722,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1766,
+              "line": 1767,
               "column": 6
             },
             "end": {
-              "line": 1768,
+              "line": 1769,
               "column": 7
             }
           },
@@ -17635,11 +17756,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1790,
+              "line": 1791,
               "column": 6
             },
             "end": {
-              "line": 1800,
+              "line": 1801,
               "column": 7
             }
           },
@@ -17670,11 +17791,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1816,
+              "line": 1817,
               "column": 6
             },
             "end": {
-              "line": 1825,
+              "line": 1826,
               "column": 7
             }
           },
@@ -17702,11 +17823,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1840,
+              "line": 1841,
               "column": 6
             },
             "end": {
-              "line": 1849,
+              "line": 1850,
               "column": 7
             }
           },
@@ -17731,11 +17852,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1868,
+              "line": 1869,
               "column": 6
             },
             "end": {
-              "line": 1885,
+              "line": 1886,
               "column": 7
             }
           },
@@ -17773,11 +17894,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1900,
+              "line": 1901,
               "column": 6
             },
             "end": {
-              "line": 1909,
+              "line": 1910,
               "column": 7
             }
           },
@@ -17802,11 +17923,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1925,
+              "line": 1926,
               "column": 6
             },
             "end": {
-              "line": 1933,
+              "line": 1934,
               "column": 7
             }
           },
@@ -17834,11 +17955,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1947,
+              "line": 1948,
               "column": 6
             },
             "end": {
-              "line": 1964,
+              "line": 1965,
               "column": 7
             }
           },
@@ -17864,11 +17985,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1976,
+              "line": 1977,
               "column": 6
             },
             "end": {
-              "line": 1983,
+              "line": 1984,
               "column": 7
             }
           },
@@ -17894,11 +18015,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1996,
+              "line": 1997,
               "column": 6
             },
             "end": {
-              "line": 2006,
+              "line": 2007,
               "column": 7
             }
           },
@@ -17929,11 +18050,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 2018,
+              "line": 2019,
               "column": 6
             },
             "end": {
-              "line": 2024,
+              "line": 2025,
               "column": 7
             }
           },
@@ -17959,11 +18080,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 2034,
+              "line": 2035,
               "column": 6
             },
             "end": {
-              "line": 2042,
+              "line": 2043,
               "column": 7
             }
           },
@@ -17984,11 +18105,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 2052,
+              "line": 2053,
               "column": 6
             },
             "end": {
-              "line": 2065,
+              "line": 2066,
               "column": 7
             }
           },
@@ -18009,11 +18130,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 2078,
+              "line": 2079,
               "column": 6
             },
             "end": {
-              "line": 2084,
+              "line": 2085,
               "column": 7
             }
           },
@@ -18044,11 +18165,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 2254,
+              "line": 2255,
               "column": 6
             },
             "end": {
-              "line": 2277,
+              "line": 2278,
               "column": 7
             }
           },
@@ -18078,11 +18199,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 2354,
+              "line": 2355,
               "column": 6
             },
             "end": {
-              "line": 2375,
+              "line": 2376,
               "column": 7
             }
           },
@@ -18103,11 +18224,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/element-mixin.html",
             "start": {
-              "line": 625,
+              "line": 633,
               "column": 6
             },
             "end": {
-              "line": 630,
+              "line": 638,
               "column": 7
             }
           },
@@ -18122,11 +18243,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/element-mixin.html",
             "start": {
-              "line": 636,
+              "line": 644,
               "column": 6
             },
             "end": {
-              "line": 636,
+              "line": 644,
               "column": 31
             }
           },
@@ -18141,11 +18262,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/element-mixin.html",
             "start": {
-              "line": 683,
+              "line": 691,
               "column": 6
             },
             "end": {
-              "line": 699,
+              "line": 707,
               "column": 7
             }
           },
@@ -18170,11 +18291,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/element-mixin.html",
             "start": {
-              "line": 742,
+              "line": 750,
               "column": 6
             },
             "end": {
-              "line": 746,
+              "line": 754,
               "column": 7
             }
           },
@@ -18195,11 +18316,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/element-mixin.html",
             "start": {
-              "line": 759,
+              "line": 767,
               "column": 6
             },
             "end": {
-              "line": 764,
+              "line": 772,
               "column": 7
             }
           },
@@ -18320,11 +18441,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/element-mixin.html",
             "start": {
-              "line": 775,
+              "line": 783,
               "column": 6
             },
             "end": {
-              "line": 778,
+              "line": 786,
               "column": 7
             }
           },
@@ -18349,11 +18470,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 2394,
+              "line": 2395,
               "column": 6
             },
             "end": {
-              "line": 2408,
+              "line": 2409,
               "column": 7
             }
           },
@@ -18392,7 +18513,7 @@
               "column": 6
             },
             "end": {
-              "line": 291,
+              "line": 294,
               "column": 7
             }
           },
@@ -18423,11 +18544,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 2479,
+              "line": 2482,
               "column": 6
             },
             "end": {
-              "line": 2489,
+              "line": 2492,
               "column": 7
             }
           },
@@ -18462,11 +18583,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/template-stamp.html",
             "start": {
-              "line": 329,
+              "line": 332,
               "column": 6
             },
             "end": {
-              "line": 338,
+              "line": 341,
               "column": 7
             }
           },
@@ -18501,11 +18622,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 2427,
+              "line": 2430,
               "column": 6
             },
             "end": {
-              "line": 2463,
+              "line": 2466,
               "column": 7
             }
           },
@@ -18527,10 +18648,14 @@
               "description": "Node metadata for current template node"
             },
             {
-              "name": "name"
+              "name": "name",
+              "type": "string",
+              "description": "Attribute name"
             },
             {
-              "name": "value"
+              "name": "value",
+              "type": "string",
+              "description": "Attribute value"
             }
           ],
           "return": {
@@ -18546,11 +18671,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/template-stamp.html",
             "start": {
-              "line": 384,
+              "line": 387,
               "column": 6
             },
             "end": {
-              "line": 387,
+              "line": 390,
               "column": 7
             }
           },
@@ -18594,11 +18719,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 2123,
+              "line": 2124,
               "column": 6
             },
             "end": {
-              "line": 2125,
+              "line": 2126,
               "column": 7
             }
           },
@@ -18629,11 +18754,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 2136,
+              "line": 2137,
               "column": 6
             },
             "end": {
-              "line": 2138,
+              "line": 2139,
               "column": 7
             }
           },
@@ -18664,11 +18789,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 2152,
+              "line": 2153,
               "column": 6
             },
             "end": {
-              "line": 2154,
+              "line": 2155,
               "column": 7
             }
           },
@@ -18694,11 +18819,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 2163,
+              "line": 2164,
               "column": 6
             },
             "end": {
-              "line": 2165,
+              "line": 2166,
               "column": 7
             }
           },
@@ -18719,11 +18844,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 2182,
+              "line": 2183,
               "column": 6
             },
             "end": {
-              "line": 2184,
+              "line": 2185,
               "column": 7
             }
           },
@@ -18749,11 +18874,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 2193,
+              "line": 2194,
               "column": 6
             },
             "end": {
-              "line": 2195,
+              "line": 2196,
               "column": 7
             }
           },
@@ -18774,11 +18899,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 2210,
+              "line": 2211,
               "column": 6
             },
             "end": {
-              "line": 2212,
+              "line": 2213,
               "column": 7
             }
           },
@@ -18809,11 +18934,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 2226,
+              "line": 2227,
               "column": 6
             },
             "end": {
-              "line": 2228,
+              "line": 2229,
               "column": 7
             }
           },
@@ -18838,11 +18963,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 2291,
+              "line": 2292,
               "column": 6
             },
             "end": {
-              "line": 2297,
+              "line": 2298,
               "column": 7
             }
           },
@@ -18873,11 +18998,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 2524,
+              "line": 2527,
               "column": 6
             },
             "end": {
-              "line": 2589,
+              "line": 2592,
               "column": 7
             }
           },
@@ -18907,11 +19032,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 2605,
+              "line": 2608,
               "column": 6
             },
             "end": {
-              "line": 2622,
+              "line": 2625,
               "column": 7
             }
           },
@@ -18961,16 +19086,85 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/element-mixin.html",
             "start": {
-              "line": 471,
+              "line": 441,
               "column": 6
             },
             "end": {
-              "line": 475,
+              "line": 445,
               "column": 7
             }
           },
           "metadata": {},
           "params": [],
+          "inheritedFrom": "Polymer.ElementMixin"
+        },
+        {
+          "name": "_processStyleText",
+          "description": "Gather style text for the template",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+            "start": {
+              "line": 588,
+              "column": 6
+            },
+            "end": {
+              "line": 591,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "is",
+              "type": "string",
+              "description": "Tag name for this element"
+            },
+            {
+              "name": "template",
+              "type": "!HTMLTemplateElement",
+              "description": "Template to process"
+            },
+            {
+              "name": "baseURI",
+              "type": "string",
+              "description": "Base URI to rebase CSS paths against"
+            }
+          ],
+          "return": {
+            "type": "string",
+            "desc": "The combined CSS text"
+          },
+          "inheritedFrom": "Polymer.ElementMixin"
+        },
+        {
+          "name": "_finalizeTemplate",
+          "description": "Configures an element `proto` to function with a given `template`.\nThe element name `is` and extends `ext` must be specified for ShadyCSS\nstyle scoping.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+            "start": {
+              "line": 602,
+              "column": 6
+            },
+            "end": {
+              "line": 621,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "is",
+              "type": "string",
+              "description": "Tag name (or type extension name) for this element"
+            },
+            {
+              "name": "ext",
+              "type": "string=",
+              "description": "For type extensions, the tag name that was extended"
+            }
+          ],
           "inheritedFrom": "Polymer.ElementMixin"
         }
       ],
@@ -20918,7 +21112,7 @@
               "column": 4
             },
             "end": {
-              "line": 41,
+              "line": 43,
               "column": 5
             }
           },
@@ -20935,11 +21129,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 43,
+              "line": 45,
               "column": 4
             },
             "end": {
-              "line": 53,
+              "line": 55,
               "column": 5
             }
           },
@@ -20960,7 +21154,7 @@
           "column": 2
         },
         "end": {
-          "line": 54,
+          "line": 56,
           "column": 3
         }
       },
@@ -21474,7 +21668,7 @@
               "column": 4
             },
             "end": {
-              "line": 49,
+              "line": 48,
               "column": 5
             }
           },
@@ -21482,8 +21676,8 @@
           "params": [
             {
               "name": "item",
-              "type": "(number|Object)",
-              "description": "The item index or the item object"
+              "type": "Object",
+              "description": "The item object"
             }
           ]
         },
@@ -21493,11 +21687,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 57,
+              "line": 56,
               "column": 4
             },
             "end": {
-              "line": 63,
+              "line": 61,
               "column": 5
             }
           },
@@ -21505,8 +21699,8 @@
           "params": [
             {
               "name": "item",
-              "type": "(number|Object)",
-              "description": "The item index or the item object"
+              "type": "Object",
+              "description": "The item object"
             }
           ]
         },
@@ -21516,11 +21710,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 71,
+              "line": 69,
               "column": 4
             },
             "end": {
-              "line": 79,
+              "line": 76,
               "column": 5
             }
           },
@@ -21528,31 +21722,8 @@
           "params": [
             {
               "name": "item",
-              "type": "(number|Object)",
-              "description": "The item index or the item object"
-            }
-          ]
-        },
-        {
-          "name": "_takeItem",
-          "description": "Returns item object itself or by the item index.",
-          "privacy": "protected",
-          "sourceRange": {
-            "start": {
-              "line": 86,
-              "column": 4
-            },
-            "end": {
-              "line": 91,
-              "column": 5
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "item",
-              "type": "(number|Object)",
-              "description": "The item index or the item object"
+              "type": "Object",
+              "description": "The item object"
             }
           ]
         },
@@ -21562,11 +21733,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 93,
+              "line": 78,
               "column": 4
             },
             "end": {
-              "line": 99,
+              "line": 84,
               "column": 5
             }
           },
@@ -21583,11 +21754,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 101,
+              "line": 86,
               "column": 4
             },
             "end": {
-              "line": 110,
+              "line": 95,
               "column": 5
             }
           },
@@ -21611,7 +21782,7 @@
           "column": 2
         },
         "end": {
-          "line": 111,
+          "line": 96,
           "column": 3
         }
       },
@@ -22392,7 +22563,7 @@
               "column": 4
             },
             "end": {
-              "line": 309,
+              "line": 313,
               "column": 5
             }
           },
@@ -22412,11 +22583,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 311,
+              "line": 315,
               "column": 4
             },
             "end": {
-              "line": 318,
+              "line": 322,
               "column": 5
             }
           },
@@ -22433,11 +22604,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 320,
+              "line": 324,
               "column": 4
             },
             "end": {
-              "line": 358,
+              "line": 362,
               "column": 5
             }
           },
@@ -22457,11 +22628,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 360,
+              "line": 364,
               "column": 4
             },
             "end": {
-              "line": 378,
+              "line": 382,
               "column": 5
             }
           },
@@ -22481,11 +22652,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 380,
+              "line": 384,
               "column": 4
             },
             "end": {
-              "line": 412,
+              "line": 416,
               "column": 5
             }
           },
@@ -22502,11 +22673,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 414,
+              "line": 418,
               "column": 4
             },
             "end": {
-              "line": 425,
+              "line": 429,
               "column": 5
             }
           },
@@ -22523,11 +22694,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 427,
+              "line": 431,
               "column": 4
             },
             "end": {
-              "line": 447,
+              "line": 451,
               "column": 5
             }
           },
@@ -22544,11 +22715,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 449,
+              "line": 453,
               "column": 4
             },
             "end": {
-              "line": 452,
+              "line": 456,
               "column": 5
             }
           },
@@ -22565,11 +22736,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 454,
+              "line": 458,
               "column": 4
             },
             "end": {
-              "line": 472,
+              "line": 476,
               "column": 5
             }
           },
@@ -22586,11 +22757,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 474,
+              "line": 478,
               "column": 4
             },
             "end": {
-              "line": 480,
+              "line": 484,
               "column": 5
             }
           },
@@ -22607,11 +22778,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 482,
+              "line": 486,
               "column": 4
             },
             "end": {
-              "line": 484,
+              "line": 488,
               "column": 5
             }
           },
@@ -22628,11 +22799,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 486,
+              "line": 490,
               "column": 4
             },
             "end": {
-              "line": 491,
+              "line": 495,
               "column": 5
             }
           },
@@ -22649,11 +22820,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 493,
+              "line": 497,
               "column": 4
             },
             "end": {
-              "line": 504,
+              "line": 508,
               "column": 5
             }
           },
@@ -22673,11 +22844,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 506,
+              "line": 510,
               "column": 4
             },
             "end": {
-              "line": 514,
+              "line": 518,
               "column": 5
             }
           },
@@ -22697,11 +22868,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 516,
+              "line": 520,
               "column": 4
             },
             "end": {
-              "line": 535,
+              "line": 539,
               "column": 5
             }
           },
@@ -22714,11 +22885,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 537,
+              "line": 541,
               "column": 4
             },
             "end": {
-              "line": 577,
+              "line": 581,
               "column": 5
             }
           },
@@ -22735,11 +22906,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 579,
+              "line": 583,
               "column": 4
             },
             "end": {
-              "line": 583,
+              "line": 587,
               "column": 5
             }
           },
@@ -22763,7 +22934,7 @@
           "column": 2
         },
         "end": {
-          "line": 584,
+          "line": 588,
           "column": 3
         }
       },
@@ -22868,7 +23039,7 @@
               "column": 4
             },
             "end": {
-              "line": 40,
+              "line": 42,
               "column": 5
             }
           },
@@ -22888,11 +23059,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 42,
+              "line": 44,
               "column": 4
             },
             "end": {
-              "line": 46,
+              "line": 48,
               "column": 5
             }
           },
@@ -22905,11 +23076,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 48,
+              "line": 50,
               "column": 4
             },
             "end": {
-              "line": 55,
+              "line": 57,
               "column": 5
             }
           },
@@ -22922,11 +23093,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 57,
+              "line": 59,
               "column": 4
             },
             "end": {
-              "line": 59,
+              "line": 61,
               "column": 5
             }
           },
@@ -22946,11 +23117,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 61,
+              "line": 63,
               "column": 4
             },
             "end": {
-              "line": 67,
+              "line": 69,
               "column": 5
             }
           },
@@ -22970,11 +23141,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 69,
+              "line": 71,
               "column": 4
             },
             "end": {
-              "line": 79,
+              "line": 81,
               "column": 5
             }
           },
@@ -22994,11 +23165,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 81,
+              "line": 83,
               "column": 4
             },
             "end": {
-              "line": 87,
+              "line": 89,
               "column": 5
             }
           },
@@ -23018,11 +23189,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 89,
+              "line": 91,
               "column": 4
             },
             "end": {
-              "line": 91,
+              "line": 93,
               "column": 5
             }
           },
@@ -23042,11 +23213,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 93,
+              "line": 95,
               "column": 4
             },
             "end": {
-              "line": 107,
+              "line": 109,
               "column": 5
             }
           },
@@ -23063,7 +23234,7 @@
           "column": 2
         },
         "end": {
-          "line": 108,
+          "line": 110,
           "column": 3
         }
       },

--- a/test/selecting.html
+++ b/test/selecting.html
@@ -169,7 +169,7 @@
       });
 
       it('should remove the item from selectedItems when row is clicked and auto-select is enabled', () => {
-        grid.selectItem(1);
+        grid.selectItem(grid.items[1]);
         const cell = getRowCells(rows[1])[1];
         cell.click();
         expect(grid.selectedItems).to.eql([]);

--- a/vaadin-grid-selection-mixin.html
+++ b/vaadin-grid-selection-mixin.html
@@ -40,10 +40,9 @@ This program is available under Apache License Version 2.0, available at https:/
      * Selects the given item.
      *
      * @method selectItem
-     * @param {number|Object} item The item index or the item object
+     * @param {Object} item The item object
      */
     selectItem(item) {
-      item = this._takeItem(item);
       if (!this._isSelected(item)) {
         this.push('selectedItems', item);
       }
@@ -53,10 +52,9 @@ This program is available under Apache License Version 2.0, available at https:/
      * Deselects the given item if it is already selected.
      *
      * @method deselect
-     * @param {number|Object} item The item index or the item object
+     * @param {Object} item The item object
      */
     deselectItem(item) {
-      item = this._takeItem(item);
       const index = this.selectedItems.indexOf(item);
       if (index > -1) {
         this.splice('selectedItems', index, 1);
@@ -67,28 +65,15 @@ This program is available under Apache License Version 2.0, available at https:/
      * Toggles the selected state of the given item.
      *
      * @method toggle
-     * @param {number|Object} item The item index or the item object
+     * @param {Object} item The item object
      */
     _toggleItem(item) {
-      item = this._takeItem(item);
       const index = this.selectedItems.indexOf(item);
       if (index === -1) {
         this.selectItem(item);
       } else {
         this.deselectItem(item);
       }
-    }
-
-    /**
-     * Returns item object itself or by the item index.
-     *
-     * @param {number|Object} item The item index or the item object
-     */
-    _takeItem(item) {
-      if (typeof item === 'number' && item >= 0 && this.items && this.items.length > item) {
-        return this.items[item];
-      }
-      return item;
     }
 
     _selectedItemsChanged(e) {


### PR DESCRIPTION
Drop support for indexes in the selection APIs. They only work in case the `items` array data source is used, not with `dataProvider`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-grid/1052)
<!-- Reviewable:end -->
