### PR TITLE
Update webcomponentsjs to 1.2.5 with shadydom fix

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -43,7 +43,7 @@
     "wct.conf.js"
   ],
   "devDependencies": {
-    "webcomponentsjs": "1.2.0",
+    "webcomponentsjs": "^1.2.5",
     "web-component-tester": "^6.1.5",
     "iron-test-helpers": "^v2.0.0",
     "paper-input": "^v2.0.0",

--- a/magi-p3-post.json
+++ b/magi-p3-post.json
@@ -1,9 +1,0 @@
-{
-  "files": ["package.json"],
-  "from": [
-    "\"resolutions\": {"
-  ],
-  "to": [
-    "\"resolutions\": {\n\"@webcomponents/webcomponentsjs\": \"2.0.0\","
-  ]
-}


### PR DESCRIPTION
Fixes #1336 

Note: this should also pick up `2.1.0` version for npm having the same `shadydom` fix, so we no longer need the resolutions section for yarn.