### PR TITLE
Add "main" to package.json to enable easy imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "@vaadin/vaadin-grid",
   "version": "5.0.0-pre.4",
   "description": "A free, flexible and high-quality Web Component for showing large amounts of tabular data",
+  "main": "vaadin-grid.html",
   "author": "Vaadin Ltd",
   "license": "Apache-2.0",
   "repository": "vaadin/vaadin-grid",


### PR DESCRIPTION
The same as #1300 but targeting `p3-preview` branch

> With ES Modules, you can do `import '@vaadin/vaadin-grid';` with this in place. Without it, you have to do `import '@vaadin/vaadin-grid/vaadin-grid.js';` This is available in other components like vaadin-button and vaadin-text-field, so it is isolated to grid. This should flow to the p3 branch as well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-grid/1301)
<!-- Reviewable:end -->
