### PR TITLE
Allow Polymer 1.x

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -29,29 +29,29 @@
   ],
   "devDependencies": {
     "web-component-tester": "^6.0.0",
-    "iron-test-helpers": "^v2.0.0",
-    "paper-input": "^v2.0.0",
-    "paper-checkbox": "^v2.0.0",
-    "iron-demo-helpers": "^v2.0.0",
-    "iron-flex-layout": "^v2.0.0",
-    "iron-image": "^v2.0.0",
-    "paper-slider": "^v2.0.0",
-    "iron-icons": "PolymerElements/iron-icons#^v2.0.0",
-    "iron-media-query": "^v2.0.0",
-    "paper-button": "^v2.0.0",
-    "iron-icon": "PolymerElements/iron-icon#^v2.0.0",
-    "paper-styles": "PolymerElements/paper-styles#^v2.0.0",
-    "iron-component-page": "^v2.0.0",
+    "iron-test-helpers": "1 - 2",
+    "paper-input": "1 - 2",
+    "paper-checkbox": "1 - 2",
+    "iron-demo-helpers": "1 - 2",
+    "iron-flex-layout": "1 - 2",
+    "iron-image": "1 - 2",
+    "paper-slider": "1 - 2",
+    "iron-icons": "PolymerElements/iron-icons#1 - 2",
+    "iron-media-query": "1 - 2",
+    "paper-button": "1 - 2",
+    "iron-icon": "PolymerElements/iron-icon#1 - 2",
+    "paper-styles": "PolymerElements/paper-styles#1 - 2",
+    "iron-component-page": "1 - 2",
     "elements-demo-resources": "v2.0.0",
-    "iron-ajax": "PolymerElements/iron-ajax#^v2.0.0",
-    "app-localize-behavior": "^v2.0.0"
+    "iron-ajax": "PolymerElements/iron-ajax#1 - 2",
+    "app-localize-behavior": "1 - 2"
   },
   "dependencies": {
     "polymer": "1.9 - 2",
-    "iron-resizable-behavior": "PolymerElements/iron-resizable-behavior#^v2.0.0",
-    "iron-scroll-target-behavior": "PolymerElements/iron-scroll-target-behavior#^v2.0.0",
-    "iron-a11y-keys-behavior": "^v2.0.0",
-    "iron-a11y-announcer": "^v2.0.0"
+    "iron-resizable-behavior": "PolymerElements/iron-resizable-behavior#1 - 2",
+    "iron-scroll-target-behavior": "PolymerElements/iron-scroll-target-behavior#1 - 2",
+    "iron-a11y-keys-behavior": "1 - 2",
+    "iron-a11y-announcer": "1 - 2"
   },
   "variants": {
     "1.x": {

--- a/bower.json
+++ b/bower.json
@@ -47,7 +47,7 @@
     "app-localize-behavior": "^v2.0.0"
   },
   "dependencies": {
-    "polymer": "^2.0.0",
+    "polymer": "1.9 - 2",
     "iron-resizable-behavior": "PolymerElements/iron-resizable-behavior#^v2.0.0",
     "iron-scroll-target-behavior": "PolymerElements/iron-scroll-target-behavior#^v2.0.0",
     "iron-a11y-keys-behavior": "^v2.0.0",


### PR DESCRIPTION
Since the Hybrid Element is being used, the bower.json should allow Polymer 1.x as a resolution.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-grid/1059)
<!-- Reviewable:end -->
