### PR TITLE
Enable reordering columns of a group with no headers

### DIFF
--- a/src/vaadin-grid-column-reordering-mixin.html
+++ b/src/vaadin-grid-column-reordering-mixin.html
@@ -129,6 +129,10 @@ This program is available under Apache License Version 2.0, available at https:/
 
       this.setAttribute('reordering', '');
       this._draggedColumn = headerCell._column;
+      while (this._draggedColumn.parentElement.childElementCount === 1) {
+        // This is the only column in the group, drag the whole group instead
+        this._draggedColumn = this._draggedColumn.parentElement;
+      }
       this._setSiblingsReorderStatus(this._draggedColumn, 'allowed');
       this._draggedColumn._reorderStatus = 'dragging';
 
@@ -279,8 +283,8 @@ This program is available under Apache License Version 2.0, available at https:/
 
     _isSwappableByPosition(targetColumn, clientX) {
       const targetCell =
-        Array.prototype.filter.call(this.$.header.querySelectorAll('[part~="cell"]'), cell => cell._column === targetColumn)[0];
-      const sourceCellRect = this.$.header.querySelector('[reorder-status=dragging]').getBoundingClientRect();
+        Array.from(this.$.header.querySelectorAll('tr:not([hidden]) [part~="cell"]')).filter(cell => targetColumn.contains(cell._column))[0];
+      const sourceCellRect = this.$.header.querySelector('tr:not([hidden]) [reorder-status=dragging]').getBoundingClientRect();
       const targetRect = targetCell.getBoundingClientRect();
       if (targetRect.left > sourceCellRect.left) {
         return clientX > targetRect.right - sourceCellRect.width;

--- a/test/column-reordering.html
+++ b/test/column-reordering.html
@@ -121,6 +121,26 @@
     </template>
   </test-fixture>
 
+  <test-fixture id="empty-header-group">
+    <template>
+      <vaadin-grid style="width: 400px; height: 200px;" size="1" column-reordering-allowed>
+        <vaadin-grid-column-group>
+          <vaadin-grid-column>
+            <template class="header">1</template>
+            <template>1</template>
+            <template class="footer">1</template>
+          </vaadin-grid-column>
+        </vaadin-grid-column-group>
+
+        <vaadin-grid-column>
+          <template class="header">2</template>
+          <template>2</template>
+          <template class="footer">2</template>
+        </vaadin-grid-column>
+      </vaadin-grid>
+    </template>
+  </test-fixture>
+
   <test-fixture id="newColumn">
     <template>
       <vaadin-grid-column>
@@ -577,6 +597,35 @@
       it('should not start reordering inside draggable footer cell content', () => {
         dragStart(visualColumnCellContents[0][2].children[0]);
         expect(grid.hasAttribute('reordering')).to.be.false;
+      });
+
+    });
+
+    describe('group with empty headers', () => {
+
+      let grid;
+
+      beforeEach(done => {
+        grid = fixture('empty-header-group');
+        grid.dataProvider = infiniteDataProvider;
+        flushGrid(grid);
+        done();
+      });
+
+      it('should swap a column and a column of a group with empty header', () => {
+        dragAndDropOver(
+          getVisualHeaderCellContent(grid, 0, 1),
+          getVisualHeaderCellContent(grid, 0, 0)
+        );
+        expectVisualOrder(grid, [2, 1]);
+      });
+
+      it('should swap a column of a group with empty header and a column', () => {
+        dragAndDropOver(
+          getVisualHeaderCellContent(grid, 0, 0),
+          getVisualHeaderCellContent(grid, 0, 1)
+        );
+        expectVisualOrder(grid, [2, 1]);
       });
 
     });


### PR DESCRIPTION
Fixes #1229

Needs to be cherry-picked to 4.X

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-grid/1244)
<!-- Reviewable:end -->
