### PR TITLE
Increase the item pool lazily after initial batch is rendered

### DIFF
--- a/src/vaadin-grid-scroller.html
+++ b/src/vaadin-grid-scroller.html
@@ -163,15 +163,35 @@ This program is available under Apache License Version 2.0, available at https:/
           return;
         }
 
-        if (this._physicalCount === 0) {
-          this._updateMetrics();
+        if (!this._initialPoolCreated) {
+          this._initialPoolCreated = true;
           super._increasePoolIfNeeded(25);
         } else {
-          const viewportCovered = this._physicalCount * this._physicalAverage >= this._viewportHeight * 3;
-          // Don't increase the pool if there's enough rows. This is to avoid an eternal loop.
-          if (!viewportCovered) {
-            this._accessIronListAPI(() => super._increasePoolIfNeeded(count));
-          }
+          this._debounceIncreasePool = Polymer.Debouncer.debounce(
+            this._debounceIncreasePool,
+            Polymer.Async.animationFrame,
+            () => {
+              this._updateMetrics();
+              const viewportCovered = this._physicalCount * this._physicalAverage >= this._viewportHeight * 3;
+              // Don't increase the pool if there's enough rows. This is to avoid an eternal loop.
+              if (!viewportCovered) {
+                this._accessIronListAPI(() => super._increasePoolIfNeeded(count));
+
+                const childNodes = Array.from(this.$.items.childNodes);
+                // Ensure the rows are in order after increasing pool
+                const rowsInOrder = !!childNodes.reduce((inOrder, current, currentIndex, array) => {
+                  if (currentIndex === 0 || array[currentIndex - 1].index === current.index - 1) {
+                    return inOrder;
+                  }
+                }, true);
+
+                if (!rowsInOrder) {
+                  childNodes.sort((row1, row2) => {
+                    return row1.index - row2.index;
+                  }).forEach(row => this.$.items.appendChild(row));
+                }
+              }
+            });
         }
       }
 

--- a/test/helpers.html
+++ b/test/helpers.html
@@ -27,6 +27,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     if (grid._debounceOverflow) {
       grid._debounceOverflow.flush();
     }
+    while (grid._debounceIncreasePool) {
+      grid._debounceIncreasePool.flush();
+      grid._debounceIncreasePool = null;
+      Polymer.flush();
+    }
   }
 
   function getCell(grid, index) {

--- a/test/keyboard-navigation.html
+++ b/test/keyboard-navigation.html
@@ -957,6 +957,7 @@
           grid.items = undefined;
           grid.size = 200;
           grid.dataProvider = infiniteDataProvider;
+          flushGrid(grid);
 
           focusItem(0);
 


### PR DESCRIPTION
This is another IE11 -targeted performance improvement PR.

Initial load time in the used test app (with a 20-column grid) dropped from 4.5 seconds to 1.5 seconds with these changes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-grid/1247)
<!-- Reviewable:end -->
