### PR TITLE
Get filter/sort changed event emitter from path under shadow dom

### DIFF
--- a/test/filtering.html
+++ b/test/filtering.html
@@ -23,14 +23,21 @@
           display: block;
         }
       </style>
-      <vaadin-grid-filter path="foo" value="[[_filterValue]]" id="filter">
-        <input value="{{_filterValue::input}}">
+      <vaadin-grid-filter
+        path="foo"
+        value="[[filterValue]]"
+        id="filter"
+      >
+        <input value="{{filterValue::input}}">
       </vaadin-grid-filter>
     </template>
     <script>
       HTMLImports.whenReady(function() {
         Polymer({
-          is: 'filter-wrapper'
+          is: 'filter-wrapper',
+          properties: {
+            filterValue: String
+          }
         });
       });
     </script>
@@ -64,7 +71,45 @@
     </template>
   </test-fixture>
 
+  <test-fixture id="event-retargeting">
+    <template>
+      <vaadin-grid>
+        <vaadin-grid-column>
+          <template class="header">
+            <filter-wrapper id=filterWrapper filter-value='foo'>
+            </filter-wrapper>
+          </template>
+          <template>[[item.first]]</template>
+        </vaadin-grid-column>
+      </vaadin-grid>
+    </template>
+  </test-fixture>
+
   <script>
+
+    describe('event retargeting', function(){
+      var grid;
+
+      beforeEach(function(done) {
+        // The before each block times out in CI with Firefox on Polymer 2
+        this.timeout(30000);
+
+        grid = fixture('event-retargeting');
+        Polymer.dom.flush();
+        grid.async(function(){
+          var filter = Polymer.dom(grid)
+            .querySelector('filter-wrapper')
+            .$$('vaadin-grid-filter');
+          filter.flushDebouncer('filter-changed');
+          done();
+        });
+      });
+
+      it('should get the real target', function(){
+        expect(grid._filters[0]).to.exist;
+        expect(grid._filters[0].is).to.equal('vaadin-grid-filter');
+      });
+    });
 
     describe('filter', function() {
       var filter;

--- a/test/sorting.html
+++ b/test/sorting.html
@@ -17,6 +17,34 @@
 
 <body>
 
+  <dom-module id="sorter-wrapper">
+    <template>
+      <vaadin-grid-sorter path="foo" direction=foo>
+        <span class="title">first</span>
+      </vaadin-grid-sorter>
+    </template>
+    <script>
+      HTMLImports.whenReady(function() {
+        Polymer({
+          is: 'sorter-wrapper'
+        });
+      });
+    </script>
+  </dom-module>
+
+  <test-fixture id="event-retargeting">
+    <template>
+      <vaadin-grid style="width: 200px; height: 200px;" multi-sort>
+        <vaadin-grid-column>
+          <template class="header">
+            <sorter-wrapper></sorter-wrapper>
+          </template>
+          <template>[[item.first]]</template>
+        </vaadin-grid-column>
+      </vaadin-grid>
+    </template>
+  </test-fixture>
+
   <test-fixture id="sorter">
     <template>
       <vaadin-grid-sorter path="path">
@@ -225,6 +253,23 @@
             expect(announcer.getAttribute('aria-hidden')).to.equal('true');
             done();
           }, 1);
+        });
+      });
+
+      describe('event retargeting', function() {
+        var grid;
+
+        beforeEach(function(done) {
+          // The before each block times out in CI with Firefox on Polymer 2
+          this.timeout(30000);
+
+          grid = fixture('event-retargeting');
+          animationFrameFlush(done);
+        });
+
+        it('should set _sorters correctly', function(){
+          expect(grid._sorters[0]).to.exist;
+          expect(grid._sorters[0].is).to.equal('vaadin-grid-sorter');
         });
       });
 

--- a/vaadin-grid-filter-behavior.html
+++ b/vaadin-grid-filter-behavior.html
@@ -23,8 +23,10 @@
     },
 
     _filterChanged: function(e) {
-      if (this._filters.indexOf(e.target) === -1) {
-        this._filters.push(e.target);
+      var filter = e.path && e.path[0] || e.target;
+
+      if (this._filters.indexOf(filter) === -1) {
+        this._filters.push(filter);
       }
 
       e.stopPropagation();

--- a/vaadin-grid-sort-behavior.html
+++ b/vaadin-grid-sort-behavior.html
@@ -57,7 +57,7 @@
     },
 
     _onSorterChanged: function(e) {
-      var sorter = e.target;
+      var sorter = e.path && e.path[0] || e.target;
 
       this._removeArrayItem(this._sorters, sorter);
       sorter._order = null;


### PR DESCRIPTION
As a developer I want to instantiate a dynamic set of columns configured by data. I define one column element for each type of data I want to be able to display and use dom-repeat and dom-if to get the right column type for the right data type. I also want my column headers to also be dynamic wrt to turning on filtering, sorting, or both. And I want each one of my dynamic column types to have the same dynamic header. Therefor I want to encapsulate vaadin-grid-sorter and vaadin-grid-filter and the business logic to configure them inside my own custom element which I can then insert into the light dom of the column header templates. This works perfectly under shady DOM, but not under shadow dom, because of event retargeting. This change causes the event listeners to use the event path property in preference of the target property if available, which allows the listener to get a reference to the filter/sorter elements even when they are nested inside a wrapper element's shadow root.

unit tests are included.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-grid/1064)
<!-- Reviewable:end -->
