### PR TITLE
Do not start reordering on resize frozen column

### DIFF
--- a/test/column-reordering.html
+++ b/test/column-reordering.html
@@ -398,6 +398,12 @@
           expect(cell.hasAttribute('last-frozen')).to.be.true;
         });
 
+        it('should not start reordering on frozen column resize handle move', () => {
+          const handle = getCellByCellContent(headerContent[0]).querySelector('[part~="resize-handle"]');
+          const cell = getCellByCellContent(headerContent[1]);
+          dragOver(handle, cell);
+          expect(grid.hasAttribute('reordering')).to.be.false;
+        });
       });
 
     });

--- a/test/column-reordering.html
+++ b/test/column-reordering.html
@@ -299,13 +299,13 @@
       it('should not start reordering on resize handle move', () => {
         const handle = getCellByCellContent(headerContent[0]).querySelector('[part~="resize-handle"]');
         dragStart(handle);
-        expect(grid.$.scroller.hasAttribute('reordering')).to.be.false;
+        expect(grid.hasAttribute('reordering')).to.be.false;
       });
 
-      it('should start reordering on grid with no reorder allowed', () => {
+      it('should not start reordering on grid with no reorder allowed', () => {
         grid.columnReorderingAllowed = false;
         dragStart(headerContent[0]);
-        expect(grid.$.scroller.hasAttribute('reordering')).to.be.false;
+        expect(grid.hasAttribute('reordering')).to.be.false;
       });
 
       describe('basic reordering', () => {

--- a/vaadin-grid-column-reordering-mixin.html
+++ b/vaadin-grid-column-reordering-mixin.html
@@ -106,6 +106,11 @@ This program is available under Apache License Version 2.0, available at https:/
           return;
         }
 
+        if (this.$.scroller.hasAttribute('column-resizing')) {
+          // Resizing is in progress
+          return;
+        }
+
         if (!this._touchDevice) {
           // Not a touch device
           this._onTrackStart(e);


### PR DESCRIPTION
Fixes #1088 
Also fixes two outdated tests checking `reordering` attribute on wrong element

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-grid/1090)
<!-- Reviewable:end -->
