### PR TITLE
add explicit native shadow dom run to test suite

### DIFF
--- a/test/index.html
+++ b/test/index.html
@@ -17,7 +17,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 </head>
 <body>
   <script>
-    WCT.loadSuites([
+      let suites = [
       'basic.html',
       'app-localize-behavior.html',
       'column.html',
@@ -48,7 +48,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       'resizing.html',
       'doctype.html',
       'lazy-import.html'
-    ]);
+    ];
+    suites = [].concat(suites.map((d)=>d+'?dom=shady'))
+               .concat(suites.map((d)=>d+'?dom=shadow'));
+    WCT.loadSuites(suites);
   </script>
 </body>
 </html>


### PR DESCRIPTION
by default, WCT runs one test run using the default DOM model for that version of polymer on that browser

this means, among other things, that currently you are not running tests AT ALL against Polymer 1 native shadow dom on chrome.

I have corrected the test suite so it explicitly runs twice, once under shady, and once under shadow, if supported. This is the approach suggested by the Polymer documentation. https://www.polymer-project.org/1.0/docs/tools/tests#shadow-dom

I notice that a few tests fail under polymer 1 native shadow dom on chrome. These are most likely bugs in the tests and or the element WRT shadow dom.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-grid/1065)
<!-- Reviewable:end -->
