### PR TITLE
Reorganize demo structure

### DIFF
--- a/demo/demos.json
+++ b/demo/demos.json
@@ -2,14 +2,14 @@
   "name": "Vaadin Grid",
   "pages": [
   {
-    "name": "Basic Usage",
+    "name": "Basics",
     "url": "grid-basic-demos",
     "src": "grid-basic-demos.html",
     "meta": {
-      "title": "vaadin-grid – Basic Usage",
+      "title": "vaadin-grid – Basic Examples",
       "description": "",
       "image": ""
-     }
+    }
   }
   ,
   {
@@ -20,7 +20,7 @@
       "title": "vaadin-grid – Assigning Data",
       "description": "",
       "image": ""
-     }
+    }
   }
   ,
   {
@@ -31,7 +31,7 @@
       "title": "vaadin-grid – Selection",
       "description": "",
       "image": ""
-     }
+    }
   }
   ,
   {
@@ -42,18 +42,29 @@
       "title": "vaadin-grid – Column Properties",
       "description": "",
       "image": ""
-     }
+    }
   }
   ,
   {
-    "name": "Sorting and Filtering",
-    "url": "grid-sorting-filtering-demos",
-    "src": "grid-sorting-filtering-demos.html",
+    "name": "Sorting",
+    "url": "grid-sorting-demos",
+    "src": "grid-sorting-demos.html",
     "meta": {
-      "title": "vaadin-grid – Sorting and Filtering",
+      "title": "vaadin-grid – Sorting",
       "description": "",
       "image": ""
-     }
+    }
+  }
+  ,
+  {
+    "name": "Filtering",
+    "url": "grid-filtering-demos",
+    "src": "grid-filtering-demos.html",
+    "meta": {
+      "title": "vaadin-grid – Filtering",
+      "description": "",
+      "image": ""
+    }
   }
   ,
   {
@@ -64,7 +75,7 @@
       "title": "vaadin-grid – Row Details",
       "description": "",
       "image": ""
-     }
+    }
   }
   ,
   {
@@ -75,7 +86,7 @@
       "title": "vaadin-grid – CRUD",
       "description": "",
       "image": ""
-     }
+    }
   }
   ,
   {
@@ -86,7 +97,7 @@
       "title": "vaadin-grid – Pagination",
       "description": "",
       "image": ""
-     }
+    }
   }
   ,
   {
@@ -101,11 +112,11 @@
   }
   ,
   {
-    "name": "Lumo Theme Variations",
-    "url": "grid-lumo-theme-demos",
-    "src": "grid-lumo-theme-demos.html",
+    "name": "Theme Variants",
+    "url": "grid-theme-demos",
+    "src": "grid-theme-demos.html",
     "meta": {
-      "title": "vaadin-grid – Lumo Theme Variations",
+      "title": "vaadin-grid – Theme Variants",
       "description": "",
       "image": ""
     }

--- a/demo/grid-crud-demos.html
+++ b/demo/grid-crud-demos.html
@@ -13,7 +13,7 @@
     </style>
 
 
-    <h3>CRUD</h3>
+    <h3>Create, Read, Update and Delete</h3>
     <p>
       Column <code>&lt;template&gt;</code> elements and data binding can be used to implement inline editing.
     </p>

--- a/demo/grid-filtering-demos.html
+++ b/demo/grid-filtering-demos.html
@@ -1,4 +1,4 @@
-<dom-module id="grid-sorting-filtering-demos">
+<dom-module id="grid-filtering-demos">
   <template>
     <style include="vaadin-component-demo-shared-styles">
       :host {
@@ -13,135 +13,6 @@
     </style>
 
 
-    <h3>Sorting</h3>
-    <p>
-      <code>&lt;vaadin-grid-sorter&gt;</code> can be used to define sorting for a column.
-      The users in the example are sorted by last name initially.
-    </p>
-    <p>
-      <b>NOTE: You must explicitly import the <code>vaadin-grid-sorter.html</code> in order to use <code>&lt;vaadin-grid-sorter&gt;</code>.</b>
-    </p>
-
-    <vaadin-demo-snippet id='grid-sorting-filtering-demos-sorting'>
-      <template preserve-content>
-        <dom-bind>
-          <template>
-
-            <x-array-data-provider items="{{items}}"></x-array-data-provider>
-
-            <vaadin-checkbox checked="{{multiSort}}">Enable Multi-Sorting</vaadin-checkbox>
-
-            <vaadin-grid aria-label="Sorting Example" items="[[items]]" multi-sort="[[multiSort]]">
-
-              <vaadin-grid-column width="60px" flex-grow="0">
-                <template class="header">#</template>
-                <template>[[index]]</template>
-              </vaadin-grid-column>
-
-              <vaadin-grid-column>
-                <template class="header">
-                  <vaadin-grid-sorter path="name.first">First Name</vaadin-grid-sorter>
-                </template>
-                <template>[[item.name.first]]</template>
-              </vaadin-grid-column>
-
-              <vaadin-grid-column>
-                <template class="header">
-                  <vaadin-grid-sorter path="name.last" direction="asc">Last Name</vaadin-grid-sorter>
-                </template>
-                <template>[[item.name.last]]</template>
-              </vaadin-grid-column>
-
-            </vaadin-grid>
-          </template>
-        </dom-bind>
-      </template>
-    </vaadin-demo-snippet>
-
-
-    <h3>Sorting with Data Provider</h3>
-    <p>
-      When the data is fetched from a data provider, the responsibility
-      of providing the correctly ordered data is on the data provider itself.
-      The data provider is asked for fresh sorted data whenever the sorting
-      order is changed on any <code>&lt;vaadin-grid-sorter&gt;</code>.
-    </p>
-    <p>
-      The effective <code>sortOrders</code> array will be included as one of
-      the data provider call options.
-    </p>
-    <p>
-      <b>Hint: </b>When using a data provider, <code>path</code> on the
-      <code>&lt;vaadin-grid-sorter&gt;</code> element can be set to any string,
-      instead of a property on the item object.
-    </p>
-
-    <vaadin-demo-snippet id='grid-sorting-filtering-demos-sorting-with-data-provider'>
-      <template preserve-content>
-        <x-remote-sorting-example></x-remote-sorting-example>
-        <dom-module id="x-remote-sorting-example">
-          <template preserve-content>
-            <vaadin-checkbox checked="{{multiSort}}">Enable Multi-Sorting</vaadin-checkbox>
-
-            <vaadin-grid aria-label="Sorting with Data Provider Example" id="grid" multi-sort="[[multiSort]]">
-
-              <vaadin-grid-column width="60px" flex-grow="0">
-                <template class="header">#</template>
-                <template>[[index]]</template>
-              </vaadin-grid-column>
-
-              <vaadin-grid-column>
-                <template class="header">
-                  <vaadin-grid-sorter path="firstName">First Name</vaadin-grid-sorter>
-                </template>
-                <template>[[item.firstName]]</template>
-              </vaadin-grid-column>
-
-              <vaadin-grid-column>
-                <template class="header">
-                  <vaadin-grid-sorter path="lastName">Last Name</vaadin-grid-sorter>
-                </template>
-                <template>[[item.lastName]]</template>
-              </vaadin-grid-column>
-
-            </vaadin-grid>
-          </template>
-          <script>
-            window.addDemoReadyListener('#grid-sorting-filtering-demos-sorting-with-data-provider', function(document) {
-              Polymer({
-                is: 'x-remote-sorting-example',
-
-                ready: function() {
-                  var grid = this.$.grid;
-
-                  grid.size = 200;
-
-                  grid.dataProvider = function(params, callback) {
-                    var xhr = new XMLHttpRequest();
-                    xhr.onload = function() {
-                      callback(JSON.parse(xhr.responseText).result);
-                    };
-
-                    var index = params.page * params.pageSize;
-                    var url = 'https://demo.vaadin.com/demo-data/1.0/people?index=' + index + '&count=' + params.pageSize;
-
-                    // `params.sortOrders` format: [{path: 'lastName', direction: 'asc'}, ...];
-                    params.sortOrders.forEach(function(sort) {
-                      url += '&orders[]=' + sort.path + ' ' + sort.direction;
-                    });
-
-                    xhr.open('GET', url, true);
-                    xhr.send();
-                  };
-                }
-              });
-            });
-          </script>
-        </dom-module>
-      </template>
-    </vaadin-demo-snippet>
-
-
     <h3>Filtering</h3>
     <p>
       <code>&lt;vaadin-grid-filter&gt;</code> can be used to define filtering for a column.
@@ -150,7 +21,7 @@
       <b>NOTE: You must explicitly import the <code>vaadin-grid-filter.html</code> in order to use <code>&lt;vaadin-grid-filter&gt;</code>.</b>
     </p>
 
-    <vaadin-demo-snippet id='grid-sorting-filtering-demos-filtering'>
+    <vaadin-demo-snippet id='grid-filtering-demos-filtering'>
       <template preserve-content>
         <dom-bind>
           <template>
@@ -204,7 +75,7 @@
       can be customized to be any string, instead of a property on the item object.
     </p>
 
-    <vaadin-demo-snippet id='grid-sorting-filtering-demos-filtering-with-data-provider'>
+    <vaadin-demo-snippet id='grid-filtering-demos-filtering-with-data-provider'>
       <template preserve-content>
         <x-remote-filtering-example></x-remote-filtering-example>
         <dom-module id="x-remote-filtering-example">
@@ -237,7 +108,7 @@
             </vaadin-grid>
           </template>
           <script>
-            window.addDemoReadyListener('#grid-sorting-filtering-demos-filtering-with-data-provider', function(document) {
+            window.addDemoReadyListener('#grid-filtering-demos-filtering-with-data-provider', function(document) {
               Polymer({
                 is: 'x-remote-filtering-example',
 
@@ -280,11 +151,11 @@
 
   </template>
   <script>
-    class GridSortingFilteringDemos extends DemoReadyEventEmitter(GridDemo(Polymer.Element)) {
+    class GridFilteringDemos extends DemoReadyEventEmitter(GridDemo(Polymer.Element)) {
       static get is() {
-        return 'grid-sorting-filtering-demos';
+        return 'grid-filtering-demos';
       }
     }
-    customElements.define(GridSortingFilteringDemos.is, GridSortingFilteringDemos);
+    customElements.define(GridFilteringDemos.is, GridFilteringDemos);
   </script>
 </dom-module>

--- a/demo/grid-sorting-demos.html
+++ b/demo/grid-sorting-demos.html
@@ -1,0 +1,154 @@
+<dom-module id="grid-sorting-demos">
+  <template>
+    <style include="vaadin-component-demo-shared-styles">
+      :host {
+        display: block;
+      }
+    </style>
+
+    <style>
+      vaadin-checkbox {
+        margin-bottom: 10px;
+      }
+    </style>
+
+
+    <h3>Sorting</h3>
+    <p>
+      <code>&lt;vaadin-grid-sorter&gt;</code> can be used to define sorting for a column.
+      The users in the example are sorted by last name initially.
+    </p>
+    <p>
+      <b>NOTE: You must explicitly import the <code>vaadin-grid-sorter.html</code> in order to use <code>&lt;vaadin-grid-sorter&gt;</code>.</b>
+    </p>
+
+    <vaadin-demo-snippet id='grid-sorting-demos-sorting'>
+      <template preserve-content>
+        <dom-bind>
+          <template>
+
+            <x-array-data-provider items="{{items}}"></x-array-data-provider>
+
+            <vaadin-checkbox checked="{{multiSort}}">Enable Multi-Sorting</vaadin-checkbox>
+
+            <vaadin-grid aria-label="Sorting Example" items="[[items]]" multi-sort="[[multiSort]]">
+
+              <vaadin-grid-column width="60px" flex-grow="0">
+                <template class="header">#</template>
+                <template>[[index]]</template>
+              </vaadin-grid-column>
+
+              <vaadin-grid-column>
+                <template class="header">
+                  <vaadin-grid-sorter path="name.first">First Name</vaadin-grid-sorter>
+                </template>
+                <template>[[item.name.first]]</template>
+              </vaadin-grid-column>
+
+              <vaadin-grid-column>
+                <template class="header">
+                  <vaadin-grid-sorter path="name.last" direction="asc">Last Name</vaadin-grid-sorter>
+                </template>
+                <template>[[item.name.last]]</template>
+              </vaadin-grid-column>
+
+            </vaadin-grid>
+          </template>
+        </dom-bind>
+      </template>
+    </vaadin-demo-snippet>
+
+
+    <h3>Sorting with Data Provider</h3>
+    <p>
+      When the data is fetched from a data provider, the responsibility
+      of providing the correctly ordered data is on the data provider itself.
+      The data provider is asked for fresh sorted data whenever the sorting
+      order is changed on any <code>&lt;vaadin-grid-sorter&gt;</code>.
+    </p>
+    <p>
+      The effective <code>sortOrders</code> array will be included as one of
+      the data provider call options.
+    </p>
+    <p>
+      <b>Hint: </b>When using a data provider, <code>path</code> on the
+      <code>&lt;vaadin-grid-sorter&gt;</code> element can be set to any string,
+      instead of a property on the item object.
+    </p>
+
+    <vaadin-demo-snippet id='grid-sorting-demos-sorting-with-data-provider'>
+      <template preserve-content>
+        <x-remote-sorting-example></x-remote-sorting-example>
+        <dom-module id="x-remote-sorting-example">
+          <template preserve-content>
+            <vaadin-checkbox checked="{{multiSort}}">Enable Multi-Sorting</vaadin-checkbox>
+
+            <vaadin-grid aria-label="Sorting with Data Provider Example" id="grid" multi-sort="[[multiSort]]">
+
+              <vaadin-grid-column width="60px" flex-grow="0">
+                <template class="header">#</template>
+                <template>[[index]]</template>
+              </vaadin-grid-column>
+
+              <vaadin-grid-column>
+                <template class="header">
+                  <vaadin-grid-sorter path="firstName">First Name</vaadin-grid-sorter>
+                </template>
+                <template>[[item.firstName]]</template>
+              </vaadin-grid-column>
+
+              <vaadin-grid-column>
+                <template class="header">
+                  <vaadin-grid-sorter path="lastName">Last Name</vaadin-grid-sorter>
+                </template>
+                <template>[[item.lastName]]</template>
+              </vaadin-grid-column>
+
+            </vaadin-grid>
+          </template>
+          <script>
+            window.addDemoReadyListener('#grid-sorting-demos-sorting-with-data-provider', function(document) {
+              Polymer({
+                is: 'x-remote-sorting-example',
+
+                ready: function() {
+                  var grid = this.$.grid;
+
+                  grid.size = 200;
+
+                  grid.dataProvider = function(params, callback) {
+                    var xhr = new XMLHttpRequest();
+                    xhr.onload = function() {
+                      callback(JSON.parse(xhr.responseText).result);
+                    };
+
+                    var index = params.page * params.pageSize;
+                    var url = 'https://demo.vaadin.com/demo-data/1.0/people?index=' + index + '&count=' + params.pageSize;
+
+                    // `params.sortOrders` format: [{path: 'lastName', direction: 'asc'}, ...];
+                    params.sortOrders.forEach(function(sort) {
+                      url += '&orders[]=' + sort.path + ' ' + sort.direction;
+                    });
+
+                    xhr.open('GET', url, true);
+                    xhr.send();
+                  };
+                }
+              });
+            });
+          </script>
+        </dom-module>
+      </template>
+    </vaadin-demo-snippet>
+
+
+  </template>
+  <script>
+    class GridSortingDemos extends DemoReadyEventEmitter(GridDemo(Polymer.Element)) {
+      static get is() {
+        return 'grid-sorting-demos';
+      }
+    }
+    customElements.define(GridSortingDemos.is, GridSortingDemos);
+  </script>
+</dom-module>

--- a/demo/grid-theme-demos.html
+++ b/demo/grid-theme-demos.html
@@ -1,4 +1,4 @@
-<dom-module id="grid-lumo-theme-demos">
+<dom-module id="grid-theme-demos">
   <template>
     <style include="vaadin-component-demo-shared-styles">
       :host {
@@ -10,7 +10,7 @@
 
     <h3>Compact</h3>
     <p><code>&lt;vaadin-grid <b>theme="compact"</b>&gt;</code></p>
-    <vaadin-demo-snippet id='grid-lumo-theme-demos-compact'>
+    <vaadin-demo-snippet id='grid-theme-demos-compact'>
       <template preserve-content>
         <dom-bind>
           <template>
@@ -50,7 +50,7 @@
 
     <h3>No border</h3>
     <p><code>&lt;vaadin-grid <b>theme="no-border"</b>&gt;</code></p>
-    <vaadin-demo-snippet id='grid-lumo-theme-demos-bordered'>
+    <vaadin-demo-snippet id='grid-theme-demos-bordered'>
       <template preserve-content>
         <dom-bind>
           <template>
@@ -90,7 +90,7 @@
 
     <h3>No row borders</h3>
     <p><code>&lt;vaadin-grid <b>theme="no-row-borders"</b>&gt;</code></p>
-    <vaadin-demo-snippet id='grid-lumo-theme-demos-row-borders'>
+    <vaadin-demo-snippet id='grid-theme-demos-row-borders'>
       <template preserve-content>
         <dom-bind>
           <template>
@@ -129,7 +129,7 @@
 
     <h3>Column borders</h3>
     <p><code>&lt;vaadin-grid <b>theme="column-borders"</b>&gt;</code></p>
-    <vaadin-demo-snippet id='grid-lumo-theme-demos-column-borders'>
+    <vaadin-demo-snippet id='grid-theme-demos-column-borders'>
       <template preserve-content>
         <dom-bind>
           <template>
@@ -169,7 +169,7 @@
 
     <h3>Row Stripes</h3>
     <p><code>&lt;vaadin-grid <b>theme="row-stripes"</b>&gt;</code></p>
-    <vaadin-demo-snippet id='grid-lumo-theme-demos-row-stripes'>
+    <vaadin-demo-snippet id='grid-theme-demos-row-stripes'>
       <template preserve-content>
         <dom-bind>
           <template>
@@ -210,7 +210,7 @@
     <h3>Wrap Cell Content</h3>
     <p><code>&lt;vaadin-grid <b>theme="wrap-cell-content"</b>&gt;</code></p>
     <p>By default, cell contents don’t wrap and all overflowing content is either clipped or truncated. Apply the <code>wrap-cell-content</code> theme to make the cell content wrap instead.</p>
-    <vaadin-demo-snippet id='grid-lumo-theme-demos-wrap-cell-content'>
+    <vaadin-demo-snippet id='grid-theme-demos-wrap-cell-content'>
       <template preserve-content>
         <dom-bind >
           <template>
@@ -250,11 +250,11 @@
 
   </template>
   <script>
-    class GridLumoThemeDemos extends DemoReadyEventEmitter(GridDemo(Polymer.Element)) {
+    class GridThemeDemos extends DemoReadyEventEmitter(GridDemo(Polymer.Element)) {
       static get is() {
-        return 'grid-lumo-theme-demos';
+        return 'grid-theme-demos';
       }
     }
-    customElements.define(GridLumoThemeDemos.is, GridLumoThemeDemos);
+    customElements.define(GridThemeDemos.is, GridThemeDemos);
   </script>
 </dom-module>

--- a/demo/x-data-provider.html
+++ b/demo/x-data-provider.html
@@ -52,7 +52,7 @@
           "state": "indre",
           "zip": 86307
         },
-        "email": "fabien.le gall@example.com",
+        "email": "fabien.legall@example.com",
         "username": "goldenlion501",
         "password": "outkast",
         "phone": "03-59-32-43-22",
@@ -829,7 +829,7 @@
           "state": "vaucluse",
           "zip": 88377
         },
-        "email": "loïs.le gall@example.com",
+        "email": "loïs.legall@example.com",
         "username": "lazypanda653",
         "password": "shaggy",
         "phone": "05-08-25-24-00",
@@ -4000,7 +4000,7 @@
           "state": "seine-maritime",
           "zip": 81736
         },
-        "email": "théo.le gall@example.com",
+        "email": "théo.legall@example.com",
         "username": "crazyfrog346",
         "password": "cheech",
         "phone": "04-01-20-94-59",


### PR DESCRIPTION
Connects to "Guidelines for component examples":
- Rename Basic Usage -> Basics
- Split "Sorting and Filtering" into "Sorting" and "Filtering"
- Rename "Lumo Theme Variations" to "Theme Variants"

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-grid/1323)
<!-- Reviewable:end -->
