### PR TITLE
Optimize attribute toggling

### DIFF
--- a/src/vaadin-grid-column-reordering-mixin.html
+++ b/src/vaadin-grid-column-reordering-mixin.html
@@ -127,7 +127,7 @@ This program is available under Apache License Version 2.0, available at https:/
         return;
       }
 
-      this.setAttribute('reordering', '');
+      this._toggleAttribute('reordering', true, this);
       this._draggedColumn = headerCell._column;
       while (this._draggedColumn.parentElement.childElementCount === 1) {
         // This is the only column in the group, drag the whole group instead
@@ -169,7 +169,7 @@ This program is available under Apache License Version 2.0, available at https:/
         return;
       }
 
-      this.removeAttribute('reordering');
+      this._toggleAttribute('reordering', false, this);
       this._draggedColumn._reorderStatus = '';
       this._setSiblingsReorderStatus(this._draggedColumn, '');
       this._draggedColumn = null;
@@ -181,7 +181,7 @@ This program is available under Apache License Version 2.0, available at https:/
       x = x || 0;
       y = y || 0;
       if (!this._draggedColumn) {
-        this.$.scroller.setAttribute('no-content-pointer-events', '');
+        this._toggleAttribute('no-content-pointer-events', true, this.$.scroller);
       }
       let cell;
       if (Polymer.Settings.useShadow) {
@@ -195,7 +195,7 @@ This program is available under Apache License Version 2.0, available at https:/
         }
 
       }
-      this.$.scroller.removeAttribute('no-content-pointer-events');
+      this._toggleAttribute('no-content-pointer-events', false, this.$.scroller);
 
       // Make sure the element is actually a cell
       if (cell && cell._column) {

--- a/src/vaadin-grid-column-resizing-mixin.html
+++ b/src/vaadin-grid-column-resizing-mixin.html
@@ -36,7 +36,7 @@ This program is available under Apache License Version 2.0, available at https:/
         const cell = handle.parentElement;
         let column = cell._column;
 
-        this.$.scroller.setAttribute('column-resizing', '');
+        this._toggleAttribute('column-resizing', true, this.$.scroller);
 
         // Get the target column to resize
         if (column.localName === 'vaadin-grid-column-group') {
@@ -73,7 +73,7 @@ This program is available under Apache License Version 2.0, available at https:/
           });
 
         if (e.detail.state === 'end') {
-          this.$.scroller.removeAttribute('column-resizing');
+          this._toggleAttribute('column-resizing', false, this.$.scroller);
         }
 
         // Notify resize

--- a/src/vaadin-grid-column.html
+++ b/src/vaadin-grid-column.html
@@ -297,11 +297,13 @@ This program is available under Apache License Version 2.0, available at https:/
       }
     }
 
-    _toggleAttribute(name, on, element) {
-      if (on) {
-        element.setAttribute(name, '');
-      } else {
-        element.removeAttribute(name);
+    _toggleAttribute(name, bool, node) {
+      if (node.hasAttribute(name) === !bool) {
+        if (bool) {
+          node.setAttribute(name, '');
+        } else {
+          node.removeAttribute(name);
+        }
       }
     }
 

--- a/src/vaadin-grid-combined-mixin.html
+++ b/src/vaadin-grid-combined-mixin.html
@@ -407,7 +407,7 @@ This program is available under Apache License Version 2.0, available at https:/
         const cell = handle.parentElement;
         let column = cell._column;
 
-        this.$.scroller.setAttribute('column-resizing', '');
+        this._toggleAttribute('column-resizing', true, this.$.scroller);
 
         // Get the target column to resize
         if (column.localName === 'vaadin-grid-column-group') {
@@ -444,7 +444,7 @@ This program is available under Apache License Version 2.0, available at https:/
           });
 
         if (e.detail.state === 'end') {
-          this.$.scroller.removeAttribute('column-resizing');
+          this._toggleAttribute('column-resizing', false, this.$.scroller);
         }
 
         // Notify resize
@@ -639,7 +639,7 @@ This program is available under Apache License Version 2.0, available at https:/
       cell.setAttribute('part', 'cell details-cell');
       // Freeze the details cell, so that it does not scroll horizontally
       // with the normal cells. This way it looks less weird.
-      cell.setAttribute('frozen', '');
+      this._toggleAttribute('frozen', true, cell);
     }
 
     _toggleDetailsCell(row, item) {

--- a/src/vaadin-grid-data-provider-mixin.html
+++ b/src/vaadin-grid-data-provider-mixin.html
@@ -180,13 +180,13 @@ This program is available under Apache License Version 2.0, available at https:/
       const {cache, scaledIndex} = this._cache.getCacheAndIndex(index);
       const item = cache.items[scaledIndex];
       if (item) {
-        el.removeAttribute('loading');
+        this._toggleAttribute('loading', false, el);
         this._updateItem(el, item);
         if (this._isExpanded(item)) {
           cache.ensureSubCacheForScaledIndex(scaledIndex);
         }
       } else {
-        el.setAttribute('loading', '');
+        this._toggleAttribute('loading', true, el);
         this._loadPage(this._getPageForIndex(scaledIndex), cache);
       }
 
@@ -303,7 +303,7 @@ This program is available under Apache License Version 2.0, available at https:/
           Array.from(this.$.items.children).forEach(row => {
             const cachedItem = this._cache.getItemForIndex(row.index);
             if (items.indexOf(cachedItem) > -1) {
-              row.removeAttribute('loading');
+              this._toggleAttribute('loading', false, row);
               this._updateItem(row, cachedItem);
             }
           });

--- a/src/vaadin-grid-row-details-mixin.html
+++ b/src/vaadin-grid-row-details-mixin.html
@@ -88,7 +88,7 @@ This program is available under Apache License Version 2.0, available at https:/
       cell.setAttribute('part', 'cell details-cell');
       // Freeze the details cell, so that it does not scroll horizontally
       // with the normal cells. This way it looks less weird.
-      cell.setAttribute('frozen', '');
+      this._toggleAttribute('frozen', true, cell);
     }
 
     _toggleDetailsCell(row, item) {

--- a/src/vaadin-grid.html
+++ b/src/vaadin-grid.html
@@ -605,10 +605,12 @@ This program is available under Apache License Version 2.0, available at https:/
       }
 
       _toggleAttribute(name, bool, node) {
-        if (bool) {
-          node.setAttribute(name, '');
-        } else {
-          node.removeAttribute(name);
+        if (node.hasAttribute(name) === !bool) {
+          if (bool) {
+            node.setAttribute(name, '');
+          } else {
+            node.removeAttribute(name);
+          }
         }
       }
 

--- a/test/basic.html
+++ b/test/basic.html
@@ -41,6 +41,45 @@
         flushGrid(grid);
       });
 
+      describe('toggle attribute', () => {
+        let node;
+
+        beforeEach(() => {
+          node = {};
+          node.setAttribute = sinon.spy();
+          node.removeAttribute = sinon.spy();
+        });
+
+        it('should set attribute', () => {
+          node.hasAttribute = () => false;
+          grid._toggleAttribute('foo', true, node);
+          expect(node.setAttribute.called).to.be.true;
+        });
+
+        it('should not re-set attribute', () => {
+          node.hasAttribute = () => true;
+          grid._toggleAttribute('foo', true, node);
+          expect(node.setAttribute.called).to.be.false;
+        });
+
+        it('should remove attribute', () => {
+          node.hasAttribute = () => true;
+          grid._toggleAttribute('foo', false, node);
+          grid._toggleAttribute('foo', '', node);
+          grid._toggleAttribute('foo', undefined, node);
+          expect(node.removeAttribute.callCount).to.equal(3);
+        });
+
+        it('should not re-remove attribute', () => {
+          node.hasAttribute = () => false;
+          grid._toggleAttribute('foo', false, node);
+          grid._toggleAttribute('foo', '', node);
+          grid._toggleAttribute('foo', undefined, node);
+          expect(node.removeAttribute.called).to.be.false;
+        });
+
+      });
+
       it('check physical item heights', () => {
         const rowHeight = grid._physicalItems[0].offsetHeight;
 


### PR DESCRIPTION
Invoking setAttribute causes overhead (on Edge at least) even if the same exact attribute already exists.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-grid/1194)
<!-- Reviewable:end -->
