### PR TITLE
Fix scrolling performance issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-sudo: false
+sudo: true
 dist: trusty
 language: node_js
 node_js: 8.0

--- a/test/.eslintrc.json
+++ b/test/.eslintrc.json
@@ -53,6 +53,7 @@
     "flushGrid": false,
     "fire": false,
     "getContainerCell": false,
-    "footerTrap": false
+    "footerTrap": false,
+    "wheel": false
   }
 }

--- a/test/column.html
+++ b/test/column.html
@@ -97,7 +97,8 @@
           it('should be bound to header cells', () => {
             column.width = '20%';
 
-            expect(getContainerCell(grid.$.header, 0, 0).style.width).to.eql('calc(20% + 100px)');
+            const width = getContainerCell(grid.$.header, 0, 0).style.width;
+            expect(width).to.be.oneOf(['calc(20% + 100px)', 'calc(100px + 20%)']);
           });
 
           it('should be bound to row cells', () => {

--- a/test/helpers.html
+++ b/test/helpers.html
@@ -85,6 +85,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     };
   }
 
+  function wheel(target, deltaX, deltaY, ctrlKey) {
+    const e = new CustomEvent('wheel', {bubbles: true, cancelable: true});
+    e.deltaX = deltaX;
+    e.deltaY = deltaY;
+    e.ctrlKey = ctrlKey;
+    target.dispatchEvent(e);
+    return e;
+  }
+
   function buildDataSet(size) {
     const data = [];
     while (data.length < size) {

--- a/test/million-dollar-scrolling.html
+++ b/test/million-dollar-scrolling.html
@@ -92,14 +92,11 @@
             grid = container.$.grid;
             grid.dataProvider = infiniteDataProvider;
             grid.size = size;
-            flushGrid(grid);
-            grid.$.table.scrollTop = grid.$.table.scrollHeight;
-            grid._scrollHandler();
-            setTimeout(() => {
-              grid.$.table.scrollTop = 0;
-              grid._scrollHandler();
+
+            scrollToEnd(grid, () => {
+              grid._scrollToIndex(0);
               done();
-            }, 50);
+            });
           });
 
           it('should be able to scroll to half-way', () => {
@@ -130,7 +127,7 @@
           });
 
           it('should be able to manually scroll to end', done => {
-            grid.$.table.scrollTop = grid.$.table.scrollHeight - 20000;
+            grid._scrollToIndex(grid.size * 0.99);
 
             simulateScrollToEnd(grid, () => {
               expect(getCellContent(getLastVisibleItem(grid)).textContent).to.contain('item' + (grid.size - 1));

--- a/test/outer-scroller.html
+++ b/test/outer-scroller.html
@@ -62,15 +62,6 @@
   <script>
     const ios = /iPad|iPhone|iPod/.test(navigator.userAgent) && !window.MSStream;
 
-    function wheel(target, deltaX, deltaY, ctrlKey) {
-      const e = new CustomEvent('wheel', {bubbles: true, cancelable: true});
-      e.deltaX = deltaX;
-      e.deltaY = deltaY;
-      e.ctrlKey = ctrlKey;
-      target.dispatchEvent(e);
-      return e;
-    }
-
     describe('outer scroller', () => {
       let grid;
       let scroller;
@@ -109,10 +100,9 @@
         expect(e.defaultPrevented).to.be.false;
       });
 
-      it('should invoke onScroll synchronously', () => {
-        const spy = sinon.spy(grid, '_translateStationaryElements');
+      it('should invoke onScroll synchronously', done => {
+        const spy = sinon.stub(grid, '_translateStationaryElements', done);
         outerScroller._syncScrollTarget();
-        expect(spy.called).to.be.true;
       });
 
       it('should invoke frozen element translate handler', done => {
@@ -166,14 +156,37 @@
           outerScroller.scrollLeft = 100;
         });
 
-        it('should scroll the outer scroller', done => {
-          target.addEventListener('scroll', () => {
-            animationFrameFlush(() => {
-              expect(outerScroller.scrollLeft).to.equal(100);
-              done();
-            });
-          });
-          target.scrollLeft = 100;
+        it('should scroll the outer scroller', () => {
+          wheel(grid, 100, 0);
+          expect(outerScroller.scrollLeft).to.equal(100);
+        });
+
+        it('should only sync outer scroller when wheel scrolling host or passthrough', () => {
+          const spy = sinon.spy(outerScroller, 'syncOuterScroller');
+
+          // Not wheelscrolling nor passthrough
+          outerScroller.passthrough = false;
+          grid._scrollHandler();
+          expect(spy.called).to.be.false;
+
+          // Wheel scrolling only
+          grid._wheelScrolling = true;
+          grid._scrollHandler();
+          expect(spy.called).to.be.true;
+
+          // Passthrough only
+          spy.reset();
+          grid._wheelScrolling = false;
+          outerScroller.passthrough = true;
+          grid._scrollHandler();
+          expect(spy.called).to.be.true;
+        });
+
+        it('should not invoke afterScroll on scroll event while outer scrolling', () => {
+          const spy = sinon.spy(grid, '_afterScroll');
+          outerScroller.dispatchEvent(new Event('mousedown'));
+          grid.$.table.dispatchEvent(new Event('scroll'));
+          expect(spy.called).to.be.false;
         });
 
       });
@@ -269,7 +282,9 @@
               expect(outerScrollerAccessible()).to.equal(outerScrollerScrollable());
               done();
             });
-            move(tableRect.width, 1);
+            requestAnimationFrame(() => {
+              move(tableRect.width, 1);
+            });
           });
 
         });

--- a/test/scrolling-mode.html
+++ b/test/scrolling-mode.html
@@ -131,6 +131,53 @@
         expect(grid.scrollHeight - grid.clientHeight).to.equal(0);
       });
 
+      it('should mark wheel scroll', () => {
+        const scroller = grid.$.scroller;
+        expect(scroller.hasAttribute('wheel-scrolling')).to.be.false;
+        expect(grid._wheelScrolling).not.to.be.ok;
+        wheel(grid, 0, 0);
+
+        expect(scroller.hasAttribute('wheel-scrolling')).to.be.true;
+        expect(grid._wheelScrolling).to.be.ok;
+        grid._debouncerWheelScrolling.flush();
+
+        expect(scroller.hasAttribute('wheel-scrolling')).to.be.false;
+        expect(grid._wheelScrolling).not.to.be.ok;
+      });
+
+      it('should defer adding scrolling state attributes', done => {
+        flushGrid(grid);
+        const scroller = grid.$.scroller;
+        grid.$.table.addEventListener('scroll', () => {
+          expect(scroller.hasAttribute('scrolling')).to.be.false;
+          requestAnimationFrame(() => {
+            expect(scroller.hasAttribute('scrolling')).to.be.true;
+            done();
+          });
+        });
+        grid.$.table.scrollLeft = 1;
+      });
+
+      it('should not invoke afterScroll on scroll event while wheel scrolling', () => {
+        const spy = sinon.spy(grid, '_afterScroll');
+        wheel(grid, 0, 0);
+        grid.$.table.dispatchEvent(new Event('scroll'));
+        expect(spy.called).to.be.false;
+      });
+
+      it('should invoke afterScroll on scroll event while not wheel scrolling', () => {
+        const spy = sinon.spy(grid, '_afterScroll');
+        grid.$.table.dispatchEvent(new Event('scroll'));
+        expect(spy.called).to.be.true;
+      });
+
+      it('should avoid jumpy headers on Edge while wheel scrolling', () => {
+        grid._edge = true;
+        expect(window.getComputedStyle(grid.$.table).zIndex).not.to.equal('auto');
+        wheel(grid, 0, 0);
+        expect(window.getComputedStyle(grid.$.table).zIndex).to.equal('auto');
+      });
+
     });
   </script>
 

--- a/vaadin-grid-outer-scroller.html
+++ b/vaadin-grid-outer-scroller.html
@@ -105,22 +105,17 @@ This program is available under Apache License Version 2.0, available at https:/
       }
 
       syncOuterScroller() {
-        if (!this._syncingScrollTarget) {
-          this._syncingOuterScroller = true;
-          this.scrollTop = this.scrollTarget.scrollTop;
-          this.scrollLeft = this.scrollTarget.scrollLeft;
-        }
-        this._syncingScrollTarget = false;
+        this.scrollTop = this.scrollTarget.scrollTop;
+        this.scrollLeft = this.scrollTarget.scrollLeft;
       }
 
       _syncScrollTarget() {
-        if (!this._syncingOuterScroller) {
-          this._syncingScrollTarget = true;
+        requestAnimationFrame(() => {
           this.scrollTarget.scrollTop = this.scrollTop;
           this.scrollTarget.scrollLeft = this.scrollLeft;
           this.scrollHandler._scrollHandler();
-        }
-        this._syncingOuterScroller = false;
+        });
+
       }
 
     }

--- a/vaadin-grid-scroll-mixin.html
+++ b/vaadin-grid-scroll-mixin.html
@@ -13,6 +13,15 @@ This program is available under Apache License Version 2.0, available at https:/
    */
   Vaadin.Grid.ScrollMixin = superClass => class ScrollMixin extends superClass {
 
+    get _timeouts() {
+      return {
+        SCROLL_PERIOD: 1000,
+        WHEEL_SCROLLING: 200,
+        SCROLLING: 100,
+        IGNORE_WHEEL: 500
+      };
+    }
+
     static get properties() {
       return {
 
@@ -57,7 +66,22 @@ This program is available under Apache License Version 2.0, available at https:/
     ready() {
       super.ready();
       this.scrollTarget = this.$.table;
-      this.addEventListener('wheel', this._onWheel.bind(this));
+
+      this.addEventListener('wheel', e => {
+        this._wheelScrolling = true;
+        this._debouncerWheelScrolling = Polymer.Debouncer.debounce(
+          this._debouncerWheelScrolling,
+          Polymer.Async.timeOut.after(this._timeouts.WHEEL_SCROLLING),
+          () => this._wheelScrolling = false
+        );
+        this._onWheel(e);
+      });
+
+      this.$.table.addEventListener('scroll', e => {
+        if (this._wheelScrolling || this.$.outerscroller.outerScrolling) {
+          e.stopImmediatePropagation();
+        }
+      }, true);
 
       this.$.items.addEventListener('focusin', (e) => {
         const itemsIndex = e.composedPath().indexOf(this.$.items);
@@ -91,7 +115,7 @@ This program is available under Apache License Version 2.0, available at https:/
         this._ignoreNewWheel = true;
         this._debouncerIgnoreNewWheel = Polymer.Debouncer.debounce(
           this._debouncerIgnoreNewWheel,
-          Polymer.Async.timeOut.after(500),
+          Polymer.Async.timeOut.after(this._timeouts.IGNORE_WHEEL),
           () => this._ignoreNewWheel = false
         );
       } else if (this._hasResidualMomentum && momentum <= this._previousMomentum || this._ignoreNewWheel) {
@@ -132,7 +156,7 @@ This program is available under Apache License Version 2.0, available at https:/
       }
       this._debounceScrolling = Polymer.Debouncer.debounce(
         this._debounceScrolling,
-        Polymer.Async.timeOut.after(100),
+        Polymer.Async.timeOut.after(this._timeouts.SCROLLING),
         () => {
           cancelAnimationFrame(this._scrollingFrame);
           delete this._scrollingFrame;
@@ -148,7 +172,7 @@ This program is available under Apache License Version 2.0, available at https:/
       }
       this._debounceScrollPeriod = Polymer.Debouncer.debounce(
         this._debounceScrollPeriod,
-        Polymer.Async.timeOut.after(1000),
+        Polymer.Async.timeOut.after(this._timeouts.SCROLL_PERIOD),
         () => {
           cancelAnimationFrame(this._scrollPeriodFrame);
           delete this._scrollPeriodFrame;
@@ -164,7 +188,9 @@ This program is available under Apache License Version 2.0, available at https:/
         this._scheduleScrolling();
       }
 
-      this.$.outerscroller.syncOuterScroller();
+      if (this._wheelScrolling || this.$.outerscroller.passthrough) {
+        this.$.outerscroller.syncOuterScroller();
+      }
     }
 
     // correct order needed for preserving correct tab order between cell contents.

--- a/vaadin-grid-scroll-mixin.html
+++ b/vaadin-grid-scroll-mixin.html
@@ -125,24 +125,17 @@ This program is available under Apache License Version 2.0, available at https:/
       (deltaX < 0 && el.scrollLeft > 0);
     }
 
-    /**
-     * Update the models, the position of the
-     * items in the viewport and recycle tiles as needed.
-     */
-    _afterScroll(e) {
-      // this._adjustVirtualIndexOffset(delta);
-
-      this._translateStationaryElements();
-
-      if (!this.hasAttribute('reordering')) {
-        this._toggleAttribute('scrolling', true, this.$.scroller);
-        this._toggleAttribute('scroll-period', true, this.$.scroller);
+    _scheduleScrolling() {
+      if (!this._scrollingFrame) {
+        // Defer setting state attributes to avoid Edge hiccups
+        this._scrollingFrame = requestAnimationFrame(() => this._toggleAttribute('scrolling', true, this.$.scroller));
       }
-
       this._debounceScrolling = Polymer.Debouncer.debounce(
         this._debounceScrolling,
         Polymer.Async.timeOut.after(100),
         () => {
+          cancelAnimationFrame(this._scrollingFrame);
+          delete this._scrollingFrame;
           this._toggleAttribute('scrolling', false, this.$.scroller);
           if (!this.$.outerscroller.outerScrolling) {
             this._reorderRows();
@@ -150,13 +143,26 @@ This program is available under Apache License Version 2.0, available at https:/
         }
       );
 
+      if (!this._scrollPeriodFrame) {
+        this._scrollPeriodFrame = requestAnimationFrame(() => this._toggleAttribute('scroll-period', true, this.$.scroller));
+      }
       this._debounceScrollPeriod = Polymer.Debouncer.debounce(
         this._debounceScrollPeriod,
         Polymer.Async.timeOut.after(1000),
         () => {
+          cancelAnimationFrame(this._scrollPeriodFrame);
+          delete this._scrollPeriodFrame;
           this._toggleAttribute('scroll-period', false, this.$.scroller);
         }
       );
+    }
+
+    _afterScroll() {
+      this._translateStationaryElements();
+
+      if (!this.hasAttribute('reordering')) {
+        this._scheduleScrolling();
+      }
 
       this.$.outerscroller.syncOuterScroller();
     }

--- a/vaadin-grid-styles.html
+++ b/vaadin-grid-styles.html
@@ -41,6 +41,12 @@ This program is available under Apache License Version 2.0, available at https:/
         position: relative;
       }
 
+      /* Avoid jumpy headers on Edge & IE */
+      [wheel-scrolling][edge] #table,
+      [wheel-scrolling][ie] #table {
+        z-index: auto;
+      }
+
       #header {
         display: block;
         position: absolute;

--- a/vaadin-grid.html
+++ b/vaadin-grid.html
@@ -31,6 +31,7 @@ This program is available under Apache License Version 2.0, available at https:/
 
     <div id="scroller"
       no-scrollbars$="[[!_scrollbarWidth]]"
+      wheel-scrolling$="[[_wheelScrolling]]"
       safari$="[[_safari]]"
       ios$="[[_ios]]"
       loading$=[[loading]]


### PR DESCRIPTION
Connects to #900 

This PR fixes the scrolling performance issues we're currently experiencing with IE/Edge. The main issue was caused by setting the "scrolling" state attribute synchronously on scroll start. Applying the attribute is now deferred with `requestAnimationFrame`.

Another performance optimization affecting all devices is that (redundant) scroll events now get ignored while the grid is scrolled with wheel.

Outer scroller logic was also streamlined and fixed so that the scrollbar handling works properly on IE/Edge.

Once this PR is merged, I'll apply the same fixes to master branch.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-grid/1182)
<!-- Reviewable:end -->
