### PR TITLE
Add missing style for loading rows

### DIFF
--- a/src/vaadin-grid-styles.html
+++ b/src/vaadin-grid-styles.html
@@ -82,6 +82,10 @@ This program is available under Apache License Version 2.0, available at https:/
         margin: 0;
       }
 
+      [part~="row"][loading] [part~="body-cell"] ::slotted(vaadin-grid-cell-content) {
+        opacity: 0;
+      }
+
       #items [part~="row"] {
         position: absolute;
       }

--- a/test/basic.html
+++ b/test/basic.html
@@ -61,6 +61,22 @@
         expect(grid.lastVisibleIndex, Math.ceil(((grid._scrollTop + grid.offsetHeight) / actualHeight) - 1));
       });
 
+      it('Should change the opacity of cell content in loading rows from 1 to 0 and back', () => {
+        const firstRow = grid.shadowRoot.querySelector('#items [part~="row"]');
+        const cellContent = grid.querySelector('vaadin-grid-cell-content');
+
+        expect(window.getComputedStyle(cellContent).opacity).to.eql('1');
+
+        firstRow.setAttribute('loading', '');
+
+        expect(window.getComputedStyle(cellContent).opacity).to.eql('0');
+
+        firstRow.removeAttribute('loading', '');
+
+        expect(window.getComputedStyle(cellContent).opacity).to.eql('1');
+      });
+
+
       it('scroll to index', () => {
         grid.size = 100;
 


### PR DESCRIPTION
Fixes #1166 

Add missing style for `loading` rows

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-grid/1178)
<!-- Reviewable:end -->
