### PR TITLE
Header text-align should respect writing direction

### DIFF
--- a/src/vaadin-grid-styles.html
+++ b/src/vaadin-grid-styles.html
@@ -55,18 +55,18 @@ This program is available under Apache License Version 2.0, available at https:/
         width: 100%;
       }
 
-      [part~="header-cell"] {
+      th {
         text-align: initial;
       }
 
       @supports (-ms-ime-align: auto) {
-        [part~="header-cell"] {
+        th {
           text-align: inherit;
         }
       }
 
       ::-ms-backdrop,
-      [part~="header-cell"] {
+      th {
         text-align: inherit;
       }
 

--- a/src/vaadin-grid-styles.html
+++ b/src/vaadin-grid-styles.html
@@ -56,8 +56,18 @@ This program is available under Apache License Version 2.0, available at https:/
       }
 
       [part~="header-cell"] {
-        font-weight: 500;
-        text-align: left;
+        text-align: initial;
+      }
+
+      @supports (-ms-ime-align: auto) {
+        [part~="header-cell"] {
+          text-align: inherit;
+        }
+      }
+
+      ::-ms-backdrop,
+      [part~="header-cell"] {
+        text-align: inherit;
       }
 
       #footer {

--- a/src/vaadin-grid-styles.html
+++ b/src/vaadin-grid-styles.html
@@ -56,18 +56,12 @@ This program is available under Apache License Version 2.0, available at https:/
       }
 
       th {
-        text-align: initial;
-      }
-
-      @supports (-ms-ime-align: auto) {
-        th {
-          text-align: inherit;
-        }
-      }
-
-      ::-ms-backdrop,
-      th {
         text-align: inherit;
+      }
+
+      /* Safari doesn't work with `inherit` */
+      [safari] th {
+        text-align: initial;
       }
 
       #footer {


### PR DESCRIPTION
If a parent element has `dir="rtl"`, the header texts should be aligned correctly as well.

IE11 and Edge don’t work with `initial`. All browsers except Safari work with `inherit`, but I don’t know a way to target Safari only – hence the IE11 and Edge specific workarounds.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-grid/1215)
<!-- Reviewable:end -->
