### PR TITLE
Remove focus outline from #table

### DIFF
--- a/vaadin-grid-styles.html
+++ b/vaadin-grid-styles.html
@@ -39,6 +39,7 @@ This program is available under Apache License Version 2.0, available at https:/
         overflow: auto;
         z-index: -2;
         position: relative;
+        outline: none;
       }
 
       /* Avoid jumpy headers on Edge & IE */


### PR DESCRIPTION
Fixes #1217 

The same as https://github.com/vaadin/vaadin-grid/commit/dfe148a467e623330bee4fe8849ad049989a0f8c#diff-30c5c1eefb237a602c6b5c40f41d7c88R42 but for 4.x

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-grid/1219)
<!-- Reviewable:end -->
