### PR TITLE
This fix is to trap null values of observer parameters causing the sorter-changed event to fire 2 times and to add details on sort changed event.

### DIFF
--- a/vaadin-grid-array-data-provider-behavior.html
+++ b/vaadin-grid-array-data-provider-behavior.html
@@ -86,11 +86,14 @@
     },
 
     _multiSort: function(a, b) {
+        var sa = a.toString().toLowerCase();
+        var sb = b.toString().toLowerCase();
+
       return this._sorters.map(function(sort) {
         if (sort.direction === 'asc') {
-          return this._compare(Polymer.Base.get(sort.path, a), Polymer.Base.get(sort.path, b));
+          return this._compare(Polymer.Base.get(sort.path, sa), Polymer.Base.get(sort.path, sb));
         } else if (sort.direction === 'desc') {
-          return this._compare(Polymer.Base.get(sort.path, b), Polymer.Base.get(sort.path, a));
+          return this._compare(Polymer.Base.get(sort.path, sb), Polymer.Base.get(sort.path, sa));
         }
         return 0;
       }, this).reduce(function firstNonZeroValue(p, n) {

--- a/vaadin-grid-array-data-provider-behavior.html
+++ b/vaadin-grid-array-data-provider-behavior.html
@@ -27,6 +27,7 @@
         return;
       }
 
+
       this.size = (items || []).length;
       this.dataProvider = this.dataProvider || this._arrayDataProvider;
       this.clearCache();

--- a/vaadin-grid-sorter.html
+++ b/vaadin-grid-sorter.html
@@ -216,12 +216,12 @@ Custom property | Description | Default
       },
 
       _pathOrDirectionChanged: function(path, direction, isAttached) {
-        if (path === undefined || direction === undefined || isAttached === undefined) {
+        if (!path  || !direction || !isAttached ) { //changed the condition to trap even NULL values, causing this observer to fire the sorter-changed event 2x
           return;
         }
 
         if (isAttached) {
-          this.fire('sorter-changed');
+          this.fire('sorter-changed',{"path":path,"direction":direction});
         }
       },
 

--- a/vaadin-grid-sorter.html
+++ b/vaadin-grid-sorter.html
@@ -216,12 +216,12 @@ Custom property | Description | Default
       },
 
       _pathOrDirectionChanged: function(path, direction, isAttached) {
-        if (!path  || !direction || !isAttached ) { //changed the condition to trap even NULL values, causing this observer to fire the sorter-changed event 2x
+        if (!path ||!direction||!isAttached) { // changed the condition to trap even NULL values, causing this observer to fire the sorter-changed event 2x
           return;
         }
 
         if (isAttached) {
-          this.fire('sorter-changed',{"path":path,"direction":direction});
+          this.fire('sorter-changed',{'path': path, 'direction': direction});
         }
       },
 

--- a/vaadin-grid-sorter.html
+++ b/vaadin-grid-sorter.html
@@ -233,9 +233,9 @@ Custom property | Description | Default
         e.preventDefault();
         if (this.direction === 'asc') {
           this.direction = 'desc';
-        } else if (this.direction === 'desc') {
+        } /*else if (this.direction === 'desc') {
           this.direction = null;
-        } else {
+        }*/ else {
           this.direction = 'asc';
         }
       },


### PR DESCRIPTION
I was actually trying to sort the entire list with pagination. Apparently, the built in sort behavior of the element is actually sorting those on current page only and not the entire list. And I believe, to be able to sort the entire list we must actually sort the data source of vaadin grid by handling it to the event sort-changed emmitted by it, and so, we need to include some details upon dispatching this event particularly the column sort path and the direction of sorting.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-grid/1066)
<!-- Reviewable:end -->
