### PR TITLE
Refactor core styles and Lumo theme

### DIFF
--- a/demo/grid-lumo-theme-demos.html
+++ b/demo/grid-lumo-theme-demos.html
@@ -6,6 +6,8 @@
       }
     </style>
 
+    <p>You can combine all of these variants together, e.g. <code>&lt;vaadin-grid <b>theme="compact no-row-borders row-stripes"</b>&gt;</code></p>
+
     <h3>Compact</h3>
     <p><code>&lt;vaadin-grid <b>theme="compact"</b>&gt;</code></p>
     <vaadin-demo-snippet id='grid-lumo-theme-demos-compact'>
@@ -46,15 +48,15 @@
       </template>
     </vaadin-demo-snippet>
 
-    <h3>Borderless</h3>
-    <p><code>&lt;vaadin-grid <b>theme="borderless"</b>&gt;</code></p>
-    <vaadin-demo-snippet id='grid-lumo-theme-demos-borderless'>
+    <h3>No border</h3>
+    <p><code>&lt;vaadin-grid <b>theme="no-border"</b>&gt;</code></p>
+    <vaadin-demo-snippet id='grid-lumo-theme-demos-bordered'>
       <template preserve-content>
         <dom-bind>
           <template>
             <iron-ajax auto url="https://demo.vaadin.com/demo-data/1.0/people?count=20" handle-as="json" last-response="{{users}}"></iron-ajax>
 
-            <vaadin-grid theme="borderless" items="[[users.result]]" column-reordering-allowed multi-sort>
+            <vaadin-grid theme="no-border" items="[[users.result]]" column-reordering-allowed multi-sort>
 
               <vaadin-grid-selection-column auto-select> </vaadin-grid-selection-column>
 
@@ -86,15 +88,15 @@
       </template>
     </vaadin-demo-snippet>
 
-    <h3>Row Dividers</h3>
-    <p><code>&lt;vaadin-grid <b>theme="row-dividers"</b>&gt;</code></p>
-    <vaadin-demo-snippet id='grid-lumo-theme-demos-row-dividers'>
+    <h3>No row borders</h3>
+    <p><code>&lt;vaadin-grid <b>theme="no-row-borders"</b>&gt;</code></p>
+    <vaadin-demo-snippet id='grid-lumo-theme-demos-row-borders'>
       <template preserve-content>
         <dom-bind>
           <template>
             <iron-ajax auto url="https://demo.vaadin.com/demo-data/1.0/people?count=20" handle-as="json" last-response="{{users}}"></iron-ajax>
 
-            <vaadin-grid theme="row-dividers" items="[[users.result]]" column-reordering-allowed multi-sort>
+            <vaadin-grid theme="no-row-borders" items="[[users.result]]" column-reordering-allowed multi-sort>
 
               <vaadin-grid-selection-column auto-select> </vaadin-grid-selection-column>
 
@@ -125,15 +127,15 @@
       </template>
     </vaadin-demo-snippet>
 
-    <h3>Column Dividers</h3>
-    <p><code>&lt;vaadin-grid <b>theme="column-dividers"</b>&gt;</code></p>
-    <vaadin-demo-snippet id='grid-lumo-theme-demos-column-dividers'>
+    <h3>Column borders</h3>
+    <p><code>&lt;vaadin-grid <b>theme="column-borders"</b>&gt;</code></p>
+    <vaadin-demo-snippet id='grid-lumo-theme-demos-column-borders'>
       <template preserve-content>
         <dom-bind>
           <template>
             <iron-ajax auto url="https://demo.vaadin.com/demo-data/1.0/people?count=20" handle-as="json" last-response="{{users}}"></iron-ajax>
 
-            <vaadin-grid theme="column-dividers" items="[[users.result]]" column-reordering-allowed multi-sort>
+            <vaadin-grid theme="column-borders" items="[[users.result]]" column-reordering-allowed multi-sort>
 
               <vaadin-grid-selection-column auto-select> </vaadin-grid-selection-column>
 
@@ -208,14 +210,13 @@
     <h3>Wrap Cell Content</h3>
     <p><code>&lt;vaadin-grid <b>theme="wrap-cell-content"</b>&gt;</code></p>
     <p>By default, cell contents don’t wrap and all overflowing content is either clipped or truncated. Apply the <code>wrap-cell-content</code> theme to make the cell content wrap instead.</p>
-    <p>This example is also using the <code>row-dividers</code> theme variant to make the content easier to read.</p>
     <vaadin-demo-snippet id='grid-lumo-theme-demos-wrap-cell-content'>
       <template preserve-content>
         <dom-bind >
           <template>
             <iron-ajax auto url="https://demo.vaadin.com/demo-data/1.0/people?count=20" handle-as="json" last-response="{{users}}"></iron-ajax>
 
-            <vaadin-grid theme="wrap-cell-content row-dividers" items="[[users.result]]" column-reordering-allowed multi-sort>
+            <vaadin-grid theme="wrap-cell-content" items="[[users.result]]" column-reordering-allowed multi-sort>
 
               <vaadin-grid-selection-column auto-select> </vaadin-grid-selection-column>
 

--- a/src/vaadin-grid-styles.html
+++ b/src/vaadin-grid-styles.html
@@ -39,6 +39,7 @@ This program is available under Apache License Version 2.0, available at https:/
         overflow: auto;
         z-index: -2;
         position: relative;
+        outline: none;
       }
 
       /* Avoid jumpy headers on Edge & IE */
@@ -107,7 +108,9 @@ This program is available under Apache License Version 2.0, available at https:/
         display: flex;
         width: 100%;
         position: relative;
-        align-items: stretch;
+        align-items: center;
+        padding: 0;
+        white-space: nowrap;
       }
 
       [part~="details-cell"] {
@@ -115,14 +118,13 @@ This program is available under Apache License Version 2.0, available at https:/
         bottom: 0;
         width: 100%;
         box-sizing: border-box;
+        padding: 0;
       }
 
-      [part~="cell"]:not([part~="details-cell"]) ::slotted(vaadin-grid-cell-content) {
+      [part~="cell"] ::slotted(vaadin-grid-cell-content) {
+        display: block;
         width: 100%;
-        display: inline-flex;
-        justify-content: center;
-        flex-direction: column;
-        white-space: nowrap;
+        box-sizing: border-box;
         overflow: hidden;
       }
 
@@ -132,6 +134,7 @@ This program is available under Apache License Version 2.0, available at https:/
 
       [frozen] {
         z-index: 2;
+        will-change: transform;
       }
 
       #outerscroller {
@@ -241,11 +244,11 @@ This program is available under Apache License Version 2.0, available at https:/
       }
 
       .sizer [part~="details-cell"] {
-        display: none;
+        display: none !important;
       }
 
       .sizer [part~="cell"][hidden] {
-        display: none;
+        display: none !important;
       }
 
       .sizer [part~="cell"] {
@@ -264,7 +267,7 @@ This program is available under Apache License Version 2.0, available at https:/
       }
 
       .sizer [part~="cell"] ::slotted(vaadin-grid-cell-content) {
-        display: none;
+        display: none !important;
       }
 
       /* Fixed mode (Tablet Edge) */
@@ -296,4 +299,3 @@ This program is available under Apache License Version 2.0, available at https:/
     </style>
   </template>
 </dom-module>
-

--- a/src/vaadin-grid.html
+++ b/src/vaadin-grid.html
@@ -203,6 +203,7 @@ This program is available under Apache License Version 2.0, available at https:/
      * `expanded` | Expanded row | row
      * `loading` | Row that is waiting for data from data provider | row
      * `odd` | Odd row | row
+     * `first` | The first body row | row
      *
      * See [ThemableMixin – how to apply styles for shadow parts](https://github.com/vaadin/vaadin-themable-mixin/wiki)
      *
@@ -467,6 +468,7 @@ This program is available under Apache License Version 2.0, available at https:/
             cell._instance.index = index;
           }
         });
+        this._toggleAttribute('first', index === 0, row);
         this._toggleAttribute('odd', index % 2, row);
         this._a11yUpdateRowRowindex(row, index);
         this._getItem(index, row);

--- a/test/.eslintrc.json
+++ b/test/.eslintrc.json
@@ -32,6 +32,7 @@
     "getCellContent": false,
     "getBodyCellContent": false,
     "getHeaderCellContent": false,
+    "getContainerCellContent": false,
     "getFirstVisibleItem": false,
     "getLastVisibleItem": false,
     "simulateScroll": false,

--- a/test/basic.html
+++ b/test/basic.html
@@ -36,7 +36,7 @@
       it('check physical item heights', () => {
         const rowHeight = grid._physicalItems[0].offsetHeight;
 
-        grid._physicalItems.forEach(item => expect(item.offsetHeight).to.equal(rowHeight));
+        grid._physicalItems.forEach(item => expect(item.offsetHeight).to.be.closeTo(rowHeight, 1));
       });
 
       it('check visible item count', () => {

--- a/test/column-groups.html
+++ b/test/column-groups.html
@@ -342,20 +342,6 @@
           animationFrameFlush(done);
         });
 
-        it('should have a border below the header', () => {
-          const cells = header.querySelectorAll('[part~="cell"]');
-          const cellOnLastRow = cells[cells.length - 1];
-
-          expect(window.getComputedStyle(cellOnLastRow).borderBottomStyle).to.eql('solid');
-        });
-
-        it('should have a border above the footer', () => {
-          const cells = footer.querySelectorAll('[part~="cell"]');
-          const cellOnFirstRow = cells[0];
-
-          expect(window.getComputedStyle(cellOnFirstRow).borderTopStyle).to.eql('solid');
-        });
-
         it('should have right content in header', () => {
           expect(getHeaderCellContent(0, 0)).to.equal('group-0');
           expect(getHeaderCellContent(0, 1)).to.equal('group-1');

--- a/test/dynamic-item-size.html
+++ b/test/dynamic-item-size.html
@@ -59,7 +59,7 @@
       it('update size using item index', done => {
         const firstItem = getFirstVisibleItem(grid);
 
-        expect(firstItem.offsetHeight).to.equal(20);
+        expect(firstItem.offsetHeight).to.be.below(100);
 
         grid.classList.add('high');
         flushGrid(grid);
@@ -69,7 +69,7 @@
         grid.style.display = 'none';
         flush(() => {
           grid.style.display = 'block';
-          expect(firstItem.offsetHeight).to.eql(102);
+          expect(firstItem.offsetHeight).not.to.be.below(100);
           done();
         });
       });

--- a/test/keyboard-navigation.html
+++ b/test/keyboard-navigation.html
@@ -18,7 +18,7 @@
 <body>
   <test-fixture id="default">
     <template>
-      <vaadin-grid>
+      <vaadin-grid theme="no-border">
         <template class="row-details">
           <input type="text">
         </template>

--- a/test/physical-count.html
+++ b/test/physical-count.html
@@ -33,6 +33,11 @@
         :host(.small) [part~="cell"] {
           line-height: 10px;
           padding: 0 !important;
+          min-height: 0;
+        }
+
+        :host(.small) [part~="cell"]::slotted(vaadin-grid-cell-content) {
+          padding: 0 !important;
         }
       </style>
     </template>

--- a/test/physical-count.html
+++ b/test/physical-count.html
@@ -13,9 +13,8 @@
   <link rel="import" href="../vaadin-grid.html">
 
   <custom-style>
-    <style is="custom-style">
+    <style>
       vaadin-grid {
-        border: none;
         font-size: 16px;
         line-height: 1.5;
       }
@@ -49,7 +48,7 @@
 
   <test-fixture id="default">
     <template>
-      <vaadin-grid style="width: 200px; height: 200px;" size="200">
+      <vaadin-grid style="width: 200px; height: 200px;" size="200" theme="no-border">
         <vaadin-grid-column>
           <template>[[index]]</template>
         </vaadin-grid-column>

--- a/test/resizing.html
+++ b/test/resizing.html
@@ -82,7 +82,7 @@
         it('should update header height', () => {
           const _bottom = grid.$.header.getBoundingClientRect().bottom;
 
-          grid.style.fontSize = '40px';
+          getHeaderCellContent(grid, 0, 0).style.fontSize = '100px';
           grid.notifyResize();
 
           const _newBottom = grid.$.header.getBoundingClientRect().bottom;
@@ -92,7 +92,7 @@
         });
 
         it('should update footer height', () => {
-          grid.style.fontSize = '40px';
+          getContainerCellContent(grid.$.footer, 0, 0).style.fontSize = '100px';
           grid.notifyResize();
           scrollToEnd(grid);
 
@@ -108,7 +108,7 @@
           const detailsCell = cells.pop();
           const _height = detailsCell.getBoundingClientRect().height;
 
-          grid.style.fontSize = '40px';
+          grid.style.fontSize = '100px';
           grid.notifyResize();
           flushGrid(grid);
 

--- a/test/row-height.html
+++ b/test/row-height.html
@@ -75,7 +75,7 @@
   <script>
     describe('rows', () => {
 
-      let grid, header, rows, defaultHeight, wrappers;
+      let grid, header, rows, defaultHeight, cells;
 
       function init(fixtureName, cb) {
         grid = fixture(fixtureName);
@@ -86,7 +86,7 @@
           rows = getRows(grid.$.items);
           defaultHeight = getRows(header)[0].clientHeight;
 
-          wrappers = getRowCells(rows[0]).map(cell => getCellContent(cell));
+          cells = getRowCells(rows[0]);
 
           cb();
         });
@@ -95,11 +95,11 @@
         header = grid.$.header;
       }
 
-      it('should have higher wrappers on each row cell', done => {
+      it('should have higher cells on each row', done => {
         init('two-columns', () => {
-          wrappers[0].style.height = wrappers[0].clientHeight * 2 + 'px';
+          cells[0].style.height = cells[0].clientHeight * 2 + 'px';
           flush(() => {
-            expect(wrappers[1].clientHeight).to.equal(wrappers[0].clientHeight);
+            expect(cells[1].clientHeight).to.equal(cells[0].clientHeight);
             done();
           });
         });

--- a/theme/lumo/vaadin-grid.html
+++ b/theme/lumo/vaadin-grid.html
@@ -2,6 +2,7 @@
 <link rel="import" href="../../../vaadin-lumo-styles/font-icons.html">
 <link rel="import" href="../../../vaadin-lumo-styles/sizing.html">
 <link rel="import" href="../../../vaadin-lumo-styles/spacing.html">
+<link rel="import" href="../../../vaadin-lumo-styles/style.html">
 <link rel="import" href="../../../vaadin-lumo-styles/typography.html">
 
 <link rel="import" href="../../../vaadin-checkbox/theme/lumo/vaadin-checkbox.html">
@@ -194,6 +195,14 @@
 
       :host([theme~="compact"]) [part="row"]:only-child [part~="header-cell"] {
         min-height: var(--lumo-size-m);
+      }
+
+      :host([theme~="compact"]) [part~="cell"] {
+        min-height: var(--lumo-size-s);
+      }
+
+      :host([theme~="compact"]) [part="row"][first] [part~="cell"]:not([part~="details-cell"]) {
+        min-height: calc(var(--lumo-size-s) - var(--_lumo-grid-border-width));
       }
 
       :host([theme~="compact"]) [part~="cell"] ::slotted(vaadin-grid-cell-content) {

--- a/theme/lumo/vaadin-grid.html
+++ b/theme/lumo/vaadin-grid.html
@@ -61,7 +61,14 @@
         outline: none;
       }
 
-      :host([navigating]) [part~="cell"]:focus {
+      :host([navigating]) [part~="cell"]:focus::before {
+        content: "";
+        position: absolute;
+        top: 0;
+        right: 0;
+        bottom: 0;
+        left: 0;
+        pointer-events: none;
         box-shadow: inset 0 0 0 2px var(--lumo-primary-color-50pct);
       }
 

--- a/theme/lumo/vaadin-grid.html
+++ b/theme/lumo/vaadin-grid.html
@@ -1,7 +1,8 @@
 <link rel="import" href="../../../vaadin-lumo-styles/color.html">
+<link rel="import" href="../../../vaadin-lumo-styles/font-icons.html">
 <link rel="import" href="../../../vaadin-lumo-styles/sizing.html">
 <link rel="import" href="../../../vaadin-lumo-styles/spacing.html">
-<link rel="import" href="../../../vaadin-lumo-styles/font-icons.html">
+<link rel="import" href="../../../vaadin-lumo-styles/typography.html">
 
 <link rel="import" href="../../../vaadin-checkbox/theme/lumo/vaadin-checkbox.html">
 
@@ -9,57 +10,106 @@
   <template>
     <style>
       :host {
-        background-color: var(--lumo-base-color);
         font-family: var(--lumo-font-family);
-        font-size: var(--lumo-font-size);
-        line-height: var(--lumo-line-height);
+        font-size: var(--lumo-font-size-m);
+        line-height: var(--lumo-line-height-s);
         color: var(--lumo-body-text-color);
-        border: 1px solid var(--lumo-contrast-10pct);
+        box-sizing: border-box;
+        -webkit-text-size-adjust: 100%;
+        -webkit-tap-highlight-color: transparent;
+
+        /* For internal use only */
+        --_lumo-grid-border-color: var(--lumo-contrast-20pct);
+        --_lumo-grid-secondary-border-color: var(--lumo-contrast-10pct);
+        --_lumo-grid-border-width: 1px;
+        --_lumo-grid-selected-row-color: var(--lumo-primary-color-10pct);
       }
+
+      /* No (outer) border */
+
+      :host(:not([theme~="no-border"])) {
+        border: var(--_lumo-grid-border-width) solid var(--_lumo-grid-border-color);
+      }
+
+      /* Cell styles */
 
       [part~="cell"] {
-        /* align-items: center; */ /* TODO: only default `stretch` works with tests */
-        padding: 0;
-        -webkit-tap-highlight-color: transparent;
-      }
-
-      [part~="header-cell"],
-      [part~="footer-cell"],
-      [part~="reorder-ghost"] {
+        min-height: var(--lumo-size-m);
         background-color: var(--lumo-base-color);
-        color: var(--lumo-secondary-text-color);
       }
 
-      [part~="header-cell"] ::slotted(*),
-      [part~="footer-cell"] ::slotted(*),
+      [part~="cell"] ::slotted(vaadin-grid-cell-content) {
+        cursor: default;
+        padding: var(--lumo-space-xs) var(--lumo-space-m);
+      }
+
+      /* Apply row borders by default and introduce the "no-row-borders" variant */
+      :host(:not([theme~="no-row-borders"])) [part~="cell"]:not([part~="details-cell"]) {
+        border-top: var(--_lumo-grid-border-width) solid var(--_lumo-grid-secondary-border-color);
+      }
+
+      /* Hide first body row top border */
+      :host(:not([theme~="no-row-borders"])) [part="row"][first] [part~="cell"]:not([part~="details-cell"]) {
+        border-top: 0;
+        min-height: calc(var(--lumo-size-m) - var(--_lumo-grid-border-width));
+      }
+
+      /* Focus-ring */
+
+      [part~="cell"]:focus {
+        outline: none;
+      }
+
+      :host([navigating]) [part~="cell"]:focus {
+        box-shadow: inset 0 0 0 2px var(--lumo-primary-color-50pct);
+      }
+
+      /* Headers and footers */
+
+      [part~="header-cell"] ::slotted(vaadin-grid-cell-content),
+      [part~="footer-cell"] ::slotted(vaadin-grid-cell-content),
       [part~="reorder-ghost"] {
-        font-size: var(--lumo-font-size-xs);
+        font-size: var(--lumo-font-size-s);
+        font-weight: 500;
       }
 
       [part="row"]:only-child [part~="header-cell"] {
         min-height: var(--lumo-size-xl);
       }
 
-      /* Header and footer divider between body rows */
+      /* Header borders */
 
-      [part~="row"] [part~="header-cell"] {
-        border-bottom: 1px solid var(--lumo-contrast-10pct);
+      /* Hide first header row top border */
+      :host(:not([theme~="no-row-borders"])) [part="row"]:first-child [part~="header-cell"] {
+        border-top: 0;
       }
 
-      [part~="row"] [part~="footer-cell"] {
-        border-top: 1px solid var(--lumo-contrast-10pct);
+      [part="row"]:last-child [part~="header-cell"] {
+        border-bottom: var(--_lumo-grid-border-width) solid transparent;
       }
 
-      /* Body rows/cells */
-
-      [part~="body-cell"] {
-        background-color: var(--lumo-base-color);
+      :host(:not([theme~="no-row-borders"])) [part="row"]:last-child [part~="header-cell"] {
+        border-bottom-color: var(--_lumo-grid-secondary-border-color);
       }
 
-      /* Selected row */
+      /* Overflow uses a stronger border color */
+      :host([overflow~="top"]) [part="row"]:last-child [part~="header-cell"] {
+        border-bottom-color: var(--_lumo-grid-border-color);
+      }
 
-      :host(:not([reordering])) [part~="row"][selected] [part~="cell"] {
-        background: linear-gradient(var(--lumo-primary-color-10pct), var(--lumo-primary-color-10pct)) var(--lumo-base-color);
+      /* Footer borders */
+
+      [part="row"]:first-child [part~="footer-cell"] {
+        border-top: var(--_lumo-grid-border-width) solid transparent;
+      }
+
+      :host(:not([theme~="no-row-borders"])) [part="row"]:first-child [part~="footer-cell"] {
+        border-top-color: var(--_lumo-grid-secondary-border-color);
+      }
+
+      /* Overflow uses a stronger border color */
+      :host([overflow~="bottom"]) [part="row"]:first-child [part~="footer-cell"] {
+        border-top-color: var(--_lumo-grid-border-color);
       }
 
       /* Column reordering */
@@ -78,107 +128,95 @@
 
       [part~="reorder-ghost"] {
         opacity: 0.85;
-        box-shadow: 0 0 0 1px var(--lumo-contrast-10pct), 0 2px 8px 0 var(--lumo-shade-30pct);
-        /* TODO why does the reorder-ghost force 0 padding? */
-        /* Use the same padding as for the vaadin-grid-cell-content element */
+        box-shadow: var(--lumo-box-shadow-s);
+        /* TODO Use the same styles as for the cell element (reorder-ghost copies styles from the cell element) */
         padding: var(--lumo-space-s) var(--lumo-space-m) !important;
-      }
-
-      /* Frozen columns */
-
-      [part~="cell"][last-frozen] {
-        border-right: 1px solid var(--lumo-contrast-10pct);
       }
 
       /* Column resizing */
 
-      :host(:not([theme~="column-dividers"])) [part~="cell"]:not([last-frozen]) [part="resize-handle"] {
-        border-right: 1px solid var(--lumo-contrast-10pct);
-        /* right: -1px; */ /* TODO: Breaks resizing tests */
+      [part="resize-handle"] {
+        width: 3px;
+        background-color: var(--lumo-primary-color-50pct);
+        opacity: 0;
+        transition: opacity 0.2s;
       }
 
-      /* Keyboard navigation */
-
-      [part~="cell"]:focus {
-        outline: none;
+      :host(:not([reordering])) *:not([column-resizing]) [part~="cell"]:hover [part="resize-handle"],
+      [part="resize-handle"]:active {
+        opacity: 1;
+        transition-delay: 0.15s;
       }
 
-      :host([navigating]) [part~="cell"]:focus {
-        box-shadow: inset 0 0 0 2px var(--lumo-primary-color-50pct);
+      /* Column borders */
+
+      :host([theme~="column-borders"]) [part~="cell"]:not([last-column]):not([part~="details-cell"]) {
+        border-right: var(--_lumo-grid-border-width) solid var(--_lumo-grid-secondary-border-color);
       }
 
-      /* Borderless */
+      /* Frozen columns */
 
-      :host([theme~="borderless"]) {
-        border: none;
+      [last-frozen] {
+        border-right: var(--_lumo-grid-border-width) solid transparent;
+        overflow: hidden;
       }
 
-      /* Row dividers */
-
-      :host([theme~="row-dividers"]) [part~="body-cell"] {
-        border-bottom: 1px solid var(--lumo-contrast-10pct);
-      }
-
-      /* Column dividers */
-
-      :host([theme~="column-dividers"]) [part~="cell"]:not([last-column]) {
-        border-right: 1px solid var(--lumo-contrast-10pct);
+      :host([overflow~="left"]) [part~="cell"][last-frozen]:not([part~="details-cell"]) {
+        border-right-color: var(--_lumo-grid-border-color);
       }
 
       /* Row stripes */
 
-      :host([theme~="row-stripes"]) [part~="row"][odd] [part~="body-cell"] {
-        background: linear-gradient(var(--lumo-contrast-5pct), var(--lumo-contrast-5pct)) var(--lumo-base-color);
+      :host([theme~="row-stripes"]) [part~="row"]:not([odd]) [part~="body-cell"],
+      :host([theme~="row-stripes"]) [part~="row"]:not([odd]) [part~="details-cell"] {
+        background-image: linear-gradient(var(--lumo-contrast-5pct), var(--lumo-contrast-5pct));
         background-repeat: repeat-x;
       }
 
-      :host([theme~="row-stripes"]) [part~="row"][odd][selected] [part~="body-cell"] {
-        background: linear-gradient(var(--lumo-primary-color-10pct), var(--lumo-primary-color-10pct)), linear-gradient(var(--lumo-contrast-5pct), var(--lumo-contrast-5pct)) var(--lumo-base-color);
-        background-repeat: repeat, repeat-x;
+      /* Selected row */
+
+      /* Raise the selected rows above unselected rows (so that box-shadow can cover unselected rows) */
+      :host(:not([reordering])) [part~="row"][selected] {
+        z-index: 1;
       }
 
-      /* Override cell content styles (experimental) */
-
-      [part~="cell"]:not([part~="details-cell"]) ::slotted(vaadin-grid-cell-content) {
-        /* Fade out overflowing content */
-        --_lumo-grid-cell-overflow-mask-image: linear-gradient(to left, transparent, #000 calc(var(--lumo-space-m) + 0.5em));
-        -webkit-mask-image: var(--_lumo-grid-cell-overflow-mask-image);
-        cursor: default;
-        padding: var(--lumo-space-s) var(--lumo-space-m);
-        box-sizing: border-box;
-        line-height: var(--lumo-line-height-s);
+      :host(:not([reordering])) [part~="row"][selected] [part~="body-cell"]:not([part~="details-cell"]) {
+        background-image: linear-gradient(var(--_lumo-grid-selected-row-color), var(--_lumo-grid-selected-row-color));
+        background-repeat: repeat;
       }
 
-      /*
-        TODO: CSS custom property in `mask-image` causes crash in Edge
-        see https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/15415089/
-      */
-      @-moz-document url-prefix() {
-        [part~="cell"]:not([part~="details-cell"]) ::slotted(vaadin-grid-cell-content) {
-          mask-image: var(--_lumo-grid-cell-overflow-mask-image);
-        }
+      /* Cover the border of an unselected row */
+      :host(:not([theme~="no-row-borders"])) [part~="row"][selected] [part~="cell"]:not([part~="details-cell"]) {
+        box-shadow: 0 var(--_lumo-grid-border-width) 0 0 var(--_lumo-grid-selected-row-color);
       }
 
-      /* Compact theme */
+      /* Compact */
 
       :host([theme~="compact"]) [part="row"]:only-child [part~="header-cell"] {
         min-height: var(--lumo-size-m);
       }
 
-      :host([theme~="compact"]) [part~="cell"]:not([part~="details-cell"]) ::slotted(vaadin-grid-cell-content) {
+      :host([theme~="compact"]) [part~="cell"] ::slotted(vaadin-grid-cell-content) {
         padding: var(--lumo-space-xs) var(--lumo-space-s);
       }
 
       /* Wrap cell contents */
 
-      :host([theme~="wrap-cell-content"]) [part~="cell"]:not([part~="details-cell"]) ::slotted(vaadin-grid-cell-content) {
+      :host([theme~="wrap-cell-content"]) [part~="cell"] ::slotted(vaadin-grid-cell-content) {
         white-space: normal;
-        -webkit-mask-image: none;
-        mask-image: none;
       }
     </style>
   </template>
 </dom-module>
 
+<dom-module theme-for="vaadin-checkbox" id="vaadin-grid-select-all-checkbox-lumo">
+  <template>
+    <style>
+      :host(.vaadin-grid-select-all-checkbox) {
+        font-size: var(--lumo-font-size-m);
+      }
+   </style>
+  </template>
+</dom-module>
 
 <link rel="import" href="../../src/vaadin-grid.html">


### PR DESCRIPTION
## New features

New styling attribute for the first body row.

## Core styles

Remove browser focus outline from the table element (can be seen if you click the grid scrollbar twice).

The `vaadin-grid-cell-content` elements are now block containers instead of flex containers, and aligned to the center of the cell (instead of stretched).

Reset browser default cell padding.

Apply the same styles for the detail cell content element as for normal cell content elements.

Force sized content to be always hidden (theme can potentially accidentally override it).

Apply `will-change: transform;` on frozen cells (improves performance in Safari).

## Lumo

Rows now have borders by default in Lumo (previously opt-in, now opt-out).

Use the `overflow` state attribute to adjust the header and footer borders.

Lumo theme variants renamed (unify naming conventions):
- `borderless` → `no-border`
- `row-dividers` → `no-row-borders`
- `column-dividers` → `column-borders`

Fixed tests and removed two tests that tested the theme instead of core functionality (header and footer borders).

Reset the select-all checkbox size.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-grid/1204)
<!-- Reviewable:end -->
