### PR TITLE
Don't focus a body cell on size change if focus is outside body

### DIFF
--- a/test/keyboard-navigation.html
+++ b/test/keyboard-navigation.html
@@ -1128,6 +1128,14 @@
             expect(getCellContent(getRowCells(focusedRow)[0]).textContent).to.equal(focusedContent);
           });
 
+          it('should not focus a cell on size change if the focus is outside the body', () => {
+            getContainerCell(grid.$.header, 0, 0).focus();
+            up();
+
+            grid.size *= 2;
+            expect(grid.shadowRoot.activeElement).to.equal(getContainerCell(grid.$.header, 0, 0));
+          });
+
           describe('rotating focus indicator prevention', () => {
             it('should hide navigation mode when a focused row goes off screen', () => {
               focusItem(0);

--- a/vaadin-grid-scroller.html
+++ b/vaadin-grid-scroller.html
@@ -129,7 +129,7 @@ This program is available under Apache License Version 2.0, available at https:/
               this.$.table.scrollTop += row.getBoundingClientRect().top - fviOffset;
             }
             // Restore keyboard focus to the right cell
-            if (row.index === this._focusedItemIndex && this._itemsFocusable) {
+            if (row.index === this._focusedItemIndex && this._itemsFocusable && this.$.items.contains(this.shadowRoot.activeElement)) {
               const cellIndex = Array.from(this._itemsFocusable.parentElement.children).indexOf(this._itemsFocusable);
               row.children[cellIndex].focus();
             }


### PR DESCRIPTION
Without the fix, for example filtering demos are quite unusable

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-grid/1063)
<!-- Reviewable:end -->
