### PR TITLE
Remove emoji icons from hierarchy demo

### DIFF
--- a/demo/grid-hierarchy-demos.html
+++ b/demo/grid-hierarchy-demos.html
@@ -21,7 +21,7 @@
                       icon-hidden="[[!item.hasChildren]]"
                       expanded="{{expanded}}"
                       level="[[level]]">
-                    [[_getIconFor(item, expanded)]]&nbsp;&nbsp;[[item.name]]
+                    [[item.name]]
                   </vaadin-grid-hierarchy-toggle>
                 </template>
               </vaadin-grid-column>
@@ -65,22 +65,6 @@
                     const hierarchyLevelSize = fsItems.length;
                     callback(pageItems, hierarchyLevelSize);
                   });
-                },
-
-                _getIconFor: function(item, expanded) {
-                  if (!item) {
-                    return;
-                  }
-
-                  if (item.type === 'dir') {
-                    if (expanded) {
-                      return '📂';
-                    } else {
-                      return '📁';
-                    }
-                  } else {
-                    return '📄';
-                  }
                 }
               });
             });


### PR DESCRIPTION
Using additional icons in the hierarchy demo makes the toggle look confusing. Users might think that these emoji icons belong to default toggle look, although they are demo-only. Reading through the demo code is required to understand that.

In addition, emoji icons look is platform-dependant, and sometimes could be not pretty.

Considering all above, it’s probably better to remove the additional emoji icons from the demo.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-grid/1082)
<!-- Reviewable:end -->
