### PR TITLE
Update demos to prefer renderers

### DIFF
--- a/demo/grid-basic-demos.html
+++ b/demo/grid-basic-demos.html
@@ -6,8 +6,66 @@
       }
     </style>
 
+    <h3>Content Renderer Function</h3>
+    <vaadin-demo-snippet id='grid-columns-demos-renderer-functions'>
+      <template preserve-content>
+        <iron-ajax auto url="https://demo.vaadin.com/demo-data/1.0/people?count=200"></iron-ajax>
 
-    <h3>Basic Binding</h3>
+        <vaadin-grid aria-label="Content Renderer Function">
+          <vaadin-grid-column id="column1" width="60px" flex-grow="0"></vaadin-grid-column>
+          <vaadin-grid-column id="column2"></vaadin-grid-column>
+          <vaadin-grid-column id="column3"></vaadin-grid-column>
+          <vaadin-grid-column id="column4" width="8em"></vaadin-grid-column>
+        </vaadin-grid>
+        <script>
+          window.addDemoReadyListener('#grid-columns-demos-renderer-functions', function(document) {
+            const ajax = document.querySelector('iron-ajax');
+            const grid = document.querySelector('vaadin-grid');
+            const column1 = document.querySelector('#column1');
+            const column2 = document.querySelector('#column2');
+            const column3 = document.querySelector('#column3');
+            const column4 = document.querySelector('#column4');
+
+            ajax.addEventListener('last-response-changed', function(e) {
+              grid.items = e.target.lastResponse.result;
+            });
+
+            column1.renderer = function(root, column, model) {
+              root.innerHTML = model.index;
+            };
+            column1.headerRenderer = column1.footerRenderer = function(root, column) {
+              root.innerHTML = '#';
+            };
+
+            column2.renderer = function(root, column, model) {
+              root.innerHTML = model.item.firstName;
+            };
+            column2.headerRenderer = column2.footerRenderer = function(root, column) {
+              root.innerHTML = 'First Name';
+            };
+
+            column3.renderer = function(root, column, model) {
+              root.innerHTML = model.item.lastName;
+            };
+            column3.headerRenderer = column3.footerRenderer = function(root, column) {
+              root.innerHTML = 'Last Name';
+            };
+
+            column4.renderer = function(root, column, model) {
+              root.innerHTML =
+                '<div style="white-space: normal">' +
+                model.item.address.street + ', ' + model.item.address.city +
+                '</div>';
+            };
+            column4.headerRenderer = column4.footerRenderer = function(root, column) {
+              root.innerHTML = 'Address';
+            };
+          });
+        </script>
+      </template>
+    </vaadin-demo-snippet>
+
+    <h3>Defining Content with Polymer Templates</h3>
     <p>
       Cells contents can be defined using <code>&lt;template&gt;</code> elements.
       Inside templates, variables like <code>[[index]]</code> and <code>[[item.prop]]</code>
@@ -86,7 +144,6 @@
             <vaadin-checkbox checked="{{editing}}" style="margin-bottom: 20px">Enable Editing</vaadin-checkbox>
 
             <vaadin-grid aria-label="Two-way Binding Example" items="[[users.result]]">
-
               <vaadin-grid-column>
                 <template class="header">First Name</template>
                 <template>
@@ -105,73 +162,9 @@
                 <template class="header">Email</template>
                 <template>[[item.firstName]].[[item.lastName]]@example.com</template>
               </vaadin-grid-column>
-
             </vaadin-grid>
           </template>
         </dom-bind>
-      </template>
-    </vaadin-demo-snippet>
-
-    <h3>Content Renderer Function</h3>
-    <p>
-      Renderer functions can be used to programatically set the content of cells.
-    </p>
-    <vaadin-demo-snippet id='grid-columns-demos-renderer-functions'>
-      <template preserve-content>
-
-        <iron-ajax auto url="https://demo.vaadin.com/demo-data/1.0/people?count=200"></iron-ajax>
-
-        <vaadin-grid aria-label="Content Renderer Function">
-          <vaadin-grid-column id="column1" width="60px" flex-grow="0"></vaadin-grid-column>
-          <vaadin-grid-column id="column2"></vaadin-grid-column>
-          <vaadin-grid-column id="column3"></vaadin-grid-column>
-          <vaadin-grid-column id="column4" width="8em"></vaadin-grid-column>
-        </vaadin-grid>
-        <script>
-          window.addDemoReadyListener('#grid-columns-demos-renderer-functions', function(document) {
-            const ajax = document.querySelector('iron-ajax');
-            const grid = document.querySelector('vaadin-grid');
-            const column1 = document.querySelector('#column1');
-            const column2 = document.querySelector('#column2');
-            const column3 = document.querySelector('#column3');
-            const column4 = document.querySelector('#column4');
-
-            ajax.addEventListener('last-response-changed', function(e) {
-              grid.items = e.target.lastResponse.result;
-            });
-
-            column1.renderer = function(root, column, model) {
-              root.innerHTML = model.index;
-            };
-            column1.headerRenderer = column1.footerRenderer = function(root, column) {
-              root.innerHTML = '#';
-            };
-
-            column2.renderer = function(root, column, model) {
-              root.innerHTML = model.item.firstName;
-            };
-            column2.headerRenderer = column2.footerRenderer = function(root, column) {
-              root.innerHTML = 'First Name';
-            };
-
-            column3.renderer = function(root, column, model) {
-              root.innerHTML = model.item.lastName;
-            };
-            column3.headerRenderer = column3.footerRenderer = function(root, column) {
-              root.innerHTML = 'Last Name';
-            };
-
-            column4.renderer = function(root, column, model) {
-              root.innerHTML =
-                '<div style="white-space: normal">' +
-                model.item.address.street + ', ' + model.item.address.city +
-                '</div>';
-            };
-            column4.headerRenderer = column4.footerRenderer = function(root, column) {
-              root.innerHTML = 'Address';
-            };
-          });
-        </script>
       </template>
     </vaadin-demo-snippet>
 

--- a/demo/grid-basic-demos.html
+++ b/demo/grid-basic-demos.html
@@ -12,52 +12,50 @@
         <iron-ajax auto url="https://demo.vaadin.com/demo-data/1.0/people?count=200"></iron-ajax>
 
         <vaadin-grid aria-label="Content Renderer Function">
-          <vaadin-grid-column id="column1" width="60px" flex-grow="0"></vaadin-grid-column>
-          <vaadin-grid-column id="column2"></vaadin-grid-column>
-          <vaadin-grid-column id="column3"></vaadin-grid-column>
-          <vaadin-grid-column id="column4" width="8em"></vaadin-grid-column>
+          <vaadin-grid-column width="60px" flex-grow="0"></vaadin-grid-column>
+          <vaadin-grid-column></vaadin-grid-column>
+          <vaadin-grid-column></vaadin-grid-column>
+          <vaadin-grid-column width="8em"></vaadin-grid-column>
         </vaadin-grid>
         <script>
           window.addDemoReadyListener('#grid-columns-demos-renderer-functions', function(document) {
             const ajax = document.querySelector('iron-ajax');
             const grid = document.querySelector('vaadin-grid');
-            const column1 = document.querySelector('#column1');
-            const column2 = document.querySelector('#column2');
-            const column3 = document.querySelector('#column3');
-            const column4 = document.querySelector('#column4');
+
+            const columns = document.querySelectorAll('vaadin-grid-column');
 
             ajax.addEventListener('last-response-changed', function(e) {
               grid.items = e.target.lastResponse.result;
             });
 
-            column1.renderer = function(root, column, model) {
+            columns[0].renderer = function(root, column, model) {
               root.innerHTML = model.index;
             };
-            column1.headerRenderer = column1.footerRenderer = function(root, column) {
+            columns[0].headerRenderer = columns[0].footerRenderer = function(root, column) {
               root.innerHTML = '#';
             };
 
-            column2.renderer = function(root, column, model) {
+            columns[1].renderer = function(root, column, model) {
               root.innerHTML = model.item.firstName;
             };
-            column2.headerRenderer = column2.footerRenderer = function(root, column) {
+            columns[1].headerRenderer = columns[1].footerRenderer = function(root, column) {
               root.innerHTML = 'First Name';
             };
 
-            column3.renderer = function(root, column, model) {
+            columns[2].renderer = function(root, column, model) {
               root.innerHTML = model.item.lastName;
             };
-            column3.headerRenderer = column3.footerRenderer = function(root, column) {
+            columns[2].headerRenderer = columns[2].footerRenderer = function(root, column) {
               root.innerHTML = 'Last Name';
             };
 
-            column4.renderer = function(root, column, model) {
+            columns[3].renderer = function(root, column, model) {
               root.innerHTML =
                 '<div style="white-space: normal">' +
                 model.item.address.street + ', ' + model.item.address.city +
                 '</div>';
             };
-            column4.headerRenderer = column4.footerRenderer = function(root, column) {
+            columns[3].headerRenderer = columns[3].footerRenderer = function(root, column) {
               root.innerHTML = 'Address';
             };
           });

--- a/demo/grid-columns-demos.html
+++ b/demo/grid-columns-demos.html
@@ -19,64 +19,78 @@
     </p>
     <vaadin-demo-snippet id='grid-columns-demos-column-grouping'>
       <template preserve-content>
-        <dom-bind>
-          <template>
+        <x-data-provider></x-data-provider>
+        
+        <vaadin-grid aria-label="Column Grouping Example" size="200">
+          <vaadin-grid-column width="30px" flex-grow="0" id="column1"></vaadin-grid-column>
+          <vaadin-grid-column width="60px" flex-grow="0" id="column2"></vaadin-grid-column>
 
-            <x-data-provider data-provider="{{dataProvider}}"></x-data-provider>
+          <vaadin-grid-column-group id="group1">
+            <vaadin-grid-column width="calc(25% - 20px)" id="column3"></vaadin-grid-column>
+            <vaadin-grid-column width="calc(25% - 20px)" id="column4"></vaadin-grid-column>
+          </vaadin-grid-column-group>
 
-            <vaadin-grid aria-label="Column Grouping Example" data-provider="[[dataProvider]]" size="200">
+          <vaadin-grid-column-group id="group2">
+            <vaadin-grid-column width="calc(25% - 20px)" id="column5"></vaadin-grid-column>
+            <vaadin-grid-column width="calc(25% - 20px)" id="column6"></vaadin-grid-column>
+            <vaadin-grid-column width="200px" id="column7"></vaadin-grid-column>
+          </vaadin-grid-column-group>
+        </vaadin-grid>
+        <script>
+          window.addDemoReadyListener('#grid-columns-demos-column-grouping', function(document) {
+            const grid = document.querySelector('vaadin-grid');
 
-              <vaadin-grid-column width="30px" flex-grow="0">
-                <template class="header">#</template>
-                <template>[[index]]</template>
-              </vaadin-grid-column>
-
-              <vaadin-grid-column width="60px" flex-grow="0">
-                <template class="header">
-                  <div aria-label="Picture"></div>
-                </template>
-                <template>
-                  <iron-image width="30" height="30" sizing="cover" alt="[[item.name.first]] [[item.name.last]]" src="[[item.picture.thumbnail]]"></iron-image>
-                </template>
-              </vaadin-grid-column>
-
-              <vaadin-grid-column-group>
-                <template class="header">Name</template>
-
-                <vaadin-grid-column width="calc(25% - 20px)">
-                  <template class="header">First</template>
-                  <template>[[item.name.first]]</template>
-                </vaadin-grid-column>
-
-                <vaadin-grid-column width="calc(25% - 20px)">
-                  <template class="header">Last</template>
-                  <template>[[item.name.last]]</template>
-                </vaadin-grid-column>
-              </vaadin-grid-column-group>
+            const dataProvider = document.querySelector('x-data-provider');
+            grid.dataProvider = dataProvider.dataProvider;
 
 
-              <vaadin-grid-column-group>
-                <template class="header">Location</template>
+            ['index', 'thumbnail', 'First', 'Last', 'City', 'State', 'Street'].forEach(function(columnName, index) {
+              const columnID = index + 1;
+              const column = document.querySelector('#column' + columnID);
 
-                <vaadin-grid-column width="calc(25% - 20px)">
-                  <template class="header">City</template>
-                  <template>[[item.location.city]]</template>
-                </vaadin-grid-column>
+              column.headerRenderer = function(root, column, model) {
+                root.innerHTML = '';
 
-                <vaadin-grid-column width="calc(25% - 20px)">
-                  <template class="header">State</template>
-                  <template>[[item.location.state]]</template>
-                </vaadin-grid-column>
+                if (columnID === 1) {
+                  root.textContent = '#';
+                } else if (columnID === 2) {
+                  root.innerHTML = '<div aria-label="Picture"></div>';
+                } else {
+                  root.textContent = columnName;
+                }
+              };
 
-                <vaadin-grid-column width="200px">
-                  <template class="header">Street</template>
-                  <template><p style="white-space: normal">[[item.location.street]]</p></template>
-                </vaadin-grid-column>
-              </vaadin-grid-column-group>
+              column.renderer = function(root, column, model) {
+                root.innerHTML = '';
 
-            </vaadin-grid>
-          </template>
-        </dom-bind>
+                const propName = columnName.toLowerCase();
+                if (columnID === 1) {
+                  root.textContent = model[propName];
+                } else if (columnID === 2) {
+                  root.innerHTML =
+                    '<iron-image width="30" height="30" sizing="cover" alt="' +
+                    model.item.name.first +
+                    model.item.name.last +
+                    '" src="' + model.item.picture[propName] + '"></iron-image>';
+                } else if (columnID < 5) {
+                  root.textContent = model.item.name[propName];
+                } else {
+                  root.textContent = model.item.location[propName];
+                }
+              };
+            });
+
+            const group1 = document.querySelector('#group1');
+            const group2 = document.querySelector('#group2');
+            group1.headerRenderer = function(root, column, model) {
+              root.textContent = 'Name';
+            };
+            group2.headerRenderer = function(root, column, model) {
+              root.textContent = 'Location';
+            };
+
+          });
+        </script>
       </template>
     </vaadin-demo-snippet>
 
@@ -92,45 +106,80 @@
     </p>
     <vaadin-demo-snippet id='grid-columns-demos-freezing-columns'>
       <template preserve-content>
-        <dom-bind>
-          <template>
-            <x-data-provider data-provider="{{dataProvider}}"></x-data-provider>
-            <vaadin-checkbox checked="{{frozen}}">Freeze First Two Columns</vaadin-checkbox>
+        <x-data-provider></x-data-provider>
 
-            <vaadin-grid aria-label="Freezing Columns Example" data-provider="[[dataProvider]]" size="200">
+        <vaadin-checkbox>Freeze First Two Columns</vaadin-checkbox>
 
-              <vaadin-grid-column width="60px" flex-grow="0" frozen="[[frozen]]">
-                <template class="header">#</template>
-                <template>[[index]]</template>
-              </vaadin-grid-column>
+        <vaadin-grid aria-label="Freezing Columns Example" size="200">
+          <vaadin-grid-column width="60px" flex-grow="0" id="column1"></vaadin-grid-column>
+          <vaadin-grid-column width="60px" flex-grow="0" id="column2"></vaadin-grid-column>
+          <vaadin-grid-column width="33%" id="column3"></vaadin-grid-column>
+          <vaadin-grid-column width="33%" id="column4"></vaadin-grid-column>
+          <vaadin-grid-column width="33%" id="column5"></vaadin-grid-column>
+        </vaadin-grid>
+        <script>
+          window.addDemoReadyListener('#grid-columns-demos-freezing-columns', function(document) {
+            const grid = document.querySelector('vaadin-grid');
+            const checkBox = document.querySelector('vaadin-checkbox');
 
-              <vaadin-grid-column width="60px" flex-grow="0" frozen="[[frozen]]">
-                <template class="header">
-                  <div aria-label="Picture"></div>
-                </template>
-                <template>
-                  <iron-image width="30" height="30" sizing="cover" alt="[[item.name.first]] [[item.name.last]]" src="[[item.picture.thumbnail]]"></iron-image>
-                </template>
-              </vaadin-grid-column>
+            checkBox.addEventListener('checked-changed', function(event) {
+              column1.frozen = column2.frozen = event.detail.value;
+            });
 
-              <vaadin-grid-column width="33%">
-                <template class="header">First Name</template>
-                <template>[[item.name.first]]</template>
-              </vaadin-grid-column>
+            const column1 = document.querySelector('#column1');
+            const column2 = document.querySelector('#column2');
+            const column3 = document.querySelector('#column3');
+            const column4 = document.querySelector('#column4');
+            const column5 = document.querySelector('#column5');
 
-              <vaadin-grid-column width="33%">
-                <template class="header">Last Name</template>
-                <template>[[item.name.last]]</template>
-              </vaadin-grid-column>
+            column1.headerRenderer = function(root, column, model) {
+              root.textContent = '#';
+            };
 
-              <vaadin-grid-column width="33%">
-                <template class="header">Email</template>
-                <template>[[item.email]]</template>
-              </vaadin-grid-column>
+            column2.headerRenderer = function(root, column, model) {
+              root.innerHTML = '<div aria-label="Picture"></div>';
+            };
 
-            </vaadin-grid>
-          </template>
-        </dom-bind>
+            column3.headerRenderer = function(root, column, model) {
+              root.textContent = 'First Name';
+            };
+
+            column4.headerRenderer = function(root, column, model) {
+              root.textContent = 'Last Name';
+            };
+
+            column5.headerRenderer = function(root, column, model) {
+              root.textContent = 'Email';
+            };
+
+            column1.renderer = function(root, column, model) {
+              root.textContent = model.index;
+            };
+
+            column2.renderer = function(root, column, model) {
+              root.innerHTML =
+                '<iron-image width="30" height="30" sizing="cover" alt="' +
+                model.item.name.first +
+                model.item.name.last +
+                '" src="' + model.item.picture.thumbnail + '"></iron-image>';
+            };
+
+            column3.renderer = function(root, column, model) {
+              root.textContent = model.item.name.first;
+            };
+
+            column4.renderer = function(root, column, model) {
+              root.textContent = model.item.name.last;
+            };
+
+            column5.renderer = function(root, column, model) {
+              root.textContent = model.item.email;
+            };
+
+            const dataProvider = document.querySelector('x-data-provider');
+            grid.dataProvider = dataProvider.dataProvider;
+          });
+        </script>
       </template>
     </vaadin-demo-snippet>
 
@@ -139,52 +188,82 @@
     <p>
       Applying <code>hidden</code> on a column or column group will hide it.
     </p>
-    <p>
-      <b>Hint:</b> Using <code>hidden</code> together with <code>&lt;iron-media-query&gt;</code>
-      is an easy way to create a responsive grid.
-    </p>
     <vaadin-demo-snippet id='grid-columns-demos-hiding-columns'>
       <template preserve-content>
-        <dom-bind>
-          <template>
-            <x-data-provider data-provider="{{dataProvider}}"></x-data-provider>
-            <vaadin-checkbox checked="{{hidden}}">Hide First Two Columns</vaadin-checkbox>
-            <iron-media-query query-matches="{{hidden}}" query="(max-width: 700px)"></iron-media-query>
+        <x-data-provider></x-data-provider>
 
-            <vaadin-grid aria-label="Hiding Columns Example" data-provider="[[dataProvider]]" size="200">
+        <vaadin-checkbox>Hide First Two Columns</vaadin-checkbox>
 
-              <vaadin-grid-column width="60px" flex-grow="0" hidden="[[hidden]]">
-                <template class="header">#</template>
-                <template>[[index]]</template>
-              </vaadin-grid-column>
+        <vaadin-grid aria-label="Hiding Columns Example" size="200">
+          <vaadin-grid-column width="60px" flex-grow="0" id="column1"></vaadin-grid-column>
+          <vaadin-grid-column width="60px" flex-grow="0" id="column2"></vaadin-grid-column>
+          <vaadin-grid-column width="33%" id="column3"></vaadin-grid-column>
+          <vaadin-grid-column width="33%" id="column4"></vaadin-grid-column>
+          <vaadin-grid-column width="33%" id="column5"></vaadin-grid-column>
+        </vaadin-grid>
+        <script>
+          window.addDemoReadyListener('#grid-columns-demos-hiding-columns', function(document) {
+            const grid = document.querySelector('vaadin-grid');
+            const checkBox = document.querySelector('vaadin-checkbox');
 
-              <vaadin-grid-column width="60px" flex-grow="0" hidden="[[hidden]]">
-                <template class="header">
-                  <div aria-label="Picture"></div>
-                </template>
-                <template>
-                  <iron-image width="30" height="30" sizing="cover" alt="[[item.name.first]] [[item.name.last]]" src="[[item.picture.thumbnail]]"></iron-image>
-                </template>
-              </vaadin-grid-column>
+            checkBox.addEventListener('checked-changed', function(event) {
+              column1.hidden = column2.hidden = event.detail.value;
+            });
 
-              <vaadin-grid-column width="33%">
-                <template class="header">First Name</template>
-                <template>[[item.name.first]]</template>
-              </vaadin-grid-column>
+            const column1 = document.querySelector('#column1');
+            const column2 = document.querySelector('#column2');
+            const column3 = document.querySelector('#column3');
+            const column4 = document.querySelector('#column4');
+            const column5 = document.querySelector('#column5');
 
-              <vaadin-grid-column width="33%">
-                <template class="header">Last Name</template>
-                <template>[[item.name.last]]</template>
-              </vaadin-grid-column>
+            column1.headerRenderer = function(root, column, model) {
+              root.textContent = '#';
+            };
 
-              <vaadin-grid-column width="33%">
-                <template class="header">Email</template>
-                <template>[[item.email]]</template>
-              </vaadin-grid-column>
+            column2.headerRenderer = function(root, column, model) {
+              root.innerHTML = '<div aria-label="Picture"></div>';
+            };
 
-            </vaadin-grid>
-          </template>
-        </dom-bind>
+            column3.headerRenderer = function(root, column, model) {
+              root.textContent = 'First Name';
+            };
+
+            column4.headerRenderer = function(root, column, model) {
+              root.textContent = 'Last Name';
+            };
+
+            column5.headerRenderer = function(root, column, model) {
+              root.textContent = 'Email';
+            };
+
+            column1.renderer = function(root, column, model) {
+              root.textContent = model.index;
+            };
+
+            column2.renderer = function(root, column, model) {
+              root.innerHTML =
+                '<iron-image width="30" height="30" sizing="cover" alt="' +
+                model.item.name.first +
+                model.item.name.last +
+                '" src="' + model.item.picture.thumbnail + '"></iron-image>';
+            };
+
+            column3.renderer = function(root, column, model) {
+              root.textContent = model.item.name.first;
+            };
+
+            column4.renderer = function(root, column, model) {
+              root.textContent = model.item.name.last;
+            };
+
+            column5.renderer = function(root, column, model) {
+              root.textContent = model.item.email;
+            };
+
+            const dataProvider = document.querySelector('x-data-provider');
+            grid.dataProvider = dataProvider.dataProvider;
+          });
+        </script>
       </template>
     </vaadin-demo-snippet>
 
@@ -203,62 +282,77 @@
     </p>
     <vaadin-demo-snippet id='grid-columns-demos-reordering-and-resizing-columns'>
       <template preserve-content>
-        <dom-bind>
-          <template>
-            <x-data-provider data-provider="{{dataProvider}}"></x-data-provider>
+        <x-data-provider></x-data-provider>
 
-            <vaadin-grid aria-label="Reordering and Resizing Columns Example" data-provider="[[dataProvider]]" size="200" column-reordering-allowed>
+        <vaadin-grid aria-label="Reordering and Resizing Columns Example" size="200" column-reordering-allowed>
+          <vaadin-grid-column width="30px" flex-grow="0" id="column1" resizable></vaadin-grid-column>
+          <vaadin-grid-column width="60px" flex-grow="0" id="column2" resizable></vaadin-grid-column>
 
-              <vaadin-grid-column width="30px" flex-grow="0" resizable>
-                <template class="header">#</template>
-                <template>[[index]]</template>
-              </vaadin-grid-column>
+          <vaadin-grid-column-group id="group1" resizable>
+            <vaadin-grid-column width="calc(25% - 20px)" id="column3"></vaadin-grid-column>
+            <vaadin-grid-column width="calc(25% - 20px)" id="column4"></vaadin-grid-column>
+          </vaadin-grid-column-group>
 
-              <vaadin-grid-column width="60px" flex-grow="0" resizable>
-                <template class="header">
-                  <div aria-label="Picture"></div>
-                </template>
-                <template>
-                  <iron-image width="30" height="30" sizing="cover" alt="[[item.name.first]] [[item.name.last]]" src="[[item.picture.thumbnail]]"></iron-image>
-                </template>
-              </vaadin-grid-column>
+          <vaadin-grid-column-group id="group2" resizable>
+            <vaadin-grid-column width="calc(25% - 20px)" id="column5"></vaadin-grid-column>
+            <vaadin-grid-column width="calc(25% - 20px)" id="column6"></vaadin-grid-column>
+            <vaadin-grid-column width="200px" id="column7"></vaadin-grid-column>
+          </vaadin-grid-column-group>
+        </vaadin-grid>
+        <script>
+          window.addDemoReadyListener('#grid-columns-demos-reordering-and-resizing-columns', function(document) {
+            const grid = document.querySelector('vaadin-grid');
 
-              <vaadin-grid-column-group resizable>
-                <template class="header">Name</template>
+            const dataProvider = document.querySelector('x-data-provider');
+            grid.dataProvider = dataProvider.dataProvider;
 
-                <vaadin-grid-column width="calc(25% - 20px)">
-                  <template class="header">First</template>
-                  <template>[[item.name.first]]</template>
-                </vaadin-grid-column>
 
-                <vaadin-grid-column width="calc(25% - 20px)">
-                  <template class="header">Last</template>
-                  <template>[[item.name.last]]</template>
-                </vaadin-grid-column>
-              </vaadin-grid-column-group>
+            ['index', 'thumbnail', 'First', 'Last', 'City', 'State', 'Street'].forEach(function(columnName, index) {
+              const columnID = index + 1;
+              const column = document.querySelector('#column' + columnID);
 
-              <vaadin-grid-column-group resizable>
-                <template class="header">Location</template>
+              column.headerRenderer = function(root, column, model) {
+                root.innerHTML = '';
 
-                <vaadin-grid-column width="calc(25% - 20px)">
-                  <template class="header">City</template>
-                  <template>[[item.location.city]]</template>
-                </vaadin-grid-column>
+                if (columnID === 1) {
+                  root.textContent = '#';
+                } else if (columnID === 2) {
+                  root.innerHTML = '<div aria-label="Picture"></div>';
+                } else {
+                  root.textContent = columnName;
+                }
+              };
 
-                <vaadin-grid-column width="calc(25% - 20px)">
-                  <template class="header">State</template>
-                  <template>[[item.location.state]]</template>
-                </vaadin-grid-column>
+              column.renderer = function(root, column, model) {
+                root.innerHTML = '';
 
-                <vaadin-grid-column width="200px" resizable>
-                  <template class="header">Street</template>
-                  <template>[[item.location.street]]</template>
-                </vaadin-grid-column>
-              </vaadin-grid-column-group>
+                const propName = columnName.toLowerCase();
+                if (columnID === 1) {
+                  root.textContent = model[propName];
+                } else if (columnID === 2) {
+                  root.innerHTML =
+                    '<iron-image width="30" height="30" sizing="cover" alt="' +
+                    model.item.name.first +
+                    model.item.name.last +
+                    '" src="' + model.item.picture[propName] + '"></iron-image>';
+                } else if (columnID < 5) {
+                  root.textContent = model.item.name[propName];
+                } else {
+                  root.textContent = model.item.location[propName];
+                }
+              };
+            });
 
-            </vaadin-grid>
-          </template>
-        </dom-bind>
+            const group1 = document.querySelector('#group1');
+            const group2 = document.querySelector('#group2');
+            group1.headerRenderer = function(root, column, model) {
+              root.textContent = 'Name';
+            };
+            group2.headerRenderer = function(root, column, model) {
+              root.textContent = 'Location';
+            };
+          });
+        </script>
       </template>
     </vaadin-demo-snippet>
 

--- a/demo/grid-columns-demos.html
+++ b/demo/grid-columns-demos.html
@@ -22,18 +22,18 @@
         <x-data-provider></x-data-provider>
 
         <vaadin-grid aria-label="Column Grouping Example" size="200">
-          <vaadin-grid-column width="30px" flex-grow="0" id="column1"></vaadin-grid-column>
-          <vaadin-grid-column width="60px" flex-grow="0" id="column2"></vaadin-grid-column>
+          <vaadin-grid-column width="30px" flex-grow="0" name="index"></vaadin-grid-column>
+          <vaadin-grid-column width="60px" flex-grow="0" name="thumbnail"></vaadin-grid-column>
 
           <vaadin-grid-column-group class="group">
-            <vaadin-grid-column width="calc(25% - 20px)" id="column3"></vaadin-grid-column>
-            <vaadin-grid-column width="calc(25% - 20px)" id="column4"></vaadin-grid-column>
+            <vaadin-grid-column width="calc(25% - 20px)" name="First"></vaadin-grid-column>
+            <vaadin-grid-column width="calc(25% - 20px)" name="Last"></vaadin-grid-column>
           </vaadin-grid-column-group>
 
           <vaadin-grid-column-group class="group">
-            <vaadin-grid-column width="calc(25% - 20px)" id="column5"></vaadin-grid-column>
-            <vaadin-grid-column width="calc(25% - 20px)" id="column6"></vaadin-grid-column>
-            <vaadin-grid-column width="200px" id="column7"></vaadin-grid-column>
+            <vaadin-grid-column width="calc(25% - 20px)" name="City"></vaadin-grid-column>
+            <vaadin-grid-column width="calc(25% - 20px)" name="State"></vaadin-grid-column>
+            <vaadin-grid-column width="200px" name="Street"></vaadin-grid-column>
           </vaadin-grid-column-group>
         </vaadin-grid>
         <script>
@@ -43,36 +43,34 @@
             const dataProvider = document.querySelector('x-data-provider');
             grid.dataProvider = dataProvider.dataProvider;
 
+            const columns = grid.querySelectorAll('vaadin-grid-column');
 
-            ['index', 'thumbnail', 'First', 'Last', 'City', 'State', 'Street'].forEach(function(columnName, index) {
-              const columnID = index + 1;
-              const column = document.querySelector('#column' + columnID);
-
+            columns.forEach(function(column, index) {
               column.headerRenderer = function(root, column, model) {
                 root.innerHTML = '';
 
-                if (columnID === 1) {
+                if (index === 0) {
                   root.textContent = '#';
-                } else if (columnID === 2) {
+                } else if (index === 1) {
                   root.innerHTML = '<div aria-label="Picture"></div>';
                 } else {
-                  root.textContent = columnName;
+                  root.textContent = column.getAttribute('name');
                 }
               };
 
               column.renderer = function(root, column, model) {
                 root.innerHTML = '';
 
-                const propName = columnName.toLowerCase();
-                if (columnID === 1) {
+                const propName = column.getAttribute('name').toLowerCase();
+                if (index === 0) {
                   root.textContent = model[propName];
-                } else if (columnID === 2) {
+                } else if (index === 1) {
                   root.innerHTML =
-                    '<iron-image width="30" height="30" sizing="cover" alt="' +
-                    model.item.name.first +
-                    model.item.name.last +
-                    '" src="' + model.item.picture[propName] + '"></iron-image>';
-                } else if (columnID < 5) {
+                    '<iron-image width="30" height="30" sizing="cover" ' +
+                      'alt="' + model.item.name.first + model.item.name.last + '"' +
+                      'src="' + model.item.picture.thumbnail + '">' +
+                    '</iron-image>';
+                } else if (index < 4) {
                   root.textContent = model.item.name[propName];
                 } else {
                   root.textContent = model.item.location[propName];
@@ -149,10 +147,10 @@
 
             columns[1].renderer = function(root, column, model) {
               root.innerHTML =
-                '<iron-image width="30" height="30" sizing="cover" alt="' +
-                model.item.name.first +
-                model.item.name.last +
-                '" src="' + model.item.picture.thumbnail + '"></iron-image>';
+                '<iron-image width="30" height="30" sizing="cover" ' +
+                  'alt="' + model.item.name.first + model.item.name.last + '"' +
+                  'src="' + model.item.picture.thumbnail + '">' +
+                '</iron-image>';
             };
 
             columns[2].renderer = function(root, column, model) {
@@ -229,10 +227,10 @@
 
             columns[1].renderer = function(root, column, model) {
               root.innerHTML =
-                '<iron-image width="30" height="30" sizing="cover" alt="' +
-                model.item.name.first +
-                model.item.name.last +
-                '" src="' + model.item.picture.thumbnail + '"></iron-image>';
+                '<iron-image width="30" height="30" sizing="cover" ' +
+                  'alt="' + model.item.name.first + model.item.name.last + '"' +
+                  'src="' + model.item.picture.thumbnail + '">' +
+                '</iron-image>';
             };
 
             columns[2].renderer = function(root, column, model) {
@@ -272,18 +270,18 @@
         <x-data-provider></x-data-provider>
 
         <vaadin-grid aria-label="Reordering and Resizing Columns Example" size="200" column-reordering-allowed>
-          <vaadin-grid-column width="30px" flex-grow="0" id="column1" resizable></vaadin-grid-column>
-          <vaadin-grid-column width="60px" flex-grow="0" id="column2" resizable></vaadin-grid-column>
+          <vaadin-grid-column width="30px" flex-grow="0" name="index" resizable></vaadin-grid-column>
+          <vaadin-grid-column width="60px" flex-grow="0" name="thumbnail" resizable></vaadin-grid-column>
 
           <vaadin-grid-column-group id="group1" resizable>
-            <vaadin-grid-column width="calc(25% - 20px)" id="column3"></vaadin-grid-column>
-            <vaadin-grid-column width="calc(25% - 20px)" id="column4"></vaadin-grid-column>
+            <vaadin-grid-column width="calc(25% - 20px)" name="First"></vaadin-grid-column>
+            <vaadin-grid-column width="calc(25% - 20px)" name="Last"></vaadin-grid-column>
           </vaadin-grid-column-group>
 
           <vaadin-grid-column-group id="group2" resizable>
-            <vaadin-grid-column width="calc(25% - 20px)" id="column5"></vaadin-grid-column>
-            <vaadin-grid-column width="calc(25% - 20px)" id="column6"></vaadin-grid-column>
-            <vaadin-grid-column width="200px" id="column7"></vaadin-grid-column>
+            <vaadin-grid-column width="calc(25% - 20px)" name="City"></vaadin-grid-column>
+            <vaadin-grid-column width="calc(25% - 20px)" name="State"></vaadin-grid-column>
+            <vaadin-grid-column width="200px" name="Street"></vaadin-grid-column>
           </vaadin-grid-column-group>
         </vaadin-grid>
         <script>
@@ -293,36 +291,34 @@
             const dataProvider = document.querySelector('x-data-provider');
             grid.dataProvider = dataProvider.dataProvider;
 
+            const columns = grid.querySelectorAll('vaadin-grid-column');
 
-            ['index', 'thumbnail', 'First', 'Last', 'City', 'State', 'Street'].forEach(function(columnName, index) {
-              const columnID = index + 1;
-              const column = document.querySelector('#column' + columnID);
-
+            columns.forEach(function(column, index) {
               column.headerRenderer = function(root, column, model) {
                 root.innerHTML = '';
 
-                if (columnID === 1) {
+                if (index === 0) {
                   root.textContent = '#';
-                } else if (columnID === 2) {
+                } else if (index === 1) {
                   root.innerHTML = '<div aria-label="Picture"></div>';
                 } else {
-                  root.textContent = columnName;
+                  root.textContent = column.getAttribute('name');
                 }
               };
 
               column.renderer = function(root, column, model) {
                 root.innerHTML = '';
 
-                const propName = columnName.toLowerCase();
-                if (columnID === 1) {
+                const propName = column.getAttribute('name').toLowerCase();
+                if (index === 0) {
                   root.textContent = model[propName];
-                } else if (columnID === 2) {
+                } else if (index === 1) {
                   root.innerHTML =
-                    '<iron-image width="30" height="30" sizing="cover" alt="' +
-                    model.item.name.first +
-                    model.item.name.last +
-                    '" src="' + model.item.picture[propName] + '"></iron-image>';
-                } else if (columnID < 5) {
+                    '<iron-image width="30" height="30" sizing="cover" ' +
+                      'alt="' + model.item.name.first + model.item.name.last + '"' +
+                      'src="' + model.item.picture.thumbnail + '">' +
+                    '</iron-image>';
+                } else if (index < 4) {
                   root.textContent = model.item.name[propName];
                 } else {
                   root.textContent = model.item.location[propName];

--- a/demo/grid-columns-demos.html
+++ b/demo/grid-columns-demos.html
@@ -20,17 +20,17 @@
     <vaadin-demo-snippet id='grid-columns-demos-column-grouping'>
       <template preserve-content>
         <x-data-provider></x-data-provider>
-        
+
         <vaadin-grid aria-label="Column Grouping Example" size="200">
           <vaadin-grid-column width="30px" flex-grow="0" id="column1"></vaadin-grid-column>
           <vaadin-grid-column width="60px" flex-grow="0" id="column2"></vaadin-grid-column>
 
-          <vaadin-grid-column-group id="group1">
+          <vaadin-grid-column-group class="group">
             <vaadin-grid-column width="calc(25% - 20px)" id="column3"></vaadin-grid-column>
             <vaadin-grid-column width="calc(25% - 20px)" id="column4"></vaadin-grid-column>
           </vaadin-grid-column-group>
 
-          <vaadin-grid-column-group id="group2">
+          <vaadin-grid-column-group class="group">
             <vaadin-grid-column width="calc(25% - 20px)" id="column5"></vaadin-grid-column>
             <vaadin-grid-column width="calc(25% - 20px)" id="column6"></vaadin-grid-column>
             <vaadin-grid-column width="200px" id="column7"></vaadin-grid-column>
@@ -80,12 +80,11 @@
               };
             });
 
-            const group1 = document.querySelector('#group1');
-            const group2 = document.querySelector('#group2');
-            group1.headerRenderer = function(root, column, model) {
+            const groups = document.querySelectorAll('.group');
+            groups[0].headerRenderer = function(root, column, model) {
               root.textContent = 'Name';
             };
-            group2.headerRenderer = function(root, column, model) {
+            groups[1].headerRenderer = function(root, column, model) {
               root.textContent = 'Location';
             };
 
@@ -111,11 +110,11 @@
         <vaadin-checkbox>Freeze First Two Columns</vaadin-checkbox>
 
         <vaadin-grid aria-label="Freezing Columns Example" size="200">
-          <vaadin-grid-column width="60px" flex-grow="0" id="column1"></vaadin-grid-column>
-          <vaadin-grid-column width="60px" flex-grow="0" id="column2"></vaadin-grid-column>
-          <vaadin-grid-column width="33%" id="column3"></vaadin-grid-column>
-          <vaadin-grid-column width="33%" id="column4"></vaadin-grid-column>
-          <vaadin-grid-column width="33%" id="column5"></vaadin-grid-column>
+          <vaadin-grid-column width="60px" flex-grow="0"></vaadin-grid-column>
+          <vaadin-grid-column width="60px" flex-grow="0"></vaadin-grid-column>
+          <vaadin-grid-column width="33%"></vaadin-grid-column>
+          <vaadin-grid-column width="33%"></vaadin-grid-column>
+          <vaadin-grid-column width="33%"></vaadin-grid-column>
         </vaadin-grid>
         <script>
           window.addDemoReadyListener('#grid-columns-demos-freezing-columns', function(document) {
@@ -123,40 +122,32 @@
             const checkBox = document.querySelector('vaadin-checkbox');
 
             checkBox.addEventListener('checked-changed', function(event) {
-              column1.frozen = column2.frozen = event.detail.value;
+              columns[0].frozen = columns[1].frozen = event.detail.value;
             });
 
-            const column1 = document.querySelector('#column1');
-            const column2 = document.querySelector('#column2');
-            const column3 = document.querySelector('#column3');
-            const column4 = document.querySelector('#column4');
-            const column5 = document.querySelector('#column5');
+            const columns = document.querySelectorAll('vaadin-grid-column');
 
-            column1.headerRenderer = function(root, column, model) {
-              root.textContent = '#';
-            };
-
-            column2.headerRenderer = function(root, column, model) {
+            columns[1].headerRenderer = function(root, column, model) {
               root.innerHTML = '<div aria-label="Picture"></div>';
             };
 
-            column3.headerRenderer = function(root, column, model) {
+            columns[2].headerRenderer = function(root, column, model) {
               root.textContent = 'First Name';
             };
 
-            column4.headerRenderer = function(root, column, model) {
+            columns[3].headerRenderer = function(root, column, model) {
               root.textContent = 'Last Name';
             };
 
-            column5.headerRenderer = function(root, column, model) {
+            columns[4].headerRenderer = function(root, column, model) {
               root.textContent = 'Email';
             };
 
-            column1.renderer = function(root, column, model) {
+            columns[0].renderer = function(root, column, model) {
               root.textContent = model.index;
             };
 
-            column2.renderer = function(root, column, model) {
+            columns[1].renderer = function(root, column, model) {
               root.innerHTML =
                 '<iron-image width="30" height="30" sizing="cover" alt="' +
                 model.item.name.first +
@@ -164,15 +155,15 @@
                 '" src="' + model.item.picture.thumbnail + '"></iron-image>';
             };
 
-            column3.renderer = function(root, column, model) {
+            columns[2].renderer = function(root, column, model) {
               root.textContent = model.item.name.first;
             };
 
-            column4.renderer = function(root, column, model) {
+            columns[3].renderer = function(root, column, model) {
               root.textContent = model.item.name.last;
             };
 
-            column5.renderer = function(root, column, model) {
+            columns[4].renderer = function(root, column, model) {
               root.textContent = model.item.email;
             };
 
@@ -195,11 +186,11 @@
         <vaadin-checkbox>Hide First Two Columns</vaadin-checkbox>
 
         <vaadin-grid aria-label="Hiding Columns Example" size="200">
-          <vaadin-grid-column width="60px" flex-grow="0" id="column1"></vaadin-grid-column>
-          <vaadin-grid-column width="60px" flex-grow="0" id="column2"></vaadin-grid-column>
-          <vaadin-grid-column width="33%" id="column3"></vaadin-grid-column>
-          <vaadin-grid-column width="33%" id="column4"></vaadin-grid-column>
-          <vaadin-grid-column width="33%" id="column5"></vaadin-grid-column>
+          <vaadin-grid-column width="60px" flex-grow="0"></vaadin-grid-column>
+          <vaadin-grid-column width="60px" flex-grow="0"></vaadin-grid-column>
+          <vaadin-grid-column width="33%"></vaadin-grid-column>
+          <vaadin-grid-column width="33%"></vaadin-grid-column>
+          <vaadin-grid-column width="33%"></vaadin-grid-column>
         </vaadin-grid>
         <script>
           window.addDemoReadyListener('#grid-columns-demos-hiding-columns', function(document) {
@@ -207,40 +198,36 @@
             const checkBox = document.querySelector('vaadin-checkbox');
 
             checkBox.addEventListener('checked-changed', function(event) {
-              column1.hidden = column2.hidden = event.detail.value;
+              columns[0].hidden = columns[1].hidden = event.detail.value;
             });
 
-            const column1 = document.querySelector('#column1');
-            const column2 = document.querySelector('#column2');
-            const column3 = document.querySelector('#column3');
-            const column4 = document.querySelector('#column4');
-            const column5 = document.querySelector('#column5');
+            const columns = document.querySelectorAll('vaadin-grid-column');
 
-            column1.headerRenderer = function(root, column, model) {
+            columns[0].headerRenderer = function(root, column, model) {
               root.textContent = '#';
             };
 
-            column2.headerRenderer = function(root, column, model) {
+            columns[1].headerRenderer = function(root, column, model) {
               root.innerHTML = '<div aria-label="Picture"></div>';
             };
 
-            column3.headerRenderer = function(root, column, model) {
+            columns[2].headerRenderer = function(root, column, model) {
               root.textContent = 'First Name';
             };
 
-            column4.headerRenderer = function(root, column, model) {
+            columns[3].headerRenderer = function(root, column, model) {
               root.textContent = 'Last Name';
             };
 
-            column5.headerRenderer = function(root, column, model) {
+            columns[4].headerRenderer = function(root, column, model) {
               root.textContent = 'Email';
             };
 
-            column1.renderer = function(root, column, model) {
+            columns[0].renderer = function(root, column, model) {
               root.textContent = model.index;
             };
 
-            column2.renderer = function(root, column, model) {
+            columns[1].renderer = function(root, column, model) {
               root.innerHTML =
                 '<iron-image width="30" height="30" sizing="cover" alt="' +
                 model.item.name.first +
@@ -248,15 +235,15 @@
                 '" src="' + model.item.picture.thumbnail + '"></iron-image>';
             };
 
-            column3.renderer = function(root, column, model) {
+            columns[2].renderer = function(root, column, model) {
               root.textContent = model.item.name.first;
             };
 
-            column4.renderer = function(root, column, model) {
+            columns[3].renderer = function(root, column, model) {
               root.textContent = model.item.name.last;
             };
 
-            column5.renderer = function(root, column, model) {
+            columns[4].renderer = function(root, column, model) {
               root.textContent = model.item.email;
             };
 

--- a/demo/grid-crud-demos.html
+++ b/demo/grid-crud-demos.html
@@ -36,10 +36,10 @@
         </div>
 
         <vaadin-grid theme="compact">
-          <vaadin-grid-column resizable id="column1"></vaadin-grid-column>
-          <vaadin-grid-column resizable id="column2"></vaadin-grid-column>
-          <vaadin-grid-column width="12em" resizable id="column3"></vaadin-grid-column>
-          <vaadin-grid-column width="14em" id="column4"></vaadin-grid-column>
+          <vaadin-grid-column resizable></vaadin-grid-column>
+          <vaadin-grid-column resizable></vaadin-grid-column>
+          <vaadin-grid-column width="12em" resizable></vaadin-grid-column>
+          <vaadin-grid-column width="14em"></vaadin-grid-column>
         </vaadin-grid>
         <script>
           window.addDemoReadyListener('#grid-crud-demos-crud', function(document) {
@@ -61,16 +61,13 @@
               }
             });
 
-            const column1 = document.querySelector('#column1');
-            const column2 = document.querySelector('#column2');
-            const column3 = document.querySelector('#column3');
-            const column4 = document.querySelector('#column4');
+            const columns = document.querySelectorAll('vaadin-grid-column');
 
-            column1.headerRenderer = function(root) {
+            columns[0].headerRenderer = function(root) {
               root.textContent = 'First Name';
             };
 
-            column1.renderer = function(root, column, model) {
+            columns[0].renderer = function(root, column, model) {
               root.innerHTML = '';
 
               const textField = new Vaadin.TextFieldElement();
@@ -80,11 +77,11 @@
               root.appendChild(textField);
             };
 
-            column2.headerRenderer = function(root) {
+            columns[1].headerRenderer = function(root) {
               root.textContent = 'Last Name';
             };
 
-            column2.renderer = function(root, column, model) {
+            columns[1].renderer = function(root, column, model) {
               root.innerHTML = '';
 
               const textField = new Vaadin.TextFieldElement();
@@ -94,15 +91,15 @@
               root.appendChild(textField);
             };
 
-            column3.headerRenderer = function(root) {
+            columns[2].headerRenderer = function(root) {
               root.textContent = 'Email';
             };
 
-            column3.renderer = function(root, column, model) {
+            columns[2].renderer = function(root, column, model) {
               root.innerHTML = '<div>' + model.item.name.first + '.' + model.item.name.last + '@example.com</div>';
             };
 
-            column4.renderer = function(root, column, model) {
+            columns[3].renderer = function(root, column, model) {
               root.innerHTML = '';
 
               const wrapper = window.document.createElement('div');

--- a/demo/grid-crud-demos.html
+++ b/demo/grid-crud-demos.html
@@ -149,7 +149,9 @@
 
             // Returns the vaadin-text-element for a given column and row
             function getTextField(column, index) {
-              const cell = column._allCells.filter(cell => cell._model && cell._model.index === index)[0];
+              const cell = column._allCells.filter(function(cell) {
+                return cell._model && cell._model.index === index;
+              })[0];
               return cell._content.firstElementChild;
             }
 

--- a/demo/grid-crud-demos.html
+++ b/demo/grid-crud-demos.html
@@ -26,6 +26,10 @@
           vaadin-grid vaadin-text-field {
             width: 100%;
           }
+
+          vaadin-grid vaadin-button {
+            margin-left: 5px;
+          }
         </style>
         <x-array-data-provider></x-array-data-provider>
 
@@ -70,8 +74,8 @@
                 textField = new Vaadin.TextFieldElement();
                 root.appendChild(textField);
               }
-              textField.setAttribute('id', 'first-' + model.index);
               textField.value = model.item.name.first;
+              textField.setAttribute('focus-target', true);
               textField.readonly = true;
             };
 
@@ -84,8 +88,8 @@
                 textField = new Vaadin.TextFieldElement();
                 root.appendChild(textField);
               }
-              textField.setAttribute('id', 'last-' + model.index);
               textField.value = model.item.name.last;
+              textField.setAttribute('focus-target', true);
               textField.readonly = true;
             };
 
@@ -104,72 +108,59 @@
                     '<vaadin-button aria-label="Edit" theme="icon" focus-target>' +
                       '<iron-icon icon="lumo:edit"></iron-icon>' +
                     '</vaadin-button>' +
-                    '<vaadin-button aria-label="Delete" theme="icon error" style="margin-left: 5px">' +
+                    '<vaadin-button aria-label="Delete" theme="icon error">' +
                       '<iron-icon icon="lumo:cross"></iron-icon>' +
                     '</vaadin-button>' +
                     '<vaadin-button aria-label="Save" theme="primary" focus-target hidden>Save</vaadin-button>' +
-                    '<vaadin-button aria-label="Cancel" hidden style="margin-left: 5px">Cancel</vaadin-button>' +
+                    '<vaadin-button aria-label="Cancel" hidden>Cancel</vaadin-button>' +
                   '</div>';
                 wrapper = root.firstElementChild;
 
-                const buttons = wrapper.querySelectorAll('vaadin-button')
+                const buttons = wrapper.querySelectorAll('vaadin-button');
+                // EDIT
                 buttons[0].addEventListener('click', function() {
-                  grid.querySelector('#first-' + wrapper._model.index).focus();
-                  updateTextFieldsVisibility(wrapper._model.index, true);
-                  updateButtonsVisibility(wrapper, true);
+                  updateTextFieldsVisibility(wrapper.idx, true);
+                  updateButtonsVisibility(buttons, wrapper.idx, true);
+                  getTextField(columns[0], wrapper.idx).focus();
                 });
+                // DELETE
                 buttons[1].addEventListener('click', function(event) {
-                  var index = grid.items.indexOf(wrapper._model.item);
-                  grid.items.splice(index, 1);
+                  grid.items.splice(wrapper.idx, 1);
                   grid.clearCache();
                 });
+                // SAVE
                 buttons[2].addEventListener('click', function() {
-                  model.item.name.first = grid.querySelector('#first-' + wrapper._model.index).value;
-                  model.item.name.last = grid.querySelector('#last-' + wrapper._model.index).value;
-
-                  updateTextFieldsVisibility(wrapper._model.index, false);
-                  updateButtonsVisibility(wrapper, false);
-                  grid.clearCache();
-                  buttons[0].focus();
+                  grid.items[wrapper.idx].name.first = getTextField(columns[0], wrapper.idx).value;
+                  grid.items[wrapper.idx].name.last = getTextField(columns[1], wrapper.idx).value;
+                  buttons[3].click();
                 });
+                // CANCEL
                 buttons[3].addEventListener('click', function(event) {
-                  updateTextFieldsVisibility(wrapper._model.index, false);
-                  updateButtonsVisibility(wrapper, false);
+                  updateTextFieldsVisibility(wrapper.idx, false);
+                  updateButtonsVisibility(buttons, wrapper.idx, false);
                   grid.clearCache();
                   buttons[0].focus();
                 });
               }
 
-              wrapper._model = model;
-              console.log(model, root, root._model);
+              // We reuse rendered content, but maintain a property with the index for actions
+              wrapper.idx = model.index;
             };
 
-            function updateTextFieldsVisibility(index, editing) {
-              if (editing) {
-                grid.querySelector('#first-' + index).removeAttribute('readonly');
-                grid.querySelector('#last-' + index).removeAttribute('readonly');
-              } else {
-                grid.querySelector('#first-' + index).setAttribute('readonly', true);
-                grid.querySelector('#last-' + index).setAttribute('readonly', true);
-              }
+            // Returns the vaadin-text-element for a given column and row
+            function getTextField(column, index) {
+              const cell = column._allCells.filter(cell => cell._model && cell._model.index === index)[0];
+              return cell._content.firstElementChild;
             }
 
-            function updateButtonsVisibility(wrapper, editing) {
-              if (editing) {
-                wrapper.querySelectorAll('[theme~="icon"]').forEach(function(btn) {
-                  btn.setAttribute('hidden', true);
-                });
-                wrapper.querySelectorAll('vaadin-button:not([theme~="icon"])').forEach(function(btn) {
-                  btn.removeAttribute('hidden');
-                });
-              } else {
-                wrapper.querySelectorAll('[theme~="icon"]').forEach(function(btn) {
-                  btn.removeAttribute('hidden');
-                });
-                wrapper.querySelectorAll('vaadin-button:not([theme~="icon"])').forEach(function(btn) {
-                  btn.setAttribute('hidden', true);
-                });
-              }
+            function updateTextFieldsVisibility(index, editing) {
+              getTextField(columns[0], index).readonly = !editing;
+              getTextField(columns[1], index).readonly = !editing;
+            }
+
+            function updateButtonsVisibility(buttons, index, editing) {
+              buttons[0].hidden = buttons[1].hidden = editing;
+              buttons[2].hidden = buttons[3].hidden = !editing;
             }
 
             const dataProvider = document.querySelector('x-array-data-provider');

--- a/demo/grid-crud-demos.html
+++ b/demo/grid-crud-demos.html
@@ -50,12 +50,10 @@
             const addBtn = document.querySelector('#add-btn');
 
             addBtn.addEventListener('click', function() {
-              if (firstname.value !== '' && lastname.value !== '') {
+              if (firstname.value && lastname.value) {
                 grid.items.unshift({name: {first: firstname.value, last: lastname.value}});
                 grid.clearCache();
-
-                firstname.value = '';
-                lastname.value = '';
+                firstname.value = lastname.value = '';
               } else {
                 alert('First Name and Last Name required');
               }
@@ -66,100 +64,84 @@
             columns[0].headerRenderer = function(root) {
               root.textContent = 'First Name';
             };
-
             columns[0].renderer = function(root, column, model) {
-              root.innerHTML = '';
-
-              const textField = new Vaadin.TextFieldElement();
+              let textField = root.firstElementChild;
+              if (!textField) {
+                textField = new Vaadin.TextFieldElement();
+                root.appendChild(textField);
+              }
               textField.setAttribute('id', 'first-' + model.index);
-              textField.setAttribute('value', model.item.name.first);
-              textField.setAttribute('readonly', true);
-              root.appendChild(textField);
+              textField.value = model.item.name.first;
+              textField.readonly = true;
             };
 
             columns[1].headerRenderer = function(root) {
               root.textContent = 'Last Name';
             };
-
             columns[1].renderer = function(root, column, model) {
-              root.innerHTML = '';
-
-              const textField = new Vaadin.TextFieldElement();
+              let textField = root.firstElementChild;
+              if (!textField) {
+                textField = new Vaadin.TextFieldElement();
+                root.appendChild(textField);
+              }
               textField.setAttribute('id', 'last-' + model.index);
-              textField.setAttribute('value', model.item.name.last);
-              textField.setAttribute('readonly', true);
-              root.appendChild(textField);
+              textField.value = model.item.name.last;
+              textField.readonly = true;
             };
 
             columns[2].headerRenderer = function(root) {
               root.textContent = 'Email';
             };
-
             columns[2].renderer = function(root, column, model) {
-              root.innerHTML = '<div>' + model.item.name.first + '.' + model.item.name.last + '@example.com</div>';
+              root.textContent = model.item.name.first + '.' + model.item.name.last + '@example.com';
             };
 
             columns[3].renderer = function(root, column, model) {
-              root.innerHTML = '';
+              let wrapper = root.firstElementChild;
+              if (!wrapper) {
+                root.innerHTML =
+                  '<div style="text-align: right">' +
+                    '<vaadin-button aria-label="Edit" theme="icon" focus-target>' +
+                      '<iron-icon icon="lumo:edit"></iron-icon>' +
+                    '</vaadin-button>' +
+                    '<vaadin-button aria-label="Delete" theme="icon error" style="margin-left: 5px">' +
+                      '<iron-icon icon="lumo:cross"></iron-icon>' +
+                    '</vaadin-button>' +
+                    '<vaadin-button aria-label="Save" theme="primary" focus-target hidden>Save</vaadin-button>' +
+                    '<vaadin-button aria-label="Cancel" hidden style="margin-left: 5px">Cancel</vaadin-button>' +
+                  '</div>';
+                wrapper = root.firstElementChild;
 
-              const wrapper = window.document.createElement('div');
-              wrapper.style.textAlign = 'right';
+                const buttons = wrapper.querySelectorAll('vaadin-button')
+                buttons[0].addEventListener('click', function() {
+                  grid.querySelector('#first-' + wrapper._model.index).focus();
+                  updateTextFieldsVisibility(wrapper._model.index, true);
+                  updateButtonsVisibility(wrapper, true);
+                });
+                buttons[1].addEventListener('click', function(event) {
+                  var index = grid.items.indexOf(wrapper._model.item);
+                  grid.items.splice(index, 1);
+                  grid.clearCache();
+                });
+                buttons[2].addEventListener('click', function() {
+                  model.item.name.first = grid.querySelector('#first-' + wrapper._model.index).value;
+                  model.item.name.last = grid.querySelector('#last-' + wrapper._model.index).value;
 
-              const editBtn = new Vaadin.ButtonElement();
-              editBtn.style.marginRight = '5px';
-              editBtn.addEventListener('click', function() {
-                grid.querySelector('#first-' + model.index).focus();
-                updateTextFieldsVisibility(model.index, true);
-                updateButtonsVisibility(wrapper, true);
-              });
-              editBtn.setAttribute('focus-target', true);
-              editBtn.setAttribute('theme', 'icon');
-              editBtn.setAttribute('aria-label', 'Edit');
-              editBtn.innerHTML = '<iron-icon icon="lumo:edit"></iron-icon>';
+                  updateTextFieldsVisibility(wrapper._model.index, false);
+                  updateButtonsVisibility(wrapper, false);
+                  grid.clearCache();
+                  buttons[0].focus();
+                });
+                buttons[3].addEventListener('click', function(event) {
+                  updateTextFieldsVisibility(wrapper._model.index, false);
+                  updateButtonsVisibility(wrapper, false);
+                  grid.clearCache();
+                  buttons[0].focus();
+                });
+              }
 
-              const deleteBtn = new Vaadin.ButtonElement();
-              deleteBtn.addEventListener('click', function(event) {
-                var index = grid.items.indexOf(model.item);
-                grid.items.splice(index, 1);
-
-                grid.clearCache();
-              });
-              deleteBtn.setAttribute('theme', 'icon error');
-              deleteBtn.setAttribute('aria-label', 'Delete');
-              deleteBtn.innerHTML = '<iron-icon icon="lumo:cross"></iron-icon>';
-
-              const saveBtn = new Vaadin.ButtonElement();
-              saveBtn.style.marginRight = '5px';
-              saveBtn.setAttribute('hidden', true);
-              saveBtn.addEventListener('click', function() {
-                model.item.name.first = grid.querySelector('#first-' + model.index).value;
-                model.item.name.last = grid.querySelector('#last-' + model.index).value;
-
-                updateTextFieldsVisibility(model.index, false);
-                updateButtonsVisibility(wrapper, false);
-                grid.clearCache();
-                editBtn.focus();
-              });
-              saveBtn.setAttribute('theme', 'primary');
-              saveBtn.setAttribute('focus-target', false);
-              saveBtn.textContent = 'Save';
-
-              const cancelBtn = new Vaadin.ButtonElement();
-              cancelBtn.setAttribute('hidden', true);
-              cancelBtn.addEventListener('click', function(event) {
-                updateTextFieldsVisibility(model.index, false);
-                updateButtonsVisibility(wrapper, false);
-                grid.clearCache();
-                editBtn.focus();
-              });
-              cancelBtn.textContent = 'Cancel';
-
-              wrapper.appendChild(editBtn);
-              wrapper.appendChild(deleteBtn);
-              wrapper.appendChild(saveBtn);
-              wrapper.appendChild(cancelBtn);
-
-              root.appendChild(wrapper);
+              wrapper._model = model;
+              console.log(model, root, root._model);
             };
 
             function updateTextFieldsVisibility(index, editing) {

--- a/demo/grid-crud-demos.html
+++ b/demo/grid-crud-demos.html
@@ -15,129 +15,189 @@
 
     <h3>CRUD</h3>
     <p>
-      Column <code>&lt;template&gt;</code> elements and data binding can be used to implement inline editing.
+      Grid renderers and JavaScript functions can be used to implement inline editing.
     </p>
     <p>
       <b>Note:</b> Remember to call <code>grid.clearCache()</code> to show updated data.
     </p>
     <vaadin-demo-snippet id='grid-crud-demos-crud'>
       <template preserve-content>
-        <x-crud></x-crud>
-        <dom-module id="x-crud">
-          <template preserve-content>
-            <style>
-              vaadin-grid vaadin-text-field {
-                width: 100%;
+        <style>
+          vaadin-grid vaadin-text-field {
+            width: 100%;
+          }
+        </style>
+        <x-array-data-provider></x-array-data-provider>
+
+        <div style="margin-bottom: 20px">
+          <vaadin-text-field id="firstname" label="First Name"></vaadin-text-field>
+          <vaadin-text-field id="lastname" label="Last Name"></vaadin-text-field>
+          <vaadin-button id="add-btn">Add</vaadin-button>
+        </div>
+
+        <vaadin-grid theme="compact">
+          <vaadin-grid-column resizable id="column1"></vaadin-grid-column>
+          <vaadin-grid-column resizable id="column2"></vaadin-grid-column>
+          <vaadin-grid-column width="12em" resizable id="column3"></vaadin-grid-column>
+          <vaadin-grid-column width="14em" id="column4"></vaadin-grid-column>
+        </vaadin-grid>
+        <script>
+          window.addDemoReadyListener('#grid-crud-demos-crud', function(document) {
+            const grid = document.querySelector('vaadin-grid');
+            const firstname = document.querySelector('#firstname');
+            const lastname = document.querySelector('#lastname');
+
+            const addBtn = document.querySelector('#add-btn');
+
+            addBtn.addEventListener('click', function() {
+              if (firstname.value !== '' && lastname.value !== '') {
+                grid.items.unshift({name: {first: firstname.value, last: lastname.value}});
+                grid.clearCache();
+
+                firstname.value = '';
+                lastname.value = '';
+              } else {
+                alert('First Name and Last Name required');
               }
-            </style>
-            <x-array-data-provider items="{{items}}" size="200"></x-array-data-provider>
-
-            <div style="margin-bottom: 20px">
-              <vaadin-text-field id="firstname" label="First Name"></vaadin-text-field>
-              <vaadin-text-field id="lastname" label="Last Name"></vaadin-text-field>
-              <vaadin-button on-click="_add">Add</vaadin-button>
-            </div>
-
-            <vaadin-grid theme="compact" id="grid" items="[[items]]">
-
-              <vaadin-grid-column resizable>
-                <template class="header">First Name</template>
-                <template>
-                  <vaadin-text-field id="first-[[index]]" value="[[item.name.first]]" on-input="_storeFirst" readonly$="[[!_isEditing(editing, item)]]"></vaadin-text-field>
-                </template>
-              </vaadin-grid-column>
-
-              <vaadin-grid-column resizable>
-                <template class="header">Last Name</template>
-                <template>
-                  <vaadin-text-field id="last-[[index]]" value="[[item.name.last]]" readonly$="[[!_isEditing(editing, item)]]"></vaadin-text-field>
-                </template>
-              </vaadin-grid-column>
-
-              <vaadin-grid-column width="12em" resizable>
-                <template class="header">Email</template>
-                <template>
-                  <div>[[item.name.first]].[[item.name.last]]@example.com</div>
-                </template>
-              </vaadin-grid-column>
-
-              <vaadin-grid-column width="14em">
-                <template>
-                  <div style="text-align: right;">
-                    <vaadin-button id="edit-button" hidden="[[editing]]" on-click="_edit" focus-target$="[[!editing]]" theme="icon" aria-label="Edit"><iron-icon icon="lumo:edit"></iron-icon></vaadin-button>
-                    <vaadin-button hidden="[[editing]]" on-click="_remove" theme="icon error" aria-label="Delete"><iron-icon icon="lumo:cross"></iron-icon></vaadin-button>
-                    <vaadin-button hidden="[[!_isEditing(editing, item)]]" on-click="_save" focus-target$="[[editing]]" theme="primary">Save</vaadin-button>
-                    <vaadin-button hidden="[[!_isEditing(editing, item)]]" on-click="_cancel">Cancel</vaadin-button>
-                  </div>
-                </template>
-              </vaadin-grid-column>
-
-            </vaadin-grid>
-          </template>
-          <script>
-            window.addDemoReadyListener('#grid-crud-demos-crud', function(document) {
-              Polymer({
-                is: 'x-crud',
-
-                properties: {
-                  editing: Object
-                },
-
-                ready: function() {
-                  this.editing = null;
-                },
-
-                _isEditing: function(editing, item) {
-                  return item === editing;
-                },
-
-                _edit: function(e) {
-                  var item = e.model.item;
-                  this.editing = item;
-
-                  this.$.grid.querySelector('#first-' + e.model.index).focus();
-                },
-
-                _save: function(e) {
-                  var item = e.model.item;
-                  item.name.first = this.$.grid.querySelector('#first-' + e.model.index).value;
-                  item.name.last = this.$.grid.querySelector('#last-' + e.model.index).value;
-
-                  this.editing = null;
-
-                  this.$.grid.clearCache();
-                  this.$.grid.querySelector('#edit-button').focus();
-                },
-
-                _cancel: function() {
-                  this.editing = null;
-
-                  this.$.grid.clearCache();
-                  this.$.grid.querySelector('#edit-button').focus();
-                },
-
-                _add: function(e) {
-                  if (this.$.firstname.value !== '' && this.$.lastname.value !== '') {
-                    this.items.unshift({name: {first: this.$.firstname.value, last: this.$.lastname.value}});
-                    this.$.grid.clearCache();
-
-                    this.$.firstname.value = '';
-                    this.$.lastname.value = '';
-                  } else {
-                    alert('First Name and Last Name required');
-                  }
-                },
-
-                _remove: function(e) {
-                  var index = this.items.indexOf(e.model.item);
-                  this.items.splice(index, 1);
-
-                  this.$.grid.clearCache();
-                }
-              });
             });
-          </script>
-        </dom-module>
+
+            const column1 = document.querySelector('#column1');
+            const column2 = document.querySelector('#column2');
+            const column3 = document.querySelector('#column3');
+            const column4 = document.querySelector('#column4');
+
+            column1.headerRenderer = function(root) {
+              root.textContent = 'First Name';
+            };
+
+            column1.renderer = function(root, column, model) {
+              root.innerHTML = '';
+
+              const textField = new Vaadin.TextFieldElement();
+              textField.setAttribute('id', 'first-' + model.index);
+              textField.setAttribute('value', model.item.name.first);
+              textField.setAttribute('readonly', true);
+              root.appendChild(textField);
+            };
+
+            column2.headerRenderer = function(root) {
+              root.textContent = 'Last Name';
+            };
+
+            column2.renderer = function(root, column, model) {
+              root.innerHTML = '';
+
+              const textField = new Vaadin.TextFieldElement();
+              textField.setAttribute('id', 'last-' + model.index);
+              textField.setAttribute('value', model.item.name.last);
+              textField.setAttribute('readonly', true);
+              root.appendChild(textField);
+            };
+
+            column3.headerRenderer = function(root) {
+              root.textContent = 'Email';
+            };
+
+            column3.renderer = function(root, column, model) {
+              root.innerHTML = '<div>' + model.item.name.first + '.' + model.item.name.last + '@example.com</div>';
+            };
+
+            column4.renderer = function(root, column, model) {
+              root.innerHTML = '';
+
+              const wrapper = window.document.createElement('div');
+              wrapper.style.textAlign = 'right';
+
+              const editBtn = new Vaadin.ButtonElement();
+              editBtn.style.marginRight = '5px';
+              editBtn.addEventListener('click', function() {
+                grid.querySelector('#first-' + model.index).focus();
+                updateTextFieldsVisibility(model.index, true);
+                updateButtonsVisibility(wrapper, true);
+              });
+              editBtn.setAttribute('focus-target', true);
+              editBtn.setAttribute('theme', 'icon');
+              editBtn.setAttribute('aria-label', 'Edit');
+              editBtn.innerHTML = '<iron-icon icon="lumo:edit"></iron-icon>';
+
+              const deleteBtn = new Vaadin.ButtonElement();
+              deleteBtn.addEventListener('click', function(event) {
+                var index = grid.items.indexOf(model.item);
+                grid.items.splice(index, 1);
+
+                grid.clearCache();
+              });
+              deleteBtn.setAttribute('theme', 'icon error');
+              deleteBtn.setAttribute('aria-label', 'Delete');
+              deleteBtn.innerHTML = '<iron-icon icon="lumo:cross"></iron-icon>';
+
+              const saveBtn = new Vaadin.ButtonElement();
+              saveBtn.style.marginRight = '5px';
+              saveBtn.setAttribute('hidden', true);
+              saveBtn.addEventListener('click', function() {
+                model.item.name.first = grid.querySelector('#first-' + model.index).value;
+                model.item.name.last = grid.querySelector('#last-' + model.index).value;
+
+                updateTextFieldsVisibility(model.index, false);
+                updateButtonsVisibility(wrapper, false);
+                grid.clearCache();
+                editBtn.focus();
+              });
+              saveBtn.setAttribute('theme', 'primary');
+              saveBtn.setAttribute('focus-target', false);
+              saveBtn.textContent = 'Save';
+
+              const cancelBtn = new Vaadin.ButtonElement();
+              cancelBtn.setAttribute('hidden', true);
+              cancelBtn.addEventListener('click', function(event) {
+                updateTextFieldsVisibility(model.index, false);
+                updateButtonsVisibility(wrapper, false);
+                grid.clearCache();
+                editBtn.focus();
+              });
+              cancelBtn.textContent = 'Cancel';
+
+              wrapper.appendChild(editBtn);
+              wrapper.appendChild(deleteBtn);
+              wrapper.appendChild(saveBtn);
+              wrapper.appendChild(cancelBtn);
+
+              root.appendChild(wrapper);
+            };
+
+            function updateTextFieldsVisibility(index, editing) {
+              if (editing) {
+                grid.querySelector('#first-' + index).removeAttribute('readonly');
+                grid.querySelector('#last-' + index).removeAttribute('readonly');
+              } else {
+                grid.querySelector('#first-' + index).setAttribute('readonly', true);
+                grid.querySelector('#last-' + index).setAttribute('readonly', true);
+              }
+            }
+
+            function updateButtonsVisibility(wrapper, editing) {
+              if (editing) {
+                wrapper.querySelectorAll('[theme~="icon"]').forEach(function(btn) {
+                  btn.setAttribute('hidden', true);
+                });
+                wrapper.querySelectorAll('vaadin-button:not([theme~="icon"])').forEach(function(btn) {
+                  btn.removeAttribute('hidden');
+                });
+              } else {
+                wrapper.querySelectorAll('[theme~="icon"]').forEach(function(btn) {
+                  btn.removeAttribute('hidden');
+                });
+                wrapper.querySelectorAll('vaadin-button:not([theme~="icon"])').forEach(function(btn) {
+                  btn.setAttribute('hidden', true);
+                });
+              }
+            }
+
+            const dataProvider = document.querySelector('x-array-data-provider');
+            dataProvider.size = 200;
+            grid.items = dataProvider.items;
+          });
+        </script>
       </template>
     </vaadin-demo-snippet>
 

--- a/demo/grid-data-demos.html
+++ b/demo/grid-data-demos.html
@@ -11,38 +11,36 @@
     <vaadin-demo-snippet id='grid-data-demos-assigning-array-data'>
       <template preserve-content>
         <vaadin-grid aria-label="Array Data Example">
-          <vaadin-grid-column width="60px" flex-grow="0" id="column1"></vaadin-grid-column>
-          <vaadin-grid-column id="column2"></vaadin-grid-column>
-          <vaadin-grid-column id="column3"></vaadin-grid-column>
+          <vaadin-grid-column width="60px" flex-grow="0"></vaadin-grid-column>
+          <vaadin-grid-column></vaadin-grid-column>
+          <vaadin-grid-column></vaadin-grid-column>
         </vaadin-grid>
         <script>
           window.addDemoReadyListener('#grid-data-demos-assigning-array-data', function(document) {
             const grid = document.querySelector('vaadin-grid');
-            const column1 = document.querySelector('#column1');
-            const column2 = document.querySelector('#column2');
-            const column3 = document.querySelector('#column3');
+            const columns = document.querySelectorAll('vaadin-grid-column');
 
-            column1.renderer = function(root, column, model) {
+            columns[0].renderer = function(root, column, model) {
               root.textContent = model.index;
             };
 
-            column2.renderer = function(root, column, model) {
+            columns[1].renderer = function(root, column, model) {
               root.textContent = model.item.firstName;
             };
 
-            column3.renderer = function(root, column, model) {
+            columns[2].renderer = function(root, column, model) {
               root.textContent = model.item.lastName;
             };
 
-            column1.headerRenderer = function(root) {
+            columns[0].headerRenderer = function(root) {
               root.textContent = '#';
             };
 
-            column2.headerRenderer = function(root) {
+            columns[1].headerRenderer = function(root) {
               root.textContent = 'First Name';
             };
 
-            column3.headerRenderer = function(root) {
+            columns[2].headerRenderer = function(root) {
               root.textContent = 'Last Name';
             };
 
@@ -73,9 +71,9 @@
         <vaadin-button raised id="remove-btn">Remove Item</vaadin-button>
 
         <vaadin-grid aria-label="Dynamic Data Example">
-          <vaadin-grid-column width="60px" flex-grow="0" id="column1"></vaadin-grid-column>
-          <vaadin-grid-column id="column2"></vaadin-grid-column>
-          <vaadin-grid-column id="column3"></vaadin-grid-column>
+          <vaadin-grid-column width="60px" flex-grow="0"></vaadin-grid-column>
+          <vaadin-grid-column></vaadin-grid-column>
+          <vaadin-grid-column></vaadin-grid-column>
         </vaadin-grid>
         <script>
           window.addDemoReadyListener('#grid-data-demos-dynamic-array-data', function(document) {
@@ -95,31 +93,29 @@
               grid.items = newItemsArray;
             });
 
-            const column1 = document.querySelector('#column1');
-            const column2 = document.querySelector('#column2');
-            const column3 = document.querySelector('#column3');
+            const columns = document.querySelectorAll('vaadin-grid-column');
 
-            column1.renderer = function(root, column, model) {
+            columns[0].renderer = function(root, column, model) {
               root.textContent = model.index;
             };
 
-            column2.renderer = function(root, column, model) {
+            columns[1].renderer = function(root, column, model) {
               root.textContent = model.item.firstName;
             };
 
-            column3.renderer = function(root, column, model) {
+            columns[2].renderer = function(root, column, model) {
               root.textContent = model.item.lastName;
             };
 
-            column1.headerRenderer = function(root) {
+            columns[0].headerRenderer = function(root) {
               root.textContent = '#';
             };
 
-            column2.headerRenderer = function(root) {
+            columns[1].headerRenderer = function(root) {
               root.textContent = 'First Name';
             };
 
-            column3.headerRenderer = function(root) {
+            columns[2].headerRenderer = function(root) {
               root.textContent = 'Last Name';
             };
 
@@ -151,9 +147,9 @@
         <vaadin-button raised id="remove-btn">Remove Item</vaadin-button>
 
         <vaadin-grid aria-label="Dynamic Data Example" height-by-rows>
-          <vaadin-grid-column width="60px" flex-grow="0" id="column1"></vaadin-grid-column>
-          <vaadin-grid-column id="column2"></vaadin-grid-column>
-          <vaadin-grid-column id="column3"></vaadin-grid-column>
+          <vaadin-grid-column width="60px" flex-grow="0"></vaadin-grid-column>
+          <vaadin-grid-column></vaadin-grid-column>
+          <vaadin-grid-column></vaadin-grid-column>
         </vaadin-grid>
         <script>
           window.addDemoReadyListener('#grid-data-demos-dynamic-height', function(document) {
@@ -173,31 +169,29 @@
               grid.items = newItemsArray;
             });
 
-            const column1 = document.querySelector('#column1');
-            const column2 = document.querySelector('#column2');
-            const column3 = document.querySelector('#column3');
+            const columns = document.querySelectorAll('vaadin-grid-column');
 
-            column1.renderer = function(root, column, model) {
+            columns[0].renderer = function(root, column, model) {
               root.textContent = model.index;
             };
 
-            column2.renderer = function(root, column, model) {
+            columns[1].renderer = function(root, column, model) {
               root.textContent = model.item.firstName;
             };
 
-            column3.renderer = function(root, column, model) {
+            columns[2].renderer = function(root, column, model) {
               root.textContent = model.item.lastName;
             };
 
-            column1.headerRenderer = function(root) {
+            columns[0].headerRenderer = function(root) {
               root.textContent = '#';
             };
 
-            column2.headerRenderer = function(root) {
+            columns[1].headerRenderer = function(root) {
               root.textContent = 'First Name';
             };
 
-            column3.headerRenderer = function(root) {
+            columns[2].headerRenderer = function(root) {
               root.textContent = 'Last Name';
             };
 
@@ -229,9 +223,9 @@
     <vaadin-demo-snippet id='grid-data-demos-assigning-remotefunction-data'>
       <template preserve-content>
         <vaadin-grid aria-label="Remote Data Example">
-          <vaadin-grid-column width="60px" flex-grow="0" id="column1"></vaadin-grid-column>
-          <vaadin-grid-column id="column2"></vaadin-grid-column>
-          <vaadin-grid-column id="column3"></vaadin-grid-column>
+          <vaadin-grid-column width="60px" flex-grow="0"></vaadin-grid-column>
+          <vaadin-grid-column></vaadin-grid-column>
+          <vaadin-grid-column></vaadin-grid-column>
         </vaadin-grid>
         <script>
           window.addDemoReadyListener('#grid-data-demos-assigning-remotefunction-data', function(document) {
@@ -248,31 +242,29 @@
               xhr.send();
             };
 
-            const column1 = document.querySelector('#column1');
-            const column2 = document.querySelector('#column2');
-            const column3 = document.querySelector('#column3');
+            const columns = document.querySelectorAll('vaadin-grid-column');
 
-            column1.renderer = function(root, column, model) {
+            columns[0].renderer = function(root, column, model) {
               root.textContent = model.index;
             };
 
-            column2.renderer = function(root, column, model) {
+            columns[1].renderer = function(root, column, model) {
               root.textContent = model.item.firstName;
             };
 
-            column3.renderer = function(root, column, model) {
+            columns[2].renderer = function(root, column, model) {
               root.textContent = model.item.lastName;
             };
 
-            column1.headerRenderer = function(root) {
+            columns[0].headerRenderer = function(root) {
               root.textContent = '#';
             };
 
-            column2.headerRenderer = function(root) {
+            columns[1].headerRenderer = function(root) {
               root.textContent = 'First Name';
             };
 
-            column3.headerRenderer = function(root) {
+            columns[2].headerRenderer = function(root) {
               root.textContent = 'Last Name';
             };
           });

--- a/demo/grid-data-demos.html
+++ b/demo/grid-data-demos.html
@@ -6,117 +6,131 @@
       }
     </style>
 
-
     <h3>Assigning Array Data</h3>
     <p>An array of objects can be assigned to the <code>items</code> property.</p>
     <vaadin-demo-snippet id='grid-data-demos-assigning-array-data'>
       <template preserve-content>
-        <x-array-data-example></x-array-data-example>
-        <dom-module id="x-array-data-example">
-          <template preserve-content>
-            <vaadin-grid aria-label="Array Data Example" items="[[items]]">
+        <vaadin-grid aria-label="Array Data Example">
+          <vaadin-grid-column width="60px" flex-grow="0" id="column1"></vaadin-grid-column>
+          <vaadin-grid-column id="column2"></vaadin-grid-column>
+          <vaadin-grid-column id="column3"></vaadin-grid-column>
+        </vaadin-grid>
+        <script>
+          window.addDemoReadyListener('#grid-data-demos-assigning-array-data', function(document) {
+            const grid = document.querySelector('vaadin-grid');
+            const column1 = document.querySelector('#column1');
+            const column2 = document.querySelector('#column2');
+            const column3 = document.querySelector('#column3');
 
-              <vaadin-grid-column width="60px" flex-grow="0">
-                <template class="header">#</template>
-                <template>[[index]]</template>
-              </vaadin-grid-column>
+            column1.renderer = function(root, column, model) {
+              root.textContent = model.index;
+            };
 
-              <vaadin-grid-column>
-                <template class="header">First Name</template>
-                <template>[[item.firstName]]</template>
-              </vaadin-grid-column>
+            column2.renderer = function(root, column, model) {
+              root.textContent = model.item.firstName;
+            };
 
-              <vaadin-grid-column>
-                <template class="header">Last Name</template>
-                <template>[[item.lastName]]</template>
-              </vaadin-grid-column>
+            column3.renderer = function(root, column, model) {
+              root.textContent = model.item.lastName;
+            };
 
-            </vaadin-grid>
-          </template>
-          <script>
-            window.addDemoReadyListener('#grid-data-demos-assigning-array-data', function(document) {
-              Polymer({
-                is: 'x-array-data-example',
+            column1.headerRenderer = function(root) {
+              root.textContent = '#';
+            };
 
-                ready: function() {
-                  var items = [];
+            column2.headerRenderer = function(root) {
+              root.textContent = 'First Name';
+            };
 
-                  for (var i = 0; i < 100; i++) {
-                    items.push({firstName: 'First Name ' + i, lastName: 'Last Name ' + i});
-                  }
+            column3.headerRenderer = function(root) {
+              root.textContent = 'Last Name';
+            };
 
-                  this.items = items;
-                }
-              });
-            });
-          </script>
-        </dom-module>
+            const items = [];
+            for (var i = 0; i < 100; i++) {
+              items.push({firstName: 'First Name ' + i, lastName: 'Last Name ' + i});
+            }
+
+            grid.items = items;
+          });
+        </script>
       </template>
     </vaadin-demo-snippet>
 
 
     <h3>Dynamic Array Data</h3>
     <p>
-      The <code>items</code> property can be modified using Polymer's array mutation methods.
+      The <code>items</code> property can be modified using array manipulations.
     </p>
     <vaadin-demo-snippet id='grid-data-demos-dynamic-array-data'>
       <template preserve-content>
-        <x-dynamic-data-example></x-dynamic-data-example>
-        <dom-module id="x-dynamic-data-example">
-          <template preserve-content>
-            <style>
-              vaadin-button {
-                margin-bottom: 20px;
-              }
-            </style>
-            <vaadin-button raised on-click="_add">Add Item</vaadin-button>
-            <vaadin-button raised on-click="_remove">Remove Item</vaadin-button>
+        <style>
+          vaadin-button {
+            margin-bottom: 20px;
+          }
+        </style>
+        <vaadin-button raised id="add-btn">Add Item</vaadin-button>
+        <vaadin-button raised id="remove-btn">Remove Item</vaadin-button>
 
-            <vaadin-grid aria-label="Dynamic Data Example" items="[[items]]">
+        <vaadin-grid aria-label="Dynamic Data Example">
+          <vaadin-grid-column width="60px" flex-grow="0" id="column1"></vaadin-grid-column>
+          <vaadin-grid-column id="column2"></vaadin-grid-column>
+          <vaadin-grid-column id="column3"></vaadin-grid-column>
+        </vaadin-grid>
+        <script>
+          window.addDemoReadyListener('#grid-data-demos-dynamic-array-data', function(document) {
+            const grid = document.querySelector('vaadin-grid');
+            const addBtn = document.querySelector('#add-btn');
+            const removeBtn = document.querySelector('#remove-btn');
 
-              <vaadin-grid-column width="60px" flex-grow="0">
-                <template class="header">#</template>
-                <template>[[index]]</template>
-              </vaadin-grid-column>
-
-              <vaadin-grid-column>
-                <template class="header">First Name</template>
-                <template>[[item.firstName]]</template>
-              </vaadin-grid-column>
-
-              <vaadin-grid-column>
-                <template class="header">Last Name</template>
-                <template>[[item.lastName]]</template>
-              </vaadin-grid-column>
-
-            </vaadin-grid>
-          </template>
-          <script>
-            window.addDemoReadyListener('#grid-data-demos-dynamic-array-data', function(document) {
-              Polymer({
-                is: 'x-dynamic-data-example',
-
-                ready: function() {
-                  var items = [];
-
-                  for (var i = 0; i < 10; i++) {
-                    items.push({firstName: 'First Name ' + i, lastName: 'Last Name ' + i});
-                  }
-
-                  this.items = items;
-                },
-
-                _add: function() {
-                  this.push('items', {firstName: 'First Name ' + this.items.length, lastName: 'Last Name ' + this.items.length});
-                },
-
-                _remove: function() {
-                  this.pop('items');
-                }
-              });
+            addBtn.addEventListener('click', function() {
+              const newItemsArray = grid.items.slice(0);
+              newItemsArray.push({firstName: 'First Name ' + newItemsArray.length, lastName: 'Last Name ' + newItemsArray.length});
+              grid.items = newItemsArray;
             });
-          </script>
-        </dom-module>
+
+            removeBtn.addEventListener('click', function() {
+              const newItemsArray = grid.items.slice(0);
+              newItemsArray.pop();
+              grid.items = newItemsArray;
+            });
+
+            const column1 = document.querySelector('#column1');
+            const column2 = document.querySelector('#column2');
+            const column3 = document.querySelector('#column3');
+
+            column1.renderer = function(root, column, model) {
+              root.textContent = model.index;
+            };
+
+            column2.renderer = function(root, column, model) {
+              root.textContent = model.item.firstName;
+            };
+
+            column3.renderer = function(root, column, model) {
+              root.textContent = model.item.lastName;
+            };
+
+            column1.headerRenderer = function(root) {
+              root.textContent = '#';
+            };
+
+            column2.headerRenderer = function(root) {
+              root.textContent = 'First Name';
+            };
+
+            column3.headerRenderer = function(root) {
+              root.textContent = 'Last Name';
+            };
+
+            const items = [];
+            for (var i = 0; i < 100; i++) {
+              items.push({firstName: 'First Name ' + i, lastName: 'Last Name ' + i});
+            }
+
+            grid.items = items;
+          });
+        </script>
       </template>
     </vaadin-demo-snippet>
 
@@ -128,62 +142,73 @@
     </p>
     <vaadin-demo-snippet id='grid-data-demos-dynamic-height'>
       <template preserve-content>
-        <x-dynamic-height-example></x-dynamic-height-example>
-        <dom-module id="x-dynamic-height-example">
-          <template preserve-content>
-            <style>
-              vaadin-button {
-                margin-bottom: 20px;
-              }
-            </style>
-            <vaadin-button raised on-click="_add">Add Item</vaadin-button>
-            <vaadin-button raised on-click="_remove">Remove Item</vaadin-button>
+        <style>
+          vaadin-button {
+            margin-bottom: 20px;
+          }
+        </style>
+        <vaadin-button raised id="add-btn">Add Item</vaadin-button>
+        <vaadin-button raised id="remove-btn">Remove Item</vaadin-button>
 
-            <vaadin-grid aria-label="Dynamic Data Example" items="[[items]]" height-by-rows>
+        <vaadin-grid aria-label="Dynamic Data Example" height-by-rows>
+          <vaadin-grid-column width="60px" flex-grow="0" id="column1"></vaadin-grid-column>
+          <vaadin-grid-column id="column2"></vaadin-grid-column>
+          <vaadin-grid-column id="column3"></vaadin-grid-column>
+        </vaadin-grid>
+        <script>
+          window.addDemoReadyListener('#grid-data-demos-dynamic-height', function(document) {
+            const grid = document.querySelector('vaadin-grid');
+            const addBtn = document.querySelector('#add-btn');
+            const removeBtn = document.querySelector('#remove-btn');
 
-              <vaadin-grid-column width="60px" flex-grow="0">
-                <template class="header">#</template>
-                <template>[[index]]</template>
-              </vaadin-grid-column>
-
-              <vaadin-grid-column>
-                <template class="header">First Name</template>
-                <template>[[item.firstName]]</template>
-              </vaadin-grid-column>
-
-              <vaadin-grid-column>
-                <template class="header">Last Name</template>
-                <template>[[item.lastName]]</template>
-              </vaadin-grid-column>
-
-            </vaadin-grid>
-          </template>
-          <script>
-            window.addDemoReadyListener('#grid-data-demos-dynamic-height', function(document) {
-              Polymer({
-                is: 'x-dynamic-height-example',
-
-                ready: function() {
-                  var items = [];
-
-                  for (var i = 0; i < 5; i++) {
-                    items.push({firstName: 'First Name ' + i, lastName: 'Last Name ' + i});
-                  }
-
-                  this.items = items;
-                },
-
-                _add: function() {
-                  this.push('items', {firstName: 'First Name ' + this.items.length, lastName: 'Last Name ' + this.items.length});
-                },
-
-                _remove: function() {
-                  this.pop('items');
-                }
-              });
+            addBtn.addEventListener('click', function() {
+              const newItemsArray = grid.items.slice(0);
+              newItemsArray.push({firstName: 'First Name ' + newItemsArray.length, lastName: 'Last Name ' + newItemsArray.length});
+              grid.items = newItemsArray;
             });
-          </script>
-        </dom-module>
+
+            removeBtn.addEventListener('click', function() {
+              const newItemsArray = grid.items.slice(0);
+              newItemsArray.pop();
+              grid.items = newItemsArray;
+            });
+
+            const column1 = document.querySelector('#column1');
+            const column2 = document.querySelector('#column2');
+            const column3 = document.querySelector('#column3');
+
+            column1.renderer = function(root, column, model) {
+              root.textContent = model.index;
+            };
+
+            column2.renderer = function(root, column, model) {
+              root.textContent = model.item.firstName;
+            };
+
+            column3.renderer = function(root, column, model) {
+              root.textContent = model.item.lastName;
+            };
+
+            column1.headerRenderer = function(root) {
+              root.textContent = '#';
+            };
+
+            column2.headerRenderer = function(root) {
+              root.textContent = 'First Name';
+            };
+
+            column3.headerRenderer = function(root) {
+              root.textContent = 'Last Name';
+            };
+
+            const items = [];
+            for (var i = 0; i < 5; i++) {
+              items.push({firstName: 'First Name ' + i, lastName: 'Last Name ' + i});
+            }
+
+            grid.items = items;
+          });
+        </script>
       </template>
     </vaadin-demo-snippet>
 
@@ -203,50 +228,55 @@
     </p>
     <vaadin-demo-snippet id='grid-data-demos-assigning-remotefunction-data'>
       <template preserve-content>
-        <x-remote-data-example></x-remote-data-example>
-        <dom-module id="x-remote-data-example">
-          <template preserve-content>
-            <vaadin-grid aria-label="Remote Data Example" data-provider="[[dataProvider]]" size="[[size]]">
+        <vaadin-grid aria-label="Remote Data Example">
+          <vaadin-grid-column width="60px" flex-grow="0" id="column1"></vaadin-grid-column>
+          <vaadin-grid-column id="column2"></vaadin-grid-column>
+          <vaadin-grid-column id="column3"></vaadin-grid-column>
+        </vaadin-grid>
+        <script>
+          window.addDemoReadyListener('#grid-data-demos-assigning-remotefunction-data', function(document) {
+            const grid = document.querySelector('vaadin-grid');
 
-              <vaadin-grid-column width="60px" flex-grow="0">
-                <template class="header">#</template>
-                <template>[[index]]</template>
-              </vaadin-grid-column>
+            grid.size = 200;
+            grid.dataProvider = function(params, callback) {
+              var xhr = new XMLHttpRequest();
+              xhr.onload = function() {
+                callback(JSON.parse(xhr.responseText).result);
+              };
+              var index = params.page * params.pageSize;
+              xhr.open('GET', 'https://demo.vaadin.com/demo-data/1.0/people?index=' + index + '&count=' + params.pageSize, true);
+              xhr.send();
+            };
 
-              <vaadin-grid-column>
-                <template class="header">First Name</template>
-                <template>[[item.firstName]]</template>
-              </vaadin-grid-column>
+            const column1 = document.querySelector('#column1');
+            const column2 = document.querySelector('#column2');
+            const column3 = document.querySelector('#column3');
 
-              <vaadin-grid-column>
-                <template class="header">Last Name</template>
-                <template>[[item.lastName]]</template>
-              </vaadin-grid-column>
+            column1.renderer = function(root, column, model) {
+              root.textContent = model.index;
+            };
 
-            </vaadin-grid>
-          </template>
-          <script>
-            window.addDemoReadyListener('#grid-data-demos-assigning-remotefunction-data', function(document) {
-              Polymer({
-                is: 'x-remote-data-example',
+            column2.renderer = function(root, column, model) {
+              root.textContent = model.item.firstName;
+            };
 
-                ready: function() {
-                  this.size = 200;
-                  this.dataProvider = function(params, callback) {
-                    var xhr = new XMLHttpRequest();
-                    xhr.onload = function() {
-                      callback(JSON.parse(xhr.responseText).result);
-                    };
-                    var index = params.page * params.pageSize;
-                    xhr.open('GET', 'https://demo.vaadin.com/demo-data/1.0/people?index=' + index + '&count=' + params.pageSize, true);
-                    xhr.send();
-                  };
-                }
+            column3.renderer = function(root, column, model) {
+              root.textContent = model.item.lastName;
+            };
 
-              });
-            });
-          </script>
-        </dom-module>
+            column1.headerRenderer = function(root) {
+              root.textContent = '#';
+            };
+
+            column2.headerRenderer = function(root) {
+              root.textContent = 'First Name';
+            };
+
+            column3.headerRenderer = function(root) {
+              root.textContent = 'Last Name';
+            };
+          });
+        </script>
       </template>
     </vaadin-demo-snippet>
 

--- a/demo/grid-lumo-theme-demos.html
+++ b/demo/grid-lumo-theme-demos.html
@@ -16,29 +16,26 @@
 
         <vaadin-grid theme="compact" column-reordering-allowed multi-sort>
           <vaadin-grid-selection-column auto-select></vaadin-grid-selection-column>
-          <vaadin-grid-column width="9em" id="column1"></vaadin-grid-column>
-          <vaadin-grid-column width="9em" id="column2"></vaadin-grid-column>
-          <vaadin-grid-column width="15em" flex-grow="2" id="column3"></vaadin-grid-column>
+          <vaadin-grid-column width="9em"></vaadin-grid-column>
+          <vaadin-grid-column width="9em"></vaadin-grid-column>
+          <vaadin-grid-column width="15em" flex-grow="2"></vaadin-grid-column>
         </vaadin-grid>
         <script>
           window.addDemoReadyListener('#grid-lumo-theme-demos-compact', function(document) {
             const ajax = document.querySelector('iron-ajax');
 
             const grid = document.querySelector('vaadin-grid');
-            const column1 = document.querySelector('#column1');
-            const column2 = document.querySelector('#column2');
-            const column3 = document.querySelector('#column3');
-
+            const columns = document.querySelectorAll('vaadin-grid-column');
 
             ajax.generateRequest();
             ajax.addEventListener('last-response-changed', function(e) {
               grid.items = e.target.lastResponse.result;
             });
 
-            column1.renderer = function(root, column, model) {
+            columns[0].renderer = function(root, column, model) {
               root.innerHTML = model.item.firstName;
             };
-            column1.headerRenderer = function(root, column) {
+            columns[0].headerRenderer = function(root, column) {
               root.innerHTML = '';
               const sorter = new Vaadin.GridSorterElement();
               sorter.setAttribute('path', 'firstName');
@@ -46,10 +43,10 @@
               root.appendChild(sorter);
             };
 
-            column2.renderer = function(root, column, model) {
+            columns[1].renderer = function(root, column, model) {
               root.innerHTML = model.item.firstName;
             };
-            column2.headerRenderer = function(root, column) {
+            columns[1].headerRenderer = function(root, column) {
               root.innerHTML = '';
               const sorter = new Vaadin.GridSorterElement();
               sorter.setAttribute('path', 'lastName');
@@ -57,10 +54,10 @@
               root.appendChild(sorter);
             };
 
-            column3.renderer = function(root, column, model) {
+            columns[2].renderer = function(root, column, model) {
               root.innerHTML = model.item.address.street + ', ' + model.item.address.city;
             };
-            column3.headerRenderer = function(root, column) {
+            columns[2].headerRenderer = function(root, column) {
               root.innerHTML = '';
               const sorter = new Vaadin.GridSorterElement();
               sorter.setAttribute('path', 'address.streest');
@@ -80,18 +77,16 @@
 
         <vaadin-grid theme="no-border" column-reordering-allowed multi-sort>
           <vaadin-grid-selection-column auto-select></vaadin-grid-selection-column>
-          <vaadin-grid-column width="9em" id="column1"></vaadin-grid-column>
-          <vaadin-grid-column width="9em" id="column2"></vaadin-grid-column>
-          <vaadin-grid-column width="15em" flex-grow="2" id="column3"></vaadin-grid-column>
+          <vaadin-grid-column width="9em"></vaadin-grid-column>
+          <vaadin-grid-column width="9em"></vaadin-grid-column>
+          <vaadin-grid-column width="15em" flex-grow="2"></vaadin-grid-column>
         </vaadin-grid>
         <script>
           window.addDemoReadyListener('#grid-lumo-theme-demos-bordered', function(document) {
             const ajax = document.querySelector('iron-ajax');
 
             const grid = document.querySelector('vaadin-grid');
-            const column1 = document.querySelector('#column1');
-            const column2 = document.querySelector('#column2');
-            const column3 = document.querySelector('#column3');
+            const columns = document.querySelectorAll('vaadin-grid-column');
 
 
             ajax.generateRequest();
@@ -99,10 +94,10 @@
               grid.items = e.target.lastResponse.result;
             });
 
-            column1.renderer = function(root, column, model) {
+            columns[0].renderer = function(root, column, model) {
               root.innerHTML = model.item.firstName;
             };
-            column1.headerRenderer = function(root, column) {
+            columns[0].headerRenderer = function(root, column) {
               root.innerHTML = '';
               const sorter = new Vaadin.GridSorterElement();
               sorter.setAttribute('path', 'firstName');
@@ -110,10 +105,10 @@
               root.appendChild(sorter);
             };
 
-            column2.renderer = function(root, column, model) {
+            columns[1].renderer = function(root, column, model) {
               root.innerHTML = model.item.firstName;
             };
-            column2.headerRenderer = function(root, column) {
+            columns[1].headerRenderer = function(root, column) {
               root.innerHTML = '';
               const sorter = new Vaadin.GridSorterElement();
               sorter.setAttribute('path', 'lastName');
@@ -121,10 +116,10 @@
               root.appendChild(sorter);
             };
 
-            column3.renderer = function(root, column, model) {
+            columns[2].renderer = function(root, column, model) {
               root.innerHTML = model.item.address.street + ', ' + model.item.address.city;
             };
-            column3.headerRenderer = function(root, column) {
+            columns[2].headerRenderer = function(root, column) {
               root.innerHTML = '';
               const sorter = new Vaadin.GridSorterElement();
               sorter.setAttribute('path', 'address.streest');
@@ -144,18 +139,16 @@
 
         <vaadin-grid theme="no-row-border" column-reordering-allowed multi-sort>
           <vaadin-grid-selection-column auto-select></vaadin-grid-selection-column>
-          <vaadin-grid-column width="9em" id="column1"></vaadin-grid-column>
-          <vaadin-grid-column width="9em" id="column2"></vaadin-grid-column>
-          <vaadin-grid-column width="15em" flex-grow="2" id="column3"></vaadin-grid-column>
+          <vaadin-grid-column width="9em"></vaadin-grid-column>
+          <vaadin-grid-column width="9em"></vaadin-grid-column>
+          <vaadin-grid-column width="15em" flex-grow="2"></vaadin-grid-column>
         </vaadin-grid>
         <script>
           window.addDemoReadyListener('#grid-lumo-theme-demos-row-borders', function(document) {
             const ajax = document.querySelector('iron-ajax');
 
             const grid = document.querySelector('vaadin-grid');
-            const column1 = document.querySelector('#column1');
-            const column2 = document.querySelector('#column2');
-            const column3 = document.querySelector('#column3');
+            const columns = document.querySelectorAll('vaadin-grid-column');
 
 
             ajax.generateRequest();
@@ -163,10 +156,10 @@
               grid.items = e.target.lastResponse.result;
             });
 
-            column1.renderer = function(root, column, model) {
+            columns[0].renderer = function(root, column, model) {
               root.innerHTML = model.item.firstName;
             };
-            column1.headerRenderer = function(root, column) {
+            columns[0].headerRenderer = function(root, column) {
               root.innerHTML = '';
               const sorter = new Vaadin.GridSorterElement();
               sorter.setAttribute('path', 'firstName');
@@ -174,10 +167,10 @@
               root.appendChild(sorter);
             };
 
-            column2.renderer = function(root, column, model) {
+            columns[1].renderer = function(root, column, model) {
               root.innerHTML = model.item.firstName;
             };
-            column2.headerRenderer = function(root, column) {
+            columns[1].headerRenderer = function(root, column) {
               root.innerHTML = '';
               const sorter = new Vaadin.GridSorterElement();
               sorter.setAttribute('path', 'lastName');
@@ -185,10 +178,10 @@
               root.appendChild(sorter);
             };
 
-            column3.renderer = function(root, column, model) {
+            columns[2].renderer = function(root, column, model) {
               root.innerHTML = model.item.address.street + ', ' + model.item.address.city;
             };
-            column3.headerRenderer = function(root, column) {
+            columns[2].headerRenderer = function(root, column) {
               root.innerHTML = '';
               const sorter = new Vaadin.GridSorterElement();
               sorter.setAttribute('path', 'address.streest');
@@ -208,18 +201,16 @@
 
         <vaadin-grid theme="column-borders" column-reordering-allowed multi-sort>
           <vaadin-grid-selection-column auto-select></vaadin-grid-selection-column>
-          <vaadin-grid-column width="9em" id="column1"></vaadin-grid-column>
-          <vaadin-grid-column width="9em" id="column2"></vaadin-grid-column>
-          <vaadin-grid-column width="15em" flex-grow="2" id="column3"></vaadin-grid-column>
+          <vaadin-grid-column width="9em"></vaadin-grid-column>
+          <vaadin-grid-column width="9em"></vaadin-grid-column>
+          <vaadin-grid-column width="15em" flex-grow="2"></vaadin-grid-column>
         </vaadin-grid>
         <script>
           window.addDemoReadyListener('#grid-lumo-theme-demos-column-borders', function(document) {
             const ajax = document.querySelector('iron-ajax');
 
             const grid = document.querySelector('vaadin-grid');
-            const column1 = document.querySelector('#column1');
-            const column2 = document.querySelector('#column2');
-            const column3 = document.querySelector('#column3');
+            const columns = document.querySelectorAll('vaadin-grid-column');
 
 
             ajax.generateRequest();
@@ -227,10 +218,10 @@
               grid.items = e.target.lastResponse.result;
             });
 
-            column1.renderer = function(root, column, model) {
+            columns[0].renderer = function(root, column, model) {
               root.innerHTML = model.item.firstName;
             };
-            column1.headerRenderer = function(root, column) {
+            columns[0].headerRenderer = function(root, column) {
               root.innerHTML = '';
               const sorter = new Vaadin.GridSorterElement();
               sorter.setAttribute('path', 'firstName');
@@ -238,10 +229,10 @@
               root.appendChild(sorter);
             };
 
-            column2.renderer = function(root, column, model) {
+            columns[1].renderer = function(root, column, model) {
               root.innerHTML = model.item.firstName;
             };
-            column2.headerRenderer = function(root, column) {
+            columns[1].headerRenderer = function(root, column) {
               root.innerHTML = '';
               const sorter = new Vaadin.GridSorterElement();
               sorter.setAttribute('path', 'lastName');
@@ -249,10 +240,10 @@
               root.appendChild(sorter);
             };
 
-            column3.renderer = function(root, column, model) {
+            columns[2].renderer = function(root, column, model) {
               root.innerHTML = model.item.address.street + ', ' + model.item.address.city;
             };
-            column3.headerRenderer = function(root, column) {
+            columns[2].headerRenderer = function(root, column) {
               root.innerHTML = '';
               const sorter = new Vaadin.GridSorterElement();
               sorter.setAttribute('path', 'address.streest');
@@ -272,18 +263,16 @@
 
         <vaadin-grid theme="row-stripes" column-reordering-allowed multi-sort>
           <vaadin-grid-selection-column auto-select></vaadin-grid-selection-column>
-          <vaadin-grid-column width="9em" id="column1"></vaadin-grid-column>
-          <vaadin-grid-column width="9em" id="column2"></vaadin-grid-column>
-          <vaadin-grid-column width="15em" flex-grow="2" id="column3"></vaadin-grid-column>
+          <vaadin-grid-column width="9em"></vaadin-grid-column>
+          <vaadin-grid-column width="9em"></vaadin-grid-column>
+          <vaadin-grid-column width="15em" flex-grow="2"></vaadin-grid-column>
         </vaadin-grid>
         <script>
           window.addDemoReadyListener('#grid-lumo-theme-demos-row-stripes', function(document) {
             const ajax = document.querySelector('iron-ajax');
 
             const grid = document.querySelector('vaadin-grid');
-            const column1 = document.querySelector('#column1');
-            const column2 = document.querySelector('#column2');
-            const column3 = document.querySelector('#column3');
+            const columns = document.querySelectorAll('vaadin-grid-column');
 
 
             ajax.generateRequest();
@@ -291,10 +280,10 @@
               grid.items = e.target.lastResponse.result;
             });
 
-            column1.renderer = function(root, column, model) {
+            columns[0].renderer = function(root, column, model) {
               root.innerHTML = model.item.firstName;
             };
-            column1.headerRenderer = function(root, column) {
+            columns[0].headerRenderer = function(root, column) {
               root.innerHTML = '';
               const sorter = new Vaadin.GridSorterElement();
               sorter.setAttribute('path', 'firstName');
@@ -302,10 +291,10 @@
               root.appendChild(sorter);
             };
 
-            column2.renderer = function(root, column, model) {
+            columns[1].renderer = function(root, column, model) {
               root.innerHTML = model.item.firstName;
             };
-            column2.headerRenderer = function(root, column) {
+            columns[1].headerRenderer = function(root, column) {
               root.innerHTML = '';
               const sorter = new Vaadin.GridSorterElement();
               sorter.setAttribute('path', 'lastName');
@@ -313,10 +302,10 @@
               root.appendChild(sorter);
             };
 
-            column3.renderer = function(root, column, model) {
+            columns[2].renderer = function(root, column, model) {
               root.innerHTML = model.item.address.street + ', ' + model.item.address.city;
             };
-            column3.headerRenderer = function(root, column) {
+            columns[2].headerRenderer = function(root, column) {
               root.innerHTML = '';
               const sorter = new Vaadin.GridSorterElement();
               sorter.setAttribute('path', 'address.streest');
@@ -337,18 +326,16 @@
 
         <vaadin-grid theme="wrap-cell-content" column-reordering-allowed multi-sort>
           <vaadin-grid-selection-column auto-select></vaadin-grid-selection-column>
-          <vaadin-grid-column width="9em" id="column1"></vaadin-grid-column>
-          <vaadin-grid-column width="9em" id="column2"></vaadin-grid-column>
-          <vaadin-grid-column width="15em" flex-grow="2" id="column3"></vaadin-grid-column>
+          <vaadin-grid-column width="9em"></vaadin-grid-column>
+          <vaadin-grid-column width="9em"></vaadin-grid-column>
+          <vaadin-grid-column width="15em" flex-grow="2"></vaadin-grid-column>
         </vaadin-grid>
         <script>
           window.addDemoReadyListener('#grid-lumo-theme-demos-wrap-cell-content', function(document) {
             const ajax = document.querySelector('iron-ajax');
 
             const grid = document.querySelector('vaadin-grid');
-            const column1 = document.querySelector('#column1');
-            const column2 = document.querySelector('#column2');
-            const column3 = document.querySelector('#column3');
+            const columns = document.querySelectorAll('vaadin-grid-column');
 
 
             ajax.generateRequest();
@@ -356,10 +343,10 @@
               grid.items = e.target.lastResponse.result;
             });
 
-            column1.renderer = function(root, column, model) {
+            columns[0].renderer = function(root, column, model) {
               root.innerHTML = model.item.firstName;
             };
-            column1.headerRenderer = function(root, column) {
+            columns[0].headerRenderer = function(root, column) {
               root.innerHTML = '';
               const sorter = new Vaadin.GridSorterElement();
               sorter.setAttribute('path', 'firstName');
@@ -367,10 +354,10 @@
               root.appendChild(sorter);
             };
 
-            column2.renderer = function(root, column, model) {
+            columns[1].renderer = function(root, column, model) {
               root.innerHTML = model.item.firstName;
             };
-            column2.headerRenderer = function(root, column) {
+            columns[1].headerRenderer = function(root, column) {
               root.innerHTML = '';
               const sorter = new Vaadin.GridSorterElement();
               sorter.setAttribute('path', 'lastName');
@@ -378,10 +365,10 @@
               root.appendChild(sorter);
             };
 
-            column3.renderer = function(root, column, model) {
+            columns[2].renderer = function(root, column, model) {
               root.innerHTML = model.item.address.street + ', ' + model.item.address.city;
             };
-            column3.headerRenderer = function(root, column) {
+            columns[2].headerRenderer = function(root, column) {
               root.innerHTML = '';
               const sorter = new Vaadin.GridSorterElement();
               sorter.setAttribute('path', 'address.streest');

--- a/demo/grid-lumo-theme-demos.html
+++ b/demo/grid-lumo-theme-demos.html
@@ -12,39 +12,63 @@
     <p><code>&lt;vaadin-grid <b>theme="compact"</b>&gt;</code></p>
     <vaadin-demo-snippet id='grid-lumo-theme-demos-compact'>
       <template preserve-content>
-        <dom-bind>
-          <template>
-            <iron-ajax auto url="https://demo.vaadin.com/demo-data/1.0/people?count=20" handle-as="json" last-response="{{users}}"></iron-ajax>
+        <iron-ajax url="https://demo.vaadin.com/demo-data/1.0/people?count=20"></iron-ajax>
 
-            <vaadin-grid theme="compact" items="[[users.result]]" column-reordering-allowed multi-sort>
+        <vaadin-grid theme="compact" column-reordering-allowed multi-sort>
+          <vaadin-grid-selection-column auto-select></vaadin-grid-selection-column>
+          <vaadin-grid-column width="9em" id="column1"></vaadin-grid-column>
+          <vaadin-grid-column width="9em" id="column2"></vaadin-grid-column>
+          <vaadin-grid-column width="15em" flex-grow="2" id="column3"></vaadin-grid-column>
+        </vaadin-grid>
+        <script>
+          window.addDemoReadyListener('#grid-lumo-theme-demos-compact', function(document) {
+            const ajax = document.querySelector('iron-ajax');
 
-              <vaadin-grid-selection-column auto-select> </vaadin-grid-selection-column>
+            const grid = document.querySelector('vaadin-grid');
+            const column1 = document.querySelector('#column1');
+            const column2 = document.querySelector('#column2');
+            const column3 = document.querySelector('#column3');
 
-              <vaadin-grid-column width="9em">
-                <template class="header">
-                  <vaadin-grid-sorter path="firstName">First Name</vaadin-grid-sorter>
-                </template>
-                <template>[[item.firstName]]
-                </template>
-              </vaadin-grid-column>
 
-              <vaadin-grid-column width="9em">
-                <template class="header">
-                  <vaadin-grid-sorter path="lastName">Last Name</vaadin-grid-sorter>
-                </template>
-                <template>[[item.lastName]]</template>
-              </vaadin-grid-column>
+            ajax.generateRequest();
+            ajax.addEventListener('last-response-changed', function(e) {
+              grid.items = e.target.lastResponse.result;
+            });
 
-              <vaadin-grid-column width="15em" flex-grow="2">
-                <template class="header">
-                  <vaadin-grid-sorter path="address.street">Address</vaadin-grid-sorter>
-                </template>
-                <template>[[item.address.street]], [[item.address.city]]</template>
-              </vaadin-grid-column>
+            column1.renderer = function(root, column, model) {
+              root.innerHTML = model.item.firstName;
+            };
+            column1.headerRenderer = function(root, column) {
+              root.innerHTML = '';
+              const sorter = new Vaadin.GridSorterElement();
+              sorter.setAttribute('path', 'firstName');
+              sorter.textContent = 'First Name';
+              root.appendChild(sorter);
+            };
 
-            </vaadin-grid>
-          </template>
-        </dom-bind>
+            column2.renderer = function(root, column, model) {
+              root.innerHTML = model.item.firstName;
+            };
+            column2.headerRenderer = function(root, column) {
+              root.innerHTML = '';
+              const sorter = new Vaadin.GridSorterElement();
+              sorter.setAttribute('path', 'lastName');
+              sorter.textContent = 'Last Name';
+              root.appendChild(sorter);
+            };
+
+            column3.renderer = function(root, column, model) {
+              root.innerHTML = model.item.address.street + ', ' + model.item.address.city;
+            };
+            column3.headerRenderer = function(root, column) {
+              root.innerHTML = '';
+              const sorter = new Vaadin.GridSorterElement();
+              sorter.setAttribute('path', 'address.streest');
+              sorter.textContent = 'Address';
+              root.appendChild(sorter);
+            };
+          });
+        </script>
       </template>
     </vaadin-demo-snippet>
 
@@ -52,39 +76,63 @@
     <p><code>&lt;vaadin-grid <b>theme="no-border"</b>&gt;</code></p>
     <vaadin-demo-snippet id='grid-lumo-theme-demos-bordered'>
       <template preserve-content>
-        <dom-bind>
-          <template>
-            <iron-ajax auto url="https://demo.vaadin.com/demo-data/1.0/people?count=20" handle-as="json" last-response="{{users}}"></iron-ajax>
+        <iron-ajax url="https://demo.vaadin.com/demo-data/1.0/people?count=20"></iron-ajax>
 
-            <vaadin-grid theme="no-border" items="[[users.result]]" column-reordering-allowed multi-sort>
+        <vaadin-grid theme="no-border" column-reordering-allowed multi-sort>
+          <vaadin-grid-selection-column auto-select></vaadin-grid-selection-column>
+          <vaadin-grid-column width="9em" id="column1"></vaadin-grid-column>
+          <vaadin-grid-column width="9em" id="column2"></vaadin-grid-column>
+          <vaadin-grid-column width="15em" flex-grow="2" id="column3"></vaadin-grid-column>
+        </vaadin-grid>
+        <script>
+          window.addDemoReadyListener('#grid-lumo-theme-demos-bordered', function(document) {
+            const ajax = document.querySelector('iron-ajax');
 
-              <vaadin-grid-selection-column auto-select> </vaadin-grid-selection-column>
+            const grid = document.querySelector('vaadin-grid');
+            const column1 = document.querySelector('#column1');
+            const column2 = document.querySelector('#column2');
+            const column3 = document.querySelector('#column3');
 
-              <vaadin-grid-column width="9em">
-                <template class="header">
-                  <vaadin-grid-sorter path="firstName">First Name</vaadin-grid-sorter>
-                </template>
-                <template>[[item.firstName]]
-                </template>
-              </vaadin-grid-column>
 
-              <vaadin-grid-column width="9em">
-                <template class="header">
-                  <vaadin-grid-sorter path="lastName">Last Name</vaadin-grid-sorter>
-                </template>
-                <template>[[item.lastName]]</template>
-              </vaadin-grid-column>
+            ajax.generateRequest();
+            ajax.addEventListener('last-response-changed', function(e) {
+              grid.items = e.target.lastResponse.result;
+            });
 
-              <vaadin-grid-column width="15em" flex-grow="2">
-                <template class="header">
-                  <vaadin-grid-sorter path="address.street">Address</vaadin-grid-sorter>
-                </template>
-                <template>[[item.address.street]], [[item.address.city]]</template>
-              </vaadin-grid-column>
+            column1.renderer = function(root, column, model) {
+              root.innerHTML = model.item.firstName;
+            };
+            column1.headerRenderer = function(root, column) {
+              root.innerHTML = '';
+              const sorter = new Vaadin.GridSorterElement();
+              sorter.setAttribute('path', 'firstName');
+              sorter.textContent = 'First Name';
+              root.appendChild(sorter);
+            };
 
-            </vaadin-grid>
-          </template>
-        </dom-bind>
+            column2.renderer = function(root, column, model) {
+              root.innerHTML = model.item.firstName;
+            };
+            column2.headerRenderer = function(root, column) {
+              root.innerHTML = '';
+              const sorter = new Vaadin.GridSorterElement();
+              sorter.setAttribute('path', 'lastName');
+              sorter.textContent = 'Last Name';
+              root.appendChild(sorter);
+            };
+
+            column3.renderer = function(root, column, model) {
+              root.innerHTML = model.item.address.street + ', ' + model.item.address.city;
+            };
+            column3.headerRenderer = function(root, column) {
+              root.innerHTML = '';
+              const sorter = new Vaadin.GridSorterElement();
+              sorter.setAttribute('path', 'address.streest');
+              sorter.textContent = 'Address';
+              root.appendChild(sorter);
+            };
+          });
+        </script>
       </template>
     </vaadin-demo-snippet>
 
@@ -92,38 +140,63 @@
     <p><code>&lt;vaadin-grid <b>theme="no-row-borders"</b>&gt;</code></p>
     <vaadin-demo-snippet id='grid-lumo-theme-demos-row-borders'>
       <template preserve-content>
-        <dom-bind>
-          <template>
-            <iron-ajax auto url="https://demo.vaadin.com/demo-data/1.0/people?count=20" handle-as="json" last-response="{{users}}"></iron-ajax>
+        <iron-ajax url="https://demo.vaadin.com/demo-data/1.0/people?count=20"></iron-ajax>
 
-            <vaadin-grid theme="no-row-borders" items="[[users.result]]" column-reordering-allowed multi-sort>
+        <vaadin-grid theme="no-row-border" column-reordering-allowed multi-sort>
+          <vaadin-grid-selection-column auto-select></vaadin-grid-selection-column>
+          <vaadin-grid-column width="9em" id="column1"></vaadin-grid-column>
+          <vaadin-grid-column width="9em" id="column2"></vaadin-grid-column>
+          <vaadin-grid-column width="15em" flex-grow="2" id="column3"></vaadin-grid-column>
+        </vaadin-grid>
+        <script>
+          window.addDemoReadyListener('#grid-lumo-theme-demos-row-borders', function(document) {
+            const ajax = document.querySelector('iron-ajax');
 
-              <vaadin-grid-selection-column auto-select> </vaadin-grid-selection-column>
+            const grid = document.querySelector('vaadin-grid');
+            const column1 = document.querySelector('#column1');
+            const column2 = document.querySelector('#column2');
+            const column3 = document.querySelector('#column3');
 
-              <vaadin-grid-column width="9em">
-                <template class="header">
-                  <vaadin-grid-sorter path="firstName">First Name</vaadin-grid-sorter>
-                </template>
-                <template>[[item.firstName]]</template>
-              </vaadin-grid-column>
 
-              <vaadin-grid-column width="9em">
-                <template class="header">
-                  <vaadin-grid-sorter path="lastName">Last Name</vaadin-grid-sorter>
-                </template>
-                <template>[[item.lastName]]</template>
-              </vaadin-grid-column>
+            ajax.generateRequest();
+            ajax.addEventListener('last-response-changed', function(e) {
+              grid.items = e.target.lastResponse.result;
+            });
 
-              <vaadin-grid-column width="15em" flex-grow="2">
-                <template class="header">
-                  <vaadin-grid-sorter path="address.street">Address</vaadin-grid-sorter>
-                </template>
-                <template>[[item.address.street]], [[item.address.city]]</template>
-              </vaadin-grid-column>
+            column1.renderer = function(root, column, model) {
+              root.innerHTML = model.item.firstName;
+            };
+            column1.headerRenderer = function(root, column) {
+              root.innerHTML = '';
+              const sorter = new Vaadin.GridSorterElement();
+              sorter.setAttribute('path', 'firstName');
+              sorter.textContent = 'First Name';
+              root.appendChild(sorter);
+            };
 
-            </vaadin-grid>
-          </template>
-        </dom-bind>
+            column2.renderer = function(root, column, model) {
+              root.innerHTML = model.item.firstName;
+            };
+            column2.headerRenderer = function(root, column) {
+              root.innerHTML = '';
+              const sorter = new Vaadin.GridSorterElement();
+              sorter.setAttribute('path', 'lastName');
+              sorter.textContent = 'Last Name';
+              root.appendChild(sorter);
+            };
+
+            column3.renderer = function(root, column, model) {
+              root.innerHTML = model.item.address.street + ', ' + model.item.address.city;
+            };
+            column3.headerRenderer = function(root, column) {
+              root.innerHTML = '';
+              const sorter = new Vaadin.GridSorterElement();
+              sorter.setAttribute('path', 'address.streest');
+              sorter.textContent = 'Address';
+              root.appendChild(sorter);
+            };
+          });
+        </script>
       </template>
     </vaadin-demo-snippet>
 
@@ -131,39 +204,63 @@
     <p><code>&lt;vaadin-grid <b>theme="column-borders"</b>&gt;</code></p>
     <vaadin-demo-snippet id='grid-lumo-theme-demos-column-borders'>
       <template preserve-content>
-        <dom-bind>
-          <template>
-            <iron-ajax auto url="https://demo.vaadin.com/demo-data/1.0/people?count=20" handle-as="json" last-response="{{users}}"></iron-ajax>
+        <iron-ajax url="https://demo.vaadin.com/demo-data/1.0/people?count=20"></iron-ajax>
 
-            <vaadin-grid theme="column-borders" items="[[users.result]]" column-reordering-allowed multi-sort>
+        <vaadin-grid theme="column-borders" column-reordering-allowed multi-sort>
+          <vaadin-grid-selection-column auto-select></vaadin-grid-selection-column>
+          <vaadin-grid-column width="9em" id="column1"></vaadin-grid-column>
+          <vaadin-grid-column width="9em" id="column2"></vaadin-grid-column>
+          <vaadin-grid-column width="15em" flex-grow="2" id="column3"></vaadin-grid-column>
+        </vaadin-grid>
+        <script>
+          window.addDemoReadyListener('#grid-lumo-theme-demos-column-borders', function(document) {
+            const ajax = document.querySelector('iron-ajax');
 
-              <vaadin-grid-selection-column auto-select> </vaadin-grid-selection-column>
+            const grid = document.querySelector('vaadin-grid');
+            const column1 = document.querySelector('#column1');
+            const column2 = document.querySelector('#column2');
+            const column3 = document.querySelector('#column3');
 
-              <vaadin-grid-column width="9em">
-                <template class="header">
-                  <vaadin-grid-sorter path="firstName">First Name</vaadin-grid-sorter>
-                </template>
-                <template>[[item.firstName]]</span>
-                </template>
-              </vaadin-grid-column>
 
-              <vaadin-grid-column width="9em">
-                <template class="header">
-                  <vaadin-grid-sorter path="lastName">Last Name</vaadin-grid-sorter>
-                </template>
-                <template>[[item.lastName]]</template>
-              </vaadin-grid-column>
+            ajax.generateRequest();
+            ajax.addEventListener('last-response-changed', function(e) {
+              grid.items = e.target.lastResponse.result;
+            });
 
-              <vaadin-grid-column width="15em" flex-grow="2">
-                <template class="header">
-                  <vaadin-grid-sorter path="address.street">Address</vaadin-grid-sorter>
-                </template>
-                <template>[[item.address.street]], [[item.address.city]]</template>
-              </vaadin-grid-column>
+            column1.renderer = function(root, column, model) {
+              root.innerHTML = model.item.firstName;
+            };
+            column1.headerRenderer = function(root, column) {
+              root.innerHTML = '';
+              const sorter = new Vaadin.GridSorterElement();
+              sorter.setAttribute('path', 'firstName');
+              sorter.textContent = 'First Name';
+              root.appendChild(sorter);
+            };
 
-            </vaadin-grid>
-          </template>
-        </dom-bind>
+            column2.renderer = function(root, column, model) {
+              root.innerHTML = model.item.firstName;
+            };
+            column2.headerRenderer = function(root, column) {
+              root.innerHTML = '';
+              const sorter = new Vaadin.GridSorterElement();
+              sorter.setAttribute('path', 'lastName');
+              sorter.textContent = 'Last Name';
+              root.appendChild(sorter);
+            };
+
+            column3.renderer = function(root, column, model) {
+              root.innerHTML = model.item.address.street + ', ' + model.item.address.city;
+            };
+            column3.headerRenderer = function(root, column) {
+              root.innerHTML = '';
+              const sorter = new Vaadin.GridSorterElement();
+              sorter.setAttribute('path', 'address.streest');
+              sorter.textContent = 'Address';
+              root.appendChild(sorter);
+            };
+          });
+        </script>
       </template>
     </vaadin-demo-snippet>
 
@@ -171,39 +268,63 @@
     <p><code>&lt;vaadin-grid <b>theme="row-stripes"</b>&gt;</code></p>
     <vaadin-demo-snippet id='grid-lumo-theme-demos-row-stripes'>
       <template preserve-content>
-        <dom-bind>
-          <template>
-            <iron-ajax auto url="https://demo.vaadin.com/demo-data/1.0/people?count=20" handle-as="json" last-response="{{users}}"></iron-ajax>
+        <iron-ajax url="https://demo.vaadin.com/demo-data/1.0/people?count=20"></iron-ajax>
 
-            <vaadin-grid theme="row-stripes" items="[[users.result]]" column-reordering-allowed multi-sort>
+        <vaadin-grid theme="row-stripes" column-reordering-allowed multi-sort>
+          <vaadin-grid-selection-column auto-select></vaadin-grid-selection-column>
+          <vaadin-grid-column width="9em" id="column1"></vaadin-grid-column>
+          <vaadin-grid-column width="9em" id="column2"></vaadin-grid-column>
+          <vaadin-grid-column width="15em" flex-grow="2" id="column3"></vaadin-grid-column>
+        </vaadin-grid>
+        <script>
+          window.addDemoReadyListener('#grid-lumo-theme-demos-row-stripes', function(document) {
+            const ajax = document.querySelector('iron-ajax');
 
-              <vaadin-grid-selection-column auto-select> </vaadin-grid-selection-column>
+            const grid = document.querySelector('vaadin-grid');
+            const column1 = document.querySelector('#column1');
+            const column2 = document.querySelector('#column2');
+            const column3 = document.querySelector('#column3');
 
-              <vaadin-grid-column width="9em">
-                <template class="header">
-                  <vaadin-grid-sorter path="firstName">First Name</vaadin-grid-sorter>
-                </template>
-                <template>[[item.firstName]]</span>
-                </template>
-              </vaadin-grid-column>
 
-              <vaadin-grid-column width="9em">
-                <template class="header">
-                  <vaadin-grid-sorter path="lastName">Last Name</vaadin-grid-sorter>
-                </template>
-                <template>[[item.lastName]]</template>
-              </vaadin-grid-column>
+            ajax.generateRequest();
+            ajax.addEventListener('last-response-changed', function(e) {
+              grid.items = e.target.lastResponse.result;
+            });
 
-              <vaadin-grid-column width="15em" flex-grow="2">
-                <template class="header">
-                  <vaadin-grid-sorter path="address.street">Address</vaadin-grid-sorter>
-                </template>
-                <template>[[item.address.street]], [[item.address.city]]</template>
-              </vaadin-grid-column>
+            column1.renderer = function(root, column, model) {
+              root.innerHTML = model.item.firstName;
+            };
+            column1.headerRenderer = function(root, column) {
+              root.innerHTML = '';
+              const sorter = new Vaadin.GridSorterElement();
+              sorter.setAttribute('path', 'firstName');
+              sorter.textContent = 'First Name';
+              root.appendChild(sorter);
+            };
 
-            </vaadin-grid>
-          </template>
-        </dom-bind>
+            column2.renderer = function(root, column, model) {
+              root.innerHTML = model.item.firstName;
+            };
+            column2.headerRenderer = function(root, column) {
+              root.innerHTML = '';
+              const sorter = new Vaadin.GridSorterElement();
+              sorter.setAttribute('path', 'lastName');
+              sorter.textContent = 'Last Name';
+              root.appendChild(sorter);
+            };
+
+            column3.renderer = function(root, column, model) {
+              root.innerHTML = model.item.address.street + ', ' + model.item.address.city;
+            };
+            column3.headerRenderer = function(root, column) {
+              root.innerHTML = '';
+              const sorter = new Vaadin.GridSorterElement();
+              sorter.setAttribute('path', 'address.streest');
+              sorter.textContent = 'Address';
+              root.appendChild(sorter);
+            };
+          });
+        </script>
       </template>
     </vaadin-demo-snippet>
 
@@ -212,39 +333,63 @@
     <p>By default, cell contents don’t wrap and all overflowing content is either clipped or truncated. Apply the <code>wrap-cell-content</code> theme to make the cell content wrap instead.</p>
     <vaadin-demo-snippet id='grid-lumo-theme-demos-wrap-cell-content'>
       <template preserve-content>
-        <dom-bind >
-          <template>
-            <iron-ajax auto url="https://demo.vaadin.com/demo-data/1.0/people?count=20" handle-as="json" last-response="{{users}}"></iron-ajax>
+        <iron-ajax url="https://demo.vaadin.com/demo-data/1.0/people?count=20"></iron-ajax>
 
-            <vaadin-grid theme="wrap-cell-content" items="[[users.result]]" column-reordering-allowed multi-sort>
+        <vaadin-grid theme="wrap-cell-content" column-reordering-allowed multi-sort>
+          <vaadin-grid-selection-column auto-select></vaadin-grid-selection-column>
+          <vaadin-grid-column width="9em" id="column1"></vaadin-grid-column>
+          <vaadin-grid-column width="9em" id="column2"></vaadin-grid-column>
+          <vaadin-grid-column width="15em" flex-grow="2" id="column3"></vaadin-grid-column>
+        </vaadin-grid>
+        <script>
+          window.addDemoReadyListener('#grid-lumo-theme-demos-wrap-cell-content', function(document) {
+            const ajax = document.querySelector('iron-ajax');
 
-              <vaadin-grid-selection-column auto-select> </vaadin-grid-selection-column>
+            const grid = document.querySelector('vaadin-grid');
+            const column1 = document.querySelector('#column1');
+            const column2 = document.querySelector('#column2');
+            const column3 = document.querySelector('#column3');
 
-              <vaadin-grid-column width="9em">
-                <template class="header">
-                  <vaadin-grid-sorter path="firstName">First Name</vaadin-grid-sorter>
-                </template>
-                <template>[[item.firstName]]</span>
-                </template>
-              </vaadin-grid-column>
 
-              <vaadin-grid-column width="9em">
-                <template class="header">
-                  <vaadin-grid-sorter path="lastName">Last Name</vaadin-grid-sorter>
-                </template>
-                <template>[[item.lastName]]</template>
-              </vaadin-grid-column>
+            ajax.generateRequest();
+            ajax.addEventListener('last-response-changed', function(e) {
+              grid.items = e.target.lastResponse.result;
+            });
 
-              <vaadin-grid-column width="15em">
-                <template class="header">
-                  <vaadin-grid-sorter path="address.street">Address</vaadin-grid-sorter>
-                </template>
-                <template>[[item.address.street]], [[item.address.city]]</template>
-              </vaadin-grid-column>
+            column1.renderer = function(root, column, model) {
+              root.innerHTML = model.item.firstName;
+            };
+            column1.headerRenderer = function(root, column) {
+              root.innerHTML = '';
+              const sorter = new Vaadin.GridSorterElement();
+              sorter.setAttribute('path', 'firstName');
+              sorter.textContent = 'First Name';
+              root.appendChild(sorter);
+            };
 
-            </vaadin-grid>
-          </template>
-        </dom-bind>
+            column2.renderer = function(root, column, model) {
+              root.innerHTML = model.item.firstName;
+            };
+            column2.headerRenderer = function(root, column) {
+              root.innerHTML = '';
+              const sorter = new Vaadin.GridSorterElement();
+              sorter.setAttribute('path', 'lastName');
+              sorter.textContent = 'Last Name';
+              root.appendChild(sorter);
+            };
+
+            column3.renderer = function(root, column, model) {
+              root.innerHTML = model.item.address.street + ', ' + model.item.address.city;
+            };
+            column3.headerRenderer = function(root, column) {
+              root.innerHTML = '';
+              const sorter = new Vaadin.GridSorterElement();
+              sorter.setAttribute('path', 'address.streest');
+              sorter.textContent = 'Address';
+              root.appendChild(sorter);
+            };
+          });
+        </script>
       </template>
     </vaadin-demo-snippet>
 

--- a/demo/grid-pagination-demos.html
+++ b/demo/grid-pagination-demos.html
@@ -54,9 +54,9 @@
         <x-array-data-provider></x-array-data-provider>
 
         <vaadin-grid page-size="10" height-by-rows>
-          <vaadin-grid-column id="column1"></vaadin-grid-column>
-          <vaadin-grid-column id="column2"></vaadin-grid-column>
-          <vaadin-grid-column width="200px" id="column3"></vaadin-grid-column>
+          <vaadin-grid-column name="First"></vaadin-grid-column>
+          <vaadin-grid-column name="Last"></vaadin-grid-column>
+          <vaadin-grid-column width="200px" name="Email"></vaadin-grid-column>
         </vaadin-grid>
 
         <div id="pages"></div>
@@ -66,26 +66,23 @@
             const grid = document.querySelector('vaadin-grid');
             let pages;
 
-            const column1 = document.querySelector('#column1');
-            const column2 = document.querySelector('#column2');
-            const column3 = document.querySelector('#column3');
+            const columns = grid.querySelectorAll('vaadin-grid-column');
 
-            ['First Name', 'Last Name', 'Email'].forEach(function(header, index) {
-              const columnID = index + 1;
-              document.querySelector('#column' + columnID).headerRenderer = function(root) {
-                root.textContent = header;
+            columns.forEach(function(column, index) {
+              column.headerRenderer = function(root) {
+                root.textContent = column.getAttribute('name');
               };
             });
 
-            column1.renderer = function(root, column, model) {
+            columns[0].renderer = function(root, column, model) {
               root.textContent = model.item.name.first;
             };
 
-            column2.renderer = function(root, column, model) {
+            columns[1].renderer = function(root, column, model) {
               root.textContent = model.item.name.last;
             };
 
-            column3.renderer = function(root, column, model) {
+            columns[2].renderer = function(root, column, model) {
               root.textContent = model.item.name.first + '.' + model.item.name.last + '@example.com';
             };
 

--- a/demo/grid-pagination-demos.html
+++ b/demo/grid-pagination-demos.html
@@ -19,126 +19,138 @@
     </p>
     <vaadin-demo-snippet id='grid-pagination-demos-pagination'>
       <template preserve-content>
-        <x-pagination></x-pagination>
-        <dom-module id="x-pagination">
-          <template preserve-content>
-            <style>
-              #pages {
-                display: flex;
-                flex-wrap: wrap;
-                margin: 20px;
+        <style>
+          #pages {
+            display: flex;
+            flex-wrap: wrap;
+            margin: 20px;
+          }
+
+          #pages > button {
+            user-select: none;
+            padding: 5px;
+            margin: 0 5px;
+            border-radius: 10%;
+            border: 0;
+            background: transparent;
+            font: inherit;
+            outline: none;
+            cursor: pointer;
+          }
+
+          #pages > button:hover,
+          #pages > button:focus {
+            color: #ccc;
+            background-color: #eee;
+          }
+
+          #pages > button[selected] {
+            font-weight: bold;
+            color: white;
+            background-color: #ccc;
+          }
+        </style>
+
+        <x-array-data-provider></x-array-data-provider>
+
+        <vaadin-grid page-size="10" height-by-rows>
+          <vaadin-grid-column id="column1"></vaadin-grid-column>
+          <vaadin-grid-column id="column2"></vaadin-grid-column>
+          <vaadin-grid-column width="200px" id="column3"></vaadin-grid-column>
+        </vaadin-grid>
+
+        <div id="pages"></div>
+
+        <script>
+          window.addDemoReadyListener('#grid-pagination-demos-pagination', function(document) {
+            const grid = document.querySelector('vaadin-grid');
+            let pages;
+
+            const column1 = document.querySelector('#column1');
+            const column2 = document.querySelector('#column2');
+            const column3 = document.querySelector('#column3');
+
+            ['First Name', 'Last Name', 'Email'].forEach(function(header, index) {
+              const columnID = index + 1;
+              document.querySelector('#column' + columnID).headerRenderer = function(root) {
+                root.textContent = header;
+              };
+            });
+
+            column1.renderer = function(root, column, model) {
+              root.textContent = model.item.name.first;
+            };
+
+            column2.renderer = function(root, column, model) {
+              root.textContent = model.item.name.last;
+            };
+
+            column3.renderer = function(root, column, model) {
+              root.textContent = model.item.name.first + '.' + model.item.name.last + '@example.com';
+            };
+
+            updateItemsFromPage(1);
+
+
+            function updateItemsFromPage(page) {
+              const dataProvider = document.querySelector('x-array-data-provider');
+              const items = dataProvider.items;
+
+              if (items === undefined || page === undefined) {
+                return;
               }
 
-              #pages > button {
-                user-select: none;
-                padding: 5px;
-                margin: 0 5px;
-                border-radius: 10%;
-                border: 0;
-                background: transparent;
-                font: inherit;
-                outline: none;
-                cursor: pointer;
-              }
-
-              #pages > button:hover,
-              #pages > button:focus {
-                color: #ccc;
-                background-color: #eee;
-              }
-
-              #pages > button[selected] {
-                font-weight: bold;
-                color: white;
-                background-color: #ccc;
-              }
-            </style>
-            <x-array-data-provider items="{{items}}"></x-array-data-provider>
-
-            <vaadin-grid id="grid" page-size="10" height-by-rows>
-
-              <vaadin-grid-column>
-                <template class="header">First Name</template>
-                <template>
-                  [[item.name.first]]
-                </template>
-              </vaadin-grid-column>
-
-              <vaadin-grid-column>
-                <template class="header">Last Name</template>
-                <template>
-                  [[item.name.last]]
-                </template>
-              </vaadin-grid-column>
-
-              <vaadin-grid-column width="200px">
-                <template class="header">Email</template>
-                <template>
-                  <div>[[item.name.first]].[[item.name.last]]@example.com</div>
-                </template>
-              </vaadin-grid-column>
-
-            </vaadin-grid>
-            <div id="pages">
-              <button on-click="_prev">&lt;</button>
-              <template is="dom-repeat" items="[[pages]]">
-                <button on-click="_select" selected$="[[_isSelected(page, item)]]">[[item]]</button>
-              </template>
-              <button on-click="_next">&gt;</button>
-            </div>
-          </template>
-          <script>
-            window.addDemoReadyListener('#grid-pagination-demos-pagination', function(document) {
-              Polymer({
-                is: 'x-pagination',
-
-                properties: {
-                  items: Array,
-                  page: Number,
-                  pages: Array
-                },
-
-                ready: function() {
-                  this.page = 0;
-                },
-
-                observers: ['_itemsChanged(items, page)'],
-
-                _isSelected: function(page, item) {
-                  return page === item - 1;
-                },
-
-                _select: function(e) {
-                  this.page = e.model.item - 1;
-                },
-
-                _next: function() {
-                  this.page = Math.min(this.pages.length - 1, this.page + 1);
-                },
-
-                _prev: function() {
-                  this.page = Math.max(0, this.page - 1);
-                },
-
-                _itemsChanged: function(items, page) {
-                  if (items === undefined || page === undefined) {
-                    return;
-                  }
-
-                  if (!this.pages) {
-                    this.pages = Array.apply(null, {length: Math.ceil(items.length / this.$.grid.pageSize)}).map(function(item, index) {
-                      return index + 1;
-                    });
-                  }
-
-                  var start = page * this.$.grid.pageSize;
-                  var end = (page + 1) * this.$.grid.pageSize;
-                  this.$.grid.items = items.slice(start, end);
+              document.querySelectorAll('#pages button').forEach(function(btn) {
+                if (parseInt(btn.textContent) === page) {
+                  btn.setAttribute('selected', true);
+                } else {
+                  btn.removeAttribute('selected');
                 }
               });
-            });
-          </script>
-        </dom-module>
+
+              if (!pages) {
+                pages = Array.apply(null, {length: Math.ceil(items.length / grid.pageSize)}).map(function(item, index) {
+                  return index + 1;
+                });
+
+                const pagesControl = document.querySelector('#pages');
+                pagesControl.innerHTML = '';
+
+                const prevBtn = window.document.createElement('button');
+                prevBtn.innerHTML = '&lt;';
+                prevBtn.addEventListener('click', function() {
+                  const selectedPage = parseInt(pagesControl.querySelector('[selected]').textContent);
+                  updateItemsFromPage(Math.max(0, selectedPage - 1));
+                });
+                pagesControl.appendChild(prevBtn);
+
+                pages.forEach(function(pageNumber) {
+                  const pageBtn = window.document.createElement('button');
+                  pageBtn.innerHTML = pageNumber;
+                  pageBtn.addEventListener('click', function(e) {
+                    updateItemsFromPage(parseInt(e.target.textContent));
+                  });
+                  if (pageNumber === page) {
+                    pageBtn.setAttribute('selected', true);
+                  }
+                  pagesControl.appendChild(pageBtn);
+                });
+
+                const nextBtn = window.document.createElement('button');
+                nextBtn.innerHTML = '&gt;';
+                nextBtn.addEventListener('click', function() {
+                  const selectedPage = parseInt(pagesControl.querySelector('[selected]').textContent);
+                  updateItemsFromPage(Math.min(pages.length - 1, selectedPage + 1));
+                });
+                pagesControl.appendChild(nextBtn);
+              }
+
+              var start = page * grid.pageSize;
+              var end = (page + 1) * grid.pageSize;
+              grid.items = items.slice(start, end);
+            }
+          });
+        </script>
       </template>
     </vaadin-demo-snippet>
 

--- a/demo/grid-row-details-demos.html
+++ b/demo/grid-row-details-demos.html
@@ -88,7 +88,6 @@
             padding: 10px 30px;
           }
         </style>
-
         <iron-ajax auto url="https://demo.vaadin.com/demo-data/1.0/people?count=200"></iron-ajax>
 
         <vaadin-grid aria-label="Toggling and Rendering Details Using JavaScrtipt Example" size="200">

--- a/demo/grid-selection-demos.html
+++ b/demo/grid-selection-demos.html
@@ -26,9 +26,9 @@
         <x-data-provider></x-data-provider>
 
         <vaadin-grid aria-label="Selection using Active Item Example" id="grid" size="200">
-          <vaadin-grid-column width="60px" flex-grow="0" id="column1"></vaadin-grid-column>
-          <vaadin-grid-column id="column2"></vaadin-grid-column>
-          <vaadin-grid-column id="column3"></vaadin-grid-column>
+          <vaadin-grid-column width="60px" flex-grow="0"></vaadin-grid-column>
+          <vaadin-grid-column></vaadin-grid-column>
+          <vaadin-grid-column></vaadin-grid-column>
         </vaadin-grid>
         <script>
           window.addDemoReadyListener('#grid-selection-demos-selection-using-active-item', function(document) {
@@ -42,31 +42,29 @@
             const dataProvider = document.querySelector('x-data-provider');
             grid.dataProvider = dataProvider.dataProvider;
 
-            const column1 = document.querySelector('#column1');
-            const column2 = document.querySelector('#column2');
-            const column3 = document.querySelector('#column3');
+            const columns = document.querySelectorAll('vaadin-grid-column');
 
-            column1.renderer = function(root, column, model) {
+            columns[0].renderer = function(root, column, model) {
               root.textContent = model.index;
             };
 
-            column2.renderer = function(root, column, model) {
+            columns[1].renderer = function(root, column, model) {
               root.textContent = model.item.name.first;
             };
 
-            column3.renderer = function(root, column, model) {
+            columns[2].renderer = function(root, column, model) {
               root.textContent = model.item.name.last;
             };
 
-            column1.headerRenderer = function(root) {
+            columns[0].headerRenderer = function(root) {
               root.textContent = '#';
             };
 
-            column2.headerRenderer = function(root) {
+            columns[1].headerRenderer = function(root) {
               root.textContent = 'First Name';
             };
 
-            column3.headerRenderer = function(root) {
+            columns[2].headerRenderer = function(root) {
               root.textContent = 'Last Name';
             };
           });
@@ -86,10 +84,10 @@
         <x-data-provider></x-data-provider>
 
         <vaadin-grid aria-label="Selection using Active Item Example" id="grid" size="200">
-          <vaadin-grid-column width="60px" flex-grow="0" id="column1"></vaadin-grid-column>
-          <vaadin-grid-column id="column2"></vaadin-grid-column>
-          <vaadin-grid-column id="column3"></vaadin-grid-column>
-          <vaadin-grid-column id="column4"></vaadin-grid-column>
+          <vaadin-grid-column width="60px" flex-grow="0"></vaadin-grid-column>
+          <vaadin-grid-column></vaadin-grid-column>
+          <vaadin-grid-column></vaadin-grid-column>
+          <vaadin-grid-column></vaadin-grid-column>
         </vaadin-grid>
         <script>
           window.addDemoReadyListener('#grid-selection-demos-selection-using-templates', function(document) {
@@ -98,24 +96,21 @@
             const dataProvider = document.querySelector('x-data-provider');
             grid.dataProvider = dataProvider.dataProvider;
 
-            const column1 = document.querySelector('#column1');
-            const column2 = document.querySelector('#column2');
-            const column3 = document.querySelector('#column3');
-            const column4 = document.querySelector('#column4');
+            const columns = document.querySelectorAll('vaadin-grid-column');
 
-            column1.renderer = function(root, column, model) {
+            columns[0].renderer = function(root, column, model) {
               root.textContent = model.index;
             };
 
-            column2.renderer = function(root, column, model) {
+            columns[1].renderer = function(root, column, model) {
               root.textContent = model.item.name.first;
             };
 
-            column3.renderer = function(root, column, model) {
+            columns[2].renderer = function(root, column, model) {
               root.textContent = model.item.name.last;
             };
 
-            column4.renderer = function(root, column, model) {
+            columns[3].renderer = function(root, column, model) {
               root.innerHTML = '';
 
               const checkBox = window.document.createElement('vaadin-checkbox');
@@ -129,15 +124,15 @@
               root.appendChild(checkBox);
             };
 
-            column1.headerRenderer = function(root) {
+            columns[0].headerRenderer = function(root) {
               root.textContent = '#';
             };
 
-            column2.headerRenderer = function(root) {
+            columns[1].headerRenderer = function(root) {
               root.textContent = 'First Name';
             };
 
-            column3.headerRenderer = function(root) {
+            columns[2].headerRenderer = function(root) {
               root.textContent = 'Last Name';
             };
           });
@@ -205,9 +200,9 @@
 
         <vaadin-grid aria-label="Multi-Selection Example" size="200">
           <vaadin-grid-selection-column auto-select></vaadin-grid-selection-column>
-          <vaadin-grid-column width="60px" flex-grow="0" id="column1"></vaadin-grid-column>
-          <vaadin-grid-column id="column2"></vaadin-grid-column>
-          <vaadin-grid-column id="column3"></vaadin-grid-column>
+          <vaadin-grid-column width="60px" flex-grow="0"></vaadin-grid-column>
+          <vaadin-grid-column></vaadin-grid-column>
+          <vaadin-grid-column></vaadin-grid-column>
         </vaadin-grid>
         <script>
           window.addDemoReadyListener('#grid-selection-demos-multi-selection-column', function(document) {
@@ -216,31 +211,29 @@
             const dataProvider = document.querySelector('x-array-data-provider');
             grid.items = dataProvider.items;
 
-            const column1 = document.querySelector('#column1');
-            const column2 = document.querySelector('#column2');
-            const column3 = document.querySelector('#column3');
+            const columns = document.querySelectorAll('vaadin-grid-column');
 
-            column1.renderer = function(root, column, model) {
+            columns[0].renderer = function(root, column, model) {
               root.textContent = model.index;
             };
 
-            column2.renderer = function(root, column, model) {
+            columns[1].renderer = function(root, column, model) {
               root.textContent = model.item.name.first;
             };
 
-            column3.renderer = function(root, column, model) {
+            columns[2].renderer = function(root, column, model) {
               root.textContent = model.item.name.last;
             };
 
-            column1.headerRenderer = function(root) {
+            columns[0].headerRenderer = function(root) {
               root.textContent = '#';
             };
 
-            column2.headerRenderer = function(root) {
+            columns[1].headerRenderer = function(root) {
               root.textContent = 'First Name';
             };
 
-            column3.headerRenderer = function(root) {
+            columns[2].headerRenderer = function(root) {
               root.textContent = 'Last Name';
             };
           });
@@ -365,10 +358,10 @@
         <x-data-provider></x-data-provider>
 
         <vaadin-grid aria-label="Space Key Action Example" size="200">
-          <vaadin-grid-column id="column1"></vaadin-grid-column>
-          <vaadin-grid-column id="column2"></vaadin-grid-column>
-          <vaadin-grid-column id="column3"></vaadin-grid-column>
-          <vaadin-grid-column id="column4"></vaadin-grid-column>
+          <vaadin-grid-column></vaadin-grid-column>
+          <vaadin-grid-column></vaadin-grid-column>
+          <vaadin-grid-column></vaadin-grid-column>
+          <vaadin-grid-column></vaadin-grid-column>
         </vaadin-grid>
         <script>
           window.addDemoReadyListener('#grid-selection-demos-space-key-action-and-click-to-activate', function(document) {
@@ -377,16 +370,13 @@
             const dataProvider = document.querySelector('x-data-provider');
             grid.dataProvider = dataProvider.dataProvider;
 
-            const column1 = document.querySelector('#column1');
-            const column2 = document.querySelector('#column2');
-            const column3 = document.querySelector('#column3');
-            const column4 = document.querySelector('#column4');
+            const columns = document.querySelectorAll('vaadin-grid-column');
 
-            column1.renderer = function(root, column, model) {
+            columns[0].renderer = function(root, column, model) {
               root.textContent = 'Space activates';
             };
 
-            column2.renderer = function(root, column, model) {
+            columns[1].renderer = function(root, column, model) {
               root.innerHTML = '';
               const alertBtn = window.document.createElement('button');
               alertBtn.textContent = 'Button';
@@ -399,7 +389,7 @@
               root.appendChild(textNode);
             };
 
-            column3.renderer = function(root, column, model) {
+            columns[2].renderer = function(root, column, model) {
               root.innerHTML = '';
               const alertBlock = window.document.createElement('div');
               alertBlock.textContent = 'Div';
@@ -412,7 +402,7 @@
               root.appendChild(textNode);
             };
 
-            column4.renderer = function(root, column, model) {
+            columns[3].renderer = function(root, column, model) {
               root.innerHTML = '';
               const alertBlock = window.document.createElement('div');
               alertBlock.textContent = 'Div with preventDefault';
@@ -427,19 +417,19 @@
 
             };
 
-            column1.headerRenderer = function(root) {
+            columns[0].headerRenderer = function(root) {
               root.textContent = 'Only text contents';
             };
 
-            column2.headerRenderer = function(root) {
+            columns[1].headerRenderer = function(root) {
               root.textContent = 'Button first child';
             };
 
-            column3.headerRenderer = function(root) {
+            columns[2].headerRenderer = function(root) {
               root.textContent = 'Div first child';
             };
 
-            column4.headerRenderer = function(root) {
+            columns[3].headerRenderer = function(root) {
               root.textContent = 'preventDefault for click';
             };
 

--- a/demo/grid-selection-demos.html
+++ b/demo/grid-selection-demos.html
@@ -23,48 +23,125 @@
     </p>
     <vaadin-demo-snippet id='grid-selection-demos-selection-using-active-item'>
       <template preserve-content>
-        <x-selection></x-selection>
-        <dom-module id="x-selection">
-          <template preserve-content>
-            <x-data-provider data-provider="{{dataProvider}}"></x-data-provider>
+        <x-data-provider></x-data-provider>
 
-            <vaadin-grid aria-label="Selection using Active Item Example" id="grid" data-provider="[[dataProvider]]" active-item="{{activeItem}}" size="200">
+        <vaadin-grid aria-label="Selection using Active Item Example" id="grid" size="200">
+          <vaadin-grid-column width="60px" flex-grow="0" id="column1"></vaadin-grid-column>
+          <vaadin-grid-column id="column2"></vaadin-grid-column>
+          <vaadin-grid-column id="column3"></vaadin-grid-column>
+        </vaadin-grid>
+        <script>
+          window.addDemoReadyListener('#grid-selection-demos-selection-using-active-item', function(document) {
+            const grid = document.querySelector('vaadin-grid');
 
-              <vaadin-grid-column width="60px" flex-grow="0">
-                <template class="header">#</template>
-                <template>[[index]]</template>
-              </vaadin-grid-column>
+            grid.addEventListener('active-item-changed', function(event) {
+              const item = event.detail.value;
+              grid.selectedItems = item ? [item] : [];
+            });
 
-              <vaadin-grid-column>
-                <template class="header">First Name</template>
-                <template>[[item.name.first]]</template>
-              </vaadin-grid-column>
+            const dataProvider = document.querySelector('x-data-provider');
+            grid.dataProvider = dataProvider.dataProvider;
 
-              <vaadin-grid-column>
-                <template class="header">Last Name</template>
-                <template>[[item.name.last]]</template>
-              </vaadin-grid-column>
+            const column1 = document.querySelector('#column1');
+            const column2 = document.querySelector('#column2');
+            const column3 = document.querySelector('#column3');
 
-            </vaadin-grid>
-          </template>
-          <script>
-            window.addDemoReadyListener('#grid-selection-demos-selection-using-active-item', function(document) {
-              Polymer({
-                is: 'x-selection',
+            column1.renderer = function(root, column, model) {
+              root.textContent = model.index;
+            };
 
-                properties: {
-                  activeItem: {
-                    observer: '_activeItemChanged'
-                  }
-                },
+            column2.renderer = function(root, column, model) {
+              root.textContent = model.item.name.first;
+            };
 
-                _activeItemChanged: function(item) {
-                  this.$.grid.selectedItems = item ? [item] : [];
+            column3.renderer = function(root, column, model) {
+              root.textContent = model.item.name.last;
+            };
+
+            column1.headerRenderer = function(root) {
+              root.textContent = '#';
+            };
+
+            column2.headerRenderer = function(root) {
+              root.textContent = 'First Name';
+            };
+
+            column3.headerRenderer = function(root) {
+              root.textContent = 'Last Name';
+            };
+          });
+        </script>
+      </template>
+    </vaadin-demo-snippet>
+
+
+    <h3>Selection using Templates</h3>
+    <p>
+      In addition to modifying selection using <code>selectedItems</code> property
+      or <code>selectItem(item)</code> and <code>deselectItem(item)</code> methods,
+      the template variable <code>{{selected}}</code> can also be used.
+    </p>
+    <vaadin-demo-snippet id='grid-selection-demos-selection-using-templates'>
+      <template preserve-content>
+        <x-data-provider></x-data-provider>
+
+        <vaadin-grid aria-label="Selection using Active Item Example" id="grid" size="200">
+          <vaadin-grid-column width="60px" flex-grow="0" id="column1"></vaadin-grid-column>
+          <vaadin-grid-column id="column2"></vaadin-grid-column>
+          <vaadin-grid-column id="column3"></vaadin-grid-column>
+          <vaadin-grid-column id="column4"></vaadin-grid-column>
+        </vaadin-grid>
+        <script>
+          window.addDemoReadyListener('#grid-selection-demos-selection-using-templates', function(document) {
+            const grid = document.querySelector('vaadin-grid');
+
+            const dataProvider = document.querySelector('x-data-provider');
+            grid.dataProvider = dataProvider.dataProvider;
+
+            const column1 = document.querySelector('#column1');
+            const column2 = document.querySelector('#column2');
+            const column3 = document.querySelector('#column3');
+            const column4 = document.querySelector('#column4');
+
+            column1.renderer = function(root, column, model) {
+              root.textContent = model.index;
+            };
+
+            column2.renderer = function(root, column, model) {
+              root.textContent = model.item.name.first;
+            };
+
+            column3.renderer = function(root, column, model) {
+              root.textContent = model.item.name.last;
+            };
+
+            column4.renderer = function(root, column, model) {
+              root.innerHTML = '';
+
+              const checkBox = window.document.createElement('vaadin-checkbox');
+              checkBox.addEventListener('checked-changed', function(event) {
+                if (event.detail.value) {
+                  grid.selectItem(model.item);
+                } else {
+                  grid.deselectItem(model.item);
                 }
               });
-            });
-          </script>
-        </dom-module>
+              root.appendChild(checkBox);
+            };
+
+            column1.headerRenderer = function(root) {
+              root.textContent = '#';
+            };
+
+            column2.headerRenderer = function(root) {
+              root.textContent = 'First Name';
+            };
+
+            column3.headerRenderer = function(root) {
+              root.textContent = 'Last Name';
+            };
+          });
+        </script>
       </template>
     </vaadin-demo-snippet>
 
@@ -82,7 +159,6 @@
             <x-data-provider data-provider="{{dataProvider}}"></x-data-provider>
 
             <vaadin-grid aria-label="Selection using Templates Example" data-provider="[[dataProvider]]" size="200">
-
               <vaadin-grid-column width="60px" flex-grow="0">
                 <template class="header">#</template>
                 <template>[[index]]</template>
@@ -103,7 +179,6 @@
                   <vaadin-checkbox aria-label="Select Row" checked="{{selected}}">Selected</vaadin-checkbox>
                 </template>
               </vaadin-grid-column>
-
             </vaadin-grid>
           </template>
         </dom-bind>
@@ -126,37 +201,52 @@
     </p>
     <vaadin-demo-snippet id='grid-selection-demos-multi-selection-column'>
       <template preserve-content>
-        <dom-bind>
-          <template>
+        <x-array-data-provider></x-array-data-provider>
 
-            <x-array-data-provider items="{{items}}"></x-array-data-provider>
+        <vaadin-grid aria-label="Multi-Selection Example" size="200">
+          <vaadin-grid-selection-column auto-select></vaadin-grid-selection-column>
+          <vaadin-grid-column width="60px" flex-grow="0" id="column1"></vaadin-grid-column>
+          <vaadin-grid-column id="column2"></vaadin-grid-column>
+          <vaadin-grid-column id="column3"></vaadin-grid-column>
+        </vaadin-grid>
+        <script>
+          window.addDemoReadyListener('#grid-selection-demos-multi-selection-column', function(document) {
+            const grid = document.querySelector('vaadin-grid');
 
-            <vaadin-grid aria-label="Multi-Selection Example" items="[[items]]">
-              <vaadin-grid-selection-column auto-select>
-              </vaadin-grid-selection-column>
+            const dataProvider = document.querySelector('x-array-data-provider');
+            grid.items = dataProvider.items;
 
-              <vaadin-grid-column width="60px" flex-grow="0">
-                <template class="header">#</template>
-                <template>[[index]]</template>
-              </vaadin-grid-column>
+            const column1 = document.querySelector('#column1');
+            const column2 = document.querySelector('#column2');
+            const column3 = document.querySelector('#column3');
 
-              <vaadin-grid-column>
-                <template class="header">First Name</template>
-                <template>[[item.name.first]]</template>
-              </vaadin-grid-column>
+            column1.renderer = function(root, column, model) {
+              root.textContent = model.index;
+            };
 
-              <vaadin-grid-column>
-                <template class="header">Last Name</template>
-                <template>[[item.name.last]]</template>
-              </vaadin-grid-column>
+            column2.renderer = function(root, column, model) {
+              root.textContent = model.item.name.first;
+            };
 
-            </vaadin-grid>
-          </template>
-        </dom-bind>
+            column3.renderer = function(root, column, model) {
+              root.textContent = model.item.name.last;
+            };
+
+            column1.headerRenderer = function(root) {
+              root.textContent = '#';
+            };
+
+            column2.headerRenderer = function(root) {
+              root.textContent = 'First Name';
+            };
+
+            column3.headerRenderer = function(root) {
+              root.textContent = 'Last Name';
+            };
+          });
+        </script>
       </template>
     </vaadin-demo-snippet>
-
-
 
 
     <h3>Custom Select All with Data Provider</h3>
@@ -176,7 +266,6 @@
             <x-data-provider data-provider="{{dataProvider}}"></x-data-provider>
 
             <vaadin-grid  aria-label="Select All with Data Example" id="grid" data-provider="[[dataProvider]]" inverted$="[[inverted]]" size="200">
-
               <vaadin-grid-column width="60px" flex-grow="0" >
                 <template class="header">
                   <input aria-label="Select All" type="checkbox" on-click="_invert" checked="[[_isChecked(inverted, indeterminate)]]" indeterminate="[[indeterminate]]"/>
@@ -195,7 +284,6 @@
                 <template class="header">Last Name</template>
                 <template>[[item.name.last]]</template>
               </vaadin-grid-column>
-
             </vaadin-grid>
           </template>
           <script>
@@ -274,73 +362,93 @@
     </p>
     <vaadin-demo-snippet id='grid-selection-demos-space-key-action-and-click-to-activate'>
       <template preserve-content>
-        <x-space-action></x-space-action>
-        <dom-module id="x-space-action">
-          <template preserve-content>
-            <x-data-provider data-provider="{{dataProvider}}"></x-data-provider>
+        <x-data-provider></x-data-provider>
 
-            <vaadin-grid aria-label="Space Key Action Example" id="grid" data-provider="[[dataProvider]]" active-item="{{activeItem}}" size="200">
+        <vaadin-grid aria-label="Space Key Action Example" size="200">
+          <vaadin-grid-column id="column1"></vaadin-grid-column>
+          <vaadin-grid-column id="column2"></vaadin-grid-column>
+          <vaadin-grid-column id="column3"></vaadin-grid-column>
+          <vaadin-grid-column id="column4"></vaadin-grid-column>
+        </vaadin-grid>
+        <script>
+          window.addDemoReadyListener('#grid-selection-demos-space-key-action-and-click-to-activate', function(document) {
+            const grid = document.querySelector('vaadin-grid');
 
-              <vaadin-grid-column>
-                <template class="header">Only text contents</template>
-                <template>
-                  Space activates
-                </template>
-              </vaadin-grid-column>
+            const dataProvider = document.querySelector('x-data-provider');
+            grid.dataProvider = dataProvider.dataProvider;
 
-              <vaadin-grid-column>
-                <template class="header">Button first child</template>
-                <template>
-                  <button on-click="_alert">Button</button>
-                  Space does not activate
-                </template>
-              </vaadin-grid-column>
+            const column1 = document.querySelector('#column1');
+            const column2 = document.querySelector('#column2');
+            const column3 = document.querySelector('#column3');
+            const column4 = document.querySelector('#column4');
 
-              <vaadin-grid-column>
-                <template class="header">Div first child</template>
-                <template>
-                  <div on-click="_alert">Div</div>
-                  Space activates
-                </template>
-              </vaadin-grid-column>
+            column1.renderer = function(root, column, model) {
+              root.textContent = 'Space activates';
+            };
 
-              <vaadin-grid-column>
-                <template class="header">preventDefault for click</template>
-                <template>
-                  <div on-click="_alertAndPreventDefault">Div with preventDefault</div>
-                  Space does not activate
-                </template>
-              </vaadin-grid-column>
-
-            </vaadin-grid>
-          </template>
-          <script>
-            window.addDemoReadyListener('#grid-selection-demos-space-key-action-and-click-to-activate', function(document) {
-              Polymer({
-                is: 'x-space-action',
-
-                properties: {
-                  activeItem: {
-                    observer: '_activeItemChanged'
-                  }
-                },
-
-                _alert: function(e) {
-                  alert(e.target.textContent + ' clicked');
-                },
-
-                _alertAndPreventDefault: function(e) {
-                  e.preventDefault();
-                  this._alert(e);
-                },
-
-                _activeItemChanged: function(item) {
-                  this.$.grid.selectedItems = item ? [item] : [];
-                }
+            column2.renderer = function(root, column, model) {
+              root.innerHTML = '';
+              const alertBtn = window.document.createElement('button');
+              alertBtn.textContent = 'Button';
+              alertBtn.addEventListener('click', function(event) {
+                alert(event.target.textContent + ' clicked');
               });
+              const textNode = window.document.createTextNode('Space does not activate');
+
+              root.appendChild(alertBtn);
+              root.appendChild(textNode);
+            };
+
+            column3.renderer = function(root, column, model) {
+              root.innerHTML = '';
+              const alertBlock = window.document.createElement('div');
+              alertBlock.textContent = 'Div';
+              alertBlock.addEventListener('click', function(event) {
+                alert(event.target.textContent + ' clicked');
+              });
+              const textNode = window.document.createTextNode('Space activates');
+
+              root.appendChild(alertBlock);
+              root.appendChild(textNode);
+            };
+
+            column4.renderer = function(root, column, model) {
+              root.innerHTML = '';
+              const alertBlock = window.document.createElement('div');
+              alertBlock.textContent = 'Div with preventDefault';
+              alertBlock.addEventListener('click', function(event) {
+                event.preventDefault();
+                alert(event.target.textContent + ' clicked');
+              });
+              const textNode = window.document.createTextNode('Space does not activate');
+
+              root.appendChild(alertBlock);
+              root.appendChild(textNode);
+
+            };
+
+            column1.headerRenderer = function(root) {
+              root.textContent = 'Only text contents';
+            };
+
+            column2.headerRenderer = function(root) {
+              root.textContent = 'Button first child';
+            };
+
+            column3.headerRenderer = function(root) {
+              root.textContent = 'Div first child';
+            };
+
+            column4.headerRenderer = function(root) {
+              root.textContent = 'preventDefault for click';
+            };
+
+            grid.addEventListener('active-item-changed', function(event) {
+              const item = event.detail.value;
+              grid.selectedItems = item ? [item] : [];
             });
-          </script>
-        </dom-module>
+          });
+        </script>
       </template>
     </vaadin-demo-snippet>
 

--- a/demo/grid-sorting-filtering-demos.html
+++ b/demo/grid-sorting-filtering-demos.html
@@ -182,27 +182,30 @@
       <template preserve-content>
         <x-array-data-provider></x-array-data-provider>
         <vaadin-grid aria-label="Filtering Example">
-          <vaadin-grid-column width="60px" flex-grow="0" id="column1"></vaadin-grid-column>
-          <vaadin-grid-column id="column2"></vaadin-grid-column>
-          <vaadin-grid-column id="column3"></vaadin-grid-column>
+          <vaadin-grid-column width="60px" flex-grow="0"></vaadin-grid-column>
+          <vaadin-grid-column name="First"></vaadin-grid-column>
+          <vaadin-grid-column name="Last"></vaadin-grid-column>
         </vaadin-grid>
         <script>
           window.addDemoReadyListener('#grid-sorting-filtering-demos-filtering', function(document) {
             const grid = document.querySelector('vaadin-grid');
-            const column1 = document.querySelector('#column1');
+            const columns = grid.querySelectorAll('vaadin-grid-column');
 
-            column1.renderer = function(root, column, model) {
+            columns[0].renderer = function(root, column, model) {
               root.textContent = model.index;
             };
 
-            column1.headerRenderer = function(root) {
+            columns[0].headerRenderer = function(root) {
               root.textContent = '#';
             };
 
-            ['First', 'Last'].forEach(function(propName, index) {
+            columns.forEach(function(column, index) {
               // Start from second column
-              const columnID = index + 2;
-              const column = document.querySelector('#column' + columnID);
+              if (index === 0) {
+                return;
+              }
+
+              const propName = column.getAttribute('name');
 
               column.renderer = function(root, column, model) {
                 root.textContent = model.item.name[propName.toLowerCase()];
@@ -252,14 +255,14 @@
     <vaadin-demo-snippet id='grid-sorting-filtering-demos-filtering-with-data-provider'>
       <template preserve-content>
         <vaadin-grid aria-label="Filtering with Data Provider Example">
-          <vaadin-grid-column width="60px" flex-grow="0" id="column1"></vaadin-grid-column>
-          <vaadin-grid-column id="column2"></vaadin-grid-column>
-          <vaadin-grid-column id="column3"></vaadin-grid-column>
+          <vaadin-grid-column width="60px" flex-grow="0"></vaadin-grid-column>
+          <vaadin-grid-column name="First"></vaadin-grid-column>
+          <vaadin-grid-column name="Last"></vaadin-grid-column>
         </vaadin-grid>
         <script>
           window.addDemoReadyListener('#grid-sorting-filtering-demos-filtering-with-data-provider', function(document) {
             const grid = document.querySelector('vaadin-grid');
-            const column1 = document.querySelector('#column1');
+            const columns = grid.querySelectorAll('vaadin-grid-column');
 
             grid.size = 200;
 
@@ -287,18 +290,21 @@
               xhr.send();
             };
 
-            column1.renderer = function(root, column, model) {
+            columns[0].renderer = function(root, column, model) {
               root.textContent = model.index;
             };
 
-            column1.headerRenderer = function(root) {
+            columns[0].headerRenderer = function(root) {
               root.textContent = '#';
             };
 
-            ['First', 'Last'].forEach(function(propName, index) {
+            columns.forEach(function(column, index) {
               // Start from second column
-              const columnID = index + 2;
-              const column = document.querySelector('#column' + columnID);
+              if (index === 0) {
+                return;
+              }
+
+              const propName = column.getAttribute('name');
 
               column.renderer = function(root, column, model) {
                 root.textContent = model.item[propName.toLowerCase() + 'Name'];

--- a/demo/grid-sorting-filtering-demos.html
+++ b/demo/grid-sorting-filtering-demos.html
@@ -24,37 +24,61 @@
 
     <vaadin-demo-snippet id='grid-sorting-filtering-demos-sorting'>
       <template preserve-content>
-        <dom-bind>
-          <template>
+        <x-array-data-provider></x-array-data-provider>
+        <vaadin-checkbox>Enable Multi-Sorting</vaadin-checkbox>
+        <vaadin-grid aria-label="Sorting Example">
+          <vaadin-grid-column width="60px" flex-grow="0" id="column1"></vaadin-grid-column>
+          <vaadin-grid-column id="column2"></vaadin-grid-column>
+          <vaadin-grid-column id="column3"></vaadin-grid-column>
+        </vaadin-grid>
+        <script>
+          window.addDemoReadyListener('#grid-sorting-filtering-demos-sorting', function(document) {
+            const grid = document.querySelector('vaadin-grid');
+            const checkBox = document.querySelector('vaadin-checkbox');
 
-            <x-array-data-provider items="{{items}}"></x-array-data-provider>
+            checkBox.addEventListener('checked-changed', function(event) {
+              grid.multiSort = event.detail.value;
+            });
 
-            <vaadin-checkbox checked="{{multiSort}}">Enable Multi-Sorting</vaadin-checkbox>
+            const dataProvider = document.querySelector('x-array-data-provider');
+            grid.items = dataProvider.items;
 
-            <vaadin-grid aria-label="Sorting Example" items="[[items]]" multi-sort="[[multiSort]]">
+            const column1 = document.querySelector('#column1');
+            const column2 = document.querySelector('#column2');
+            const column3 = document.querySelector('#column3');
 
-              <vaadin-grid-column width="60px" flex-grow="0">
-                <template class="header">#</template>
-                <template>[[index]]</template>
-              </vaadin-grid-column>
+            column1.renderer = function(root, column, model) {
+              root.textContent = model.index;
+            };
 
-              <vaadin-grid-column>
-                <template class="header">
-                  <vaadin-grid-sorter path="name.first">First Name</vaadin-grid-sorter>
-                </template>
-                <template>[[item.name.first]]</template>
-              </vaadin-grid-column>
+            column2.renderer = function(root, column, model) {
+              root.textContent = model.item.name.first;
+            };
 
-              <vaadin-grid-column>
-                <template class="header">
-                  <vaadin-grid-sorter path="name.last" direction="asc">Last Name</vaadin-grid-sorter>
-                </template>
-                <template>[[item.name.last]]</template>
-              </vaadin-grid-column>
+            column3.renderer = function(root, column, model) {
+              root.textContent = model.item.name.last;
+            };
 
-            </vaadin-grid>
-          </template>
-        </dom-bind>
+            column1.headerRenderer = function(root) {
+              root.textContent = '#';
+            };
+
+            column2.headerRenderer = function(root) {
+              const sorter = window.document.createElement('vaadin-grid-sorter');
+              sorter.setAttribute('path', 'name.first');
+              sorter.textContent = 'First Name';
+              root.appendChild(sorter);
+            };
+
+            column3.headerRenderer = function(root) {
+              const sorter = window.document.createElement('vaadin-grid-sorter');
+              sorter.setAttribute('path', 'name.last');
+              sorter.setAttribute('direction', 'asc');
+              sorter.textContent = 'Last Name';
+              root.appendChild(sorter);
+            };
+          });
+        </script>
       </template>
     </vaadin-demo-snippet>
 
@@ -78,66 +102,74 @@
 
     <vaadin-demo-snippet id='grid-sorting-filtering-demos-sorting-with-data-provider'>
       <template preserve-content>
-        <x-remote-sorting-example></x-remote-sorting-example>
-        <dom-module id="x-remote-sorting-example">
-          <template preserve-content>
-            <vaadin-checkbox checked="{{multiSort}}">Enable Multi-Sorting</vaadin-checkbox>
+        <vaadin-checkbox>Enable Multi-Sorting</vaadin-checkbox>
+        <vaadin-grid aria-label="Sorting Example">
+          <vaadin-grid-column width="60px" flex-grow="0" id="column1"></vaadin-grid-column>
+          <vaadin-grid-column id="column2"></vaadin-grid-column>
+          <vaadin-grid-column id="column3"></vaadin-grid-column>
+        </vaadin-grid>
+        <script>
+          window.addDemoReadyListener('#grid-sorting-filtering-demos-sorting-with-data-provider', function(document) {
+            const grid = document.querySelector('vaadin-grid');
+            const checkBox = document.querySelector('vaadin-checkbox');
 
-            <vaadin-grid aria-label="Sorting with Data Provider Example" id="grid" multi-sort="[[multiSort]]">
-
-              <vaadin-grid-column width="60px" flex-grow="0">
-                <template class="header">#</template>
-                <template>[[index]]</template>
-              </vaadin-grid-column>
-
-              <vaadin-grid-column>
-                <template class="header">
-                  <vaadin-grid-sorter path="firstName">First Name</vaadin-grid-sorter>
-                </template>
-                <template>[[item.firstName]]</template>
-              </vaadin-grid-column>
-
-              <vaadin-grid-column>
-                <template class="header">
-                  <vaadin-grid-sorter path="lastName">Last Name</vaadin-grid-sorter>
-                </template>
-                <template>[[item.lastName]]</template>
-              </vaadin-grid-column>
-
-            </vaadin-grid>
-          </template>
-          <script>
-            window.addDemoReadyListener('#grid-sorting-filtering-demos-sorting-with-data-provider', function(document) {
-              Polymer({
-                is: 'x-remote-sorting-example',
-
-                ready: function() {
-                  var grid = this.$.grid;
-
-                  grid.size = 200;
-
-                  grid.dataProvider = function(params, callback) {
-                    var xhr = new XMLHttpRequest();
-                    xhr.onload = function() {
-                      callback(JSON.parse(xhr.responseText).result);
-                    };
-
-                    var index = params.page * params.pageSize;
-                    var url = 'https://demo.vaadin.com/demo-data/1.0/people?index=' + index + '&count=' + params.pageSize;
-
-                    // `params.sortOrders` format: [{path: 'lastName', direction: 'asc'}, ...];
-                    params.sortOrders.forEach(function(sort) {
-                      url += '&orders[]=' + sort.path + ' ' + sort.direction;
-                    });
-
-                    xhr.open('GET', url, true);
-                    xhr.send();
-                  };
-                }
-              });
+            checkBox.addEventListener('checked-changed', function(event) {
+              grid.multiSort = event.detail.value;
             });
-          </script>
-        </dom-module>
+            grid.size = 200;
+            grid.dataProvider = function(params, callback) {
+              var xhr = new XMLHttpRequest();
+              xhr.onload = function() {
+                callback(JSON.parse(xhr.responseText).result);
+              };
+
+              var index = params.page * params.pageSize;
+              var url = 'https://demo.vaadin.com/demo-data/1.0/people?index=' + index + '&count=' + params.pageSize;
+
+              // `params.sortOrders` format: [{path: 'lastName', direction: 'asc'}, ...];
+              params.sortOrders.forEach(function(sort) {
+                url += '&orders[]=' + sort.path + ' ' + sort.direction;
+              });
+
+              xhr.open('GET', url, true);
+              xhr.send();
+            };
+
+            const column1 = document.querySelector('#column1');
+            const column2 = document.querySelector('#column2');
+            const column3 = document.querySelector('#column3');
+
+            column1.renderer = function(root, column, model) {
+              root.textContent = model.index;
+            };
+
+            column2.renderer = function(root, column, model) {
+              root.textContent = model.item.firstName;
+            };
+
+            column3.renderer = function(root, column, model) {
+              root.textContent = model.item.lastName;
+            };
+
+            column1.headerRenderer = function(root) {
+              root.textContent = '#';
+            };
+
+            column2.headerRenderer = function(root) {
+              const sorter = window.document.createElement('vaadin-grid-sorter');
+              sorter.setAttribute('path', 'firstName');
+              sorter.textContent = 'First Name';
+              root.appendChild(sorter);
+            };
+
+            column3.headerRenderer = function(root) {
+              const sorter = window.document.createElement('vaadin-grid-sorter');
+              sorter.setAttribute('path', 'lastName');
+              sorter.textContent = 'Last Name';
+              root.appendChild(sorter);
+            };
+          });
+        </script>
       </template>
     </vaadin-demo-snippet>
 
@@ -152,39 +184,56 @@
 
     <vaadin-demo-snippet id='grid-sorting-filtering-demos-filtering'>
       <template preserve-content>
-        <dom-bind>
-          <template>
+        <x-array-data-provider></x-array-data-provider>
+        <vaadin-grid aria-label="Filtering Example">
+          <vaadin-grid-column width="60px" flex-grow="0" id="column1"></vaadin-grid-column>
+          <vaadin-grid-column id="column2"></vaadin-grid-column>
+          <vaadin-grid-column id="column3"></vaadin-grid-column>
+        </vaadin-grid>
+        <script>
+          window.addDemoReadyListener('#grid-sorting-filtering-demos-filtering', function(document) {
+            const grid = document.querySelector('vaadin-grid');
+            const column1 = document.querySelector('#column1');
 
-            <x-array-data-provider items="{{items}}"></x-array-data-provider>
+            column1.renderer = function(root, column, model) {
+              root.textContent = model.index;
+            };
 
-            <vaadin-grid aria-label="Filtering Example" items="[[items]]">
+            column1.headerRenderer = function(root) {
+              root.textContent = '#';
+            };
 
-              <vaadin-grid-column width="60px" flex-grow="0">
-                <template class="header">#</template>
-                <template>[[index]]</template>
-              </vaadin-grid-column>
+            ['First', 'Last'].forEach(function(propName, index) {
+              // Start from second column
+              const columnID = index + 2;
+              const column = document.querySelector('#column' + columnID);
 
-              <vaadin-grid-column>
-                <template class="header">
-                  <vaadin-grid-filter aria-label="First Name" path="name.first" value="[[_filterFirstName]]">
-                    <vaadin-text-field slot="filter" placeholder="First Name" value="{{_filterFirstName}}" focus-target></vaadin-text-field>
-                  </vaadin-grid-filter>
-                </template>
-                <template>[[item.name.first]]</template>
-              </vaadin-grid-column>
+              column.renderer = function(root, column, model) {
+                root.textContent = model.item.name[propName.toLowerCase()];
+              };
 
-              <vaadin-grid-column>
-                <template class="header">
-                  <vaadin-grid-filter aria-label="Last Name" path="name.last" value="[[_filterLastName]]">
-                    <vaadin-text-field slot="filter" placeholder="Last Name" value="{{_filterLastName}}" focus-target></vaadin-text-field>
-                  </vaadin-grid-filter>
-                </template>
-                <template>[[item.name.last]]</template>
-              </vaadin-grid-column>
+              column.headerRenderer = function(root) {
+                const filter = window.document.createElement('vaadin-grid-filter');
+                filter.setAttribute('path', 'name.' + propName.toLowerCase());
 
-            </vaadin-grid>
-          </template>
-        </dom-bind>
+                const textField = window.document.createElement('vaadin-text-field');
+                textField.setAttribute('slot', 'filter');
+                textField.setAttribute('focus-target', true);
+                textField.setAttribute('placeholder', propName + ' Name');
+
+                textField.addEventListener('value-changed', function(event) {
+                  filter.value = event.detail.value;
+                });
+
+                filter.appendChild(textField);
+                root.appendChild(filter);
+              };
+            });
+
+            const dataProvider = document.querySelector('x-array-data-provider');
+            grid.items = dataProvider.items;
+          });
+        </script>
       </template>
     </vaadin-demo-snippet>
 
@@ -206,74 +255,78 @@
 
     <vaadin-demo-snippet id='grid-sorting-filtering-demos-filtering-with-data-provider'>
       <template preserve-content>
-        <x-remote-filtering-example></x-remote-filtering-example>
-        <dom-module id="x-remote-filtering-example">
-          <template preserve-content>
-            <vaadin-grid aria-label="Filtering with Data Provider Example" id="grid">
+        <vaadin-grid aria-label="Filtering with Data Provider Example">
+          <vaadin-grid-column width="60px" flex-grow="0" id="column1"></vaadin-grid-column>
+          <vaadin-grid-column id="column2"></vaadin-grid-column>
+          <vaadin-grid-column id="column3"></vaadin-grid-column>
+        </vaadin-grid>
+        <script>
+          window.addDemoReadyListener('#grid-sorting-filtering-demos-filtering-with-data-provider', function(document) {
+            const grid = document.querySelector('vaadin-grid');
+            const column1 = document.querySelector('#column1');
 
-              <vaadin-grid-column width="60px" flex-grow="0">
-                <template class="header">#</template>
-                <template>[[index]]</template>
-              </vaadin-grid-column>
+            grid.size = 200;
 
-              <vaadin-grid-column>
-                <template class="header">
-                  <vaadin-grid-filter aria-label="Fist Name" path="firstName" value="[[_filterFirstName]]">
-                    <vaadin-text-field slot="filter" placeholder="First Name" value="{{_filterFirstName}}" focus-target></vaadin-text-field>
-                  </vaadin-grid-filter>
-                </template>
-                <template>[[item.firstName]]</template>
-              </vaadin-grid-column>
+            grid.dataProvider = function(params, callback) {
+              var xhr = new XMLHttpRequest();
+              xhr.onload = function() {
+                var response = JSON.parse(xhr.responseText);
 
-              <vaadin-grid-column>
-                <template class="header">
-                  <vaadin-grid-filter aria-label="Last Name" path="lastName" value="[[_filterLastName]]">
-                    <vaadin-text-field slot="filter" placeholder="Last Name" value="{{_filterLastName}}" focus-target></vaadin-text-field>
-                  </vaadin-grid-filter>
-                </template>
-                <template>[[item.lastName]]</template>
-              </vaadin-grid-column>
+                // Number of items changes after filtering. We need
+                // to update the grid size based on server response.
+                grid.size = response.size;
 
-            </vaadin-grid>
-          </template>
-          <script>
-            window.addDemoReadyListener('#grid-sorting-filtering-demos-filtering-with-data-provider', function(document) {
-              Polymer({
-                is: 'x-remote-filtering-example',
+                callback(response.result);
+              };
 
-                ready: function() {
-                  var grid = this.$.grid;
+              var index = params.page * params.pageSize;
+              var url = 'https://demo.vaadin.com/demo-data/1.0/people?index=' + index + '&count=' + params.pageSize;
 
-                  grid.size = 200;
-
-                  grid.dataProvider = function(params, callback) {
-                    var xhr = new XMLHttpRequest();
-                    xhr.onload = function() {
-                      var response = JSON.parse(xhr.responseText);
-
-                      // Number of items changes after filtering. We need
-                      // to update the grid size based on server response.
-                      grid.size = response.size;
-
-                      callback(response.result);
-                    };
-
-                    var index = params.page * params.pageSize;
-                    var url = 'https://demo.vaadin.com/demo-data/1.0/people?index=' + index + '&count=' + params.pageSize;
-
-                    // `params.filters` format: [{path: 'lastName', direction: 'asc'}, ...];
-                    params.filters.forEach(function(filter) {
-                      url += '&filters[' + filter.path + ']=' + encodeURIComponent(filter.value);
-                    });
-
-                    xhr.open('GET', url, true);
-                    xhr.send();
-                  };
-                }
+              // `params.filters` format: [{path: 'lastName', direction: 'asc'}, ...];
+              params.filters.forEach(function(filter) {
+                url += '&filters[' + filter.path + ']=' + encodeURIComponent(filter.value);
               });
+
+              xhr.open('GET', url, true);
+              xhr.send();
+            };
+
+            column1.renderer = function(root, column, model) {
+              root.textContent = model.index;
+            };
+
+            column1.headerRenderer = function(root) {
+              root.textContent = '#';
+            };
+
+            ['First', 'Last'].forEach(function(propName, index) {
+              // Start from second column
+              const columnID = index + 2;
+              const column = document.querySelector('#column' + columnID);
+
+              column.renderer = function(root, column, model) {
+                root.textContent = model.item[propName.toLowerCase() + 'Name'];
+              };
+
+              column.headerRenderer = function(root) {
+                const filter = window.document.createElement('vaadin-grid-filter');
+                filter.setAttribute('path', propName.toLowerCase() + 'Name');
+
+                const textField = window.document.createElement('vaadin-text-field');
+                textField.setAttribute('slot', 'filter');
+                textField.setAttribute('focus-target', true);
+                textField.setAttribute('placeholder', propName + ' Name');
+
+                textField.addEventListener('value-changed', function(event) {
+                  filter.value = event.detail.value;
+                });
+
+                filter.appendChild(textField);
+                root.appendChild(filter);
+              };
             });
-          </script>
-        </dom-module>
+          });
+        </script>
       </template>
     </vaadin-demo-snippet>
 

--- a/demo/grid-sorting-filtering-demos.html
+++ b/demo/grid-sorting-filtering-demos.html
@@ -27,9 +27,9 @@
         <x-array-data-provider></x-array-data-provider>
         <vaadin-checkbox>Enable Multi-Sorting</vaadin-checkbox>
         <vaadin-grid aria-label="Sorting Example">
-          <vaadin-grid-column width="60px" flex-grow="0" id="column1"></vaadin-grid-column>
-          <vaadin-grid-column id="column2"></vaadin-grid-column>
-          <vaadin-grid-column id="column3"></vaadin-grid-column>
+          <vaadin-grid-column width="60px" flex-grow="0"></vaadin-grid-column>
+          <vaadin-grid-column></vaadin-grid-column>
+          <vaadin-grid-column></vaadin-grid-column>
         </vaadin-grid>
         <script>
           window.addDemoReadyListener('#grid-sorting-filtering-demos-sorting', function(document) {
@@ -43,34 +43,32 @@
             const dataProvider = document.querySelector('x-array-data-provider');
             grid.items = dataProvider.items;
 
-            const column1 = document.querySelector('#column1');
-            const column2 = document.querySelector('#column2');
-            const column3 = document.querySelector('#column3');
+            const columns = document.querySelectorAll('vaadin-grid-column');
 
-            column1.renderer = function(root, column, model) {
+            columns[0].renderer = function(root, column, model) {
               root.textContent = model.index;
             };
 
-            column2.renderer = function(root, column, model) {
+            columns[1].renderer = function(root, column, model) {
               root.textContent = model.item.name.first;
             };
 
-            column3.renderer = function(root, column, model) {
+            columns[2].renderer = function(root, column, model) {
               root.textContent = model.item.name.last;
             };
 
-            column1.headerRenderer = function(root) {
+            columns[0].headerRenderer = function(root) {
               root.textContent = '#';
             };
 
-            column2.headerRenderer = function(root) {
+            columns[1].headerRenderer = function(root) {
               const sorter = window.document.createElement('vaadin-grid-sorter');
               sorter.setAttribute('path', 'name.first');
               sorter.textContent = 'First Name';
               root.appendChild(sorter);
             };
 
-            column3.headerRenderer = function(root) {
+            columns[2].headerRenderer = function(root) {
               const sorter = window.document.createElement('vaadin-grid-sorter');
               sorter.setAttribute('path', 'name.last');
               sorter.setAttribute('direction', 'asc');
@@ -104,9 +102,9 @@
       <template preserve-content>
         <vaadin-checkbox>Enable Multi-Sorting</vaadin-checkbox>
         <vaadin-grid aria-label="Sorting Example">
-          <vaadin-grid-column width="60px" flex-grow="0" id="column1"></vaadin-grid-column>
-          <vaadin-grid-column id="column2"></vaadin-grid-column>
-          <vaadin-grid-column id="column3"></vaadin-grid-column>
+          <vaadin-grid-column width="60px" flex-grow="0"></vaadin-grid-column>
+          <vaadin-grid-column></vaadin-grid-column>
+          <vaadin-grid-column></vaadin-grid-column>
         </vaadin-grid>
         <script>
           window.addDemoReadyListener('#grid-sorting-filtering-demos-sorting-with-data-provider', function(document) {
@@ -135,34 +133,32 @@
               xhr.send();
             };
 
-            const column1 = document.querySelector('#column1');
-            const column2 = document.querySelector('#column2');
-            const column3 = document.querySelector('#column3');
+            const columns = document.querySelectorAll('vaadin-grid-column');
 
-            column1.renderer = function(root, column, model) {
+            columns[0].renderer = function(root, column, model) {
               root.textContent = model.index;
             };
 
-            column2.renderer = function(root, column, model) {
+            columns[1].renderer = function(root, column, model) {
               root.textContent = model.item.firstName;
             };
 
-            column3.renderer = function(root, column, model) {
+            columns[2].renderer = function(root, column, model) {
               root.textContent = model.item.lastName;
             };
 
-            column1.headerRenderer = function(root) {
+            columns[0].headerRenderer = function(root) {
               root.textContent = '#';
             };
 
-            column2.headerRenderer = function(root) {
+            columns[1].headerRenderer = function(root) {
               const sorter = window.document.createElement('vaadin-grid-sorter');
               sorter.setAttribute('path', 'firstName');
               sorter.textContent = 'First Name';
               root.appendChild(sorter);
             };
 
-            column3.headerRenderer = function(root) {
+            columns[2].headerRenderer = function(root) {
               const sorter = window.document.createElement('vaadin-grid-sorter');
               sorter.setAttribute('path', 'lastName');
               sorter.textContent = 'Last Name';

--- a/src/vaadin-grid-filter.html
+++ b/src/vaadin-grid-filter.html
@@ -70,6 +70,7 @@ This program is available under Apache License Version 2.0, available at https:/
 
         /** @protected */
         connectedCallback() {
+          super.connectedCallback();
           this._connected = true;
         }
 


### PR DESCRIPTION
Fixes #1331 

Some of the demos cannot be easily converted and requires `renderers` improvements:
- Exposing `selected` property to `model` (row related)
- Possibility to call `renderer` externally with additional argument/method
- Exposing `level` and `expanded` for `tree-demos` as currently it's working with cell instance

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-grid/1337)
<!-- Reviewable:end -->