### PR TITLE
Add `first-column` attribute on the first visible column

### DIFF
--- a/src/vaadin-grid-column-reordering-mixin.html
+++ b/src/vaadin-grid-column-reordering-mixin.html
@@ -298,7 +298,7 @@ This program is available under Apache License Version 2.0, available at https:/
       column1._order = column2._order;
       column2._order = _order;
       this._updateLastFrozen();
-      this._updateLastColumn();
+      this._updateFirstAndLastColumn();
     }
 
     _getTargetColumn(targetCell, draggedColumn) {

--- a/src/vaadin-grid-dynamic-columns-mixin.html
+++ b/src/vaadin-grid-dynamic-columns-mixin.html
@@ -123,15 +123,16 @@ This program is available under Apache License Version 2.0, available at https:/
       });
     }
 
-    _updateLastColumn() {
-      Array.from(this.shadowRoot.querySelectorAll('tr')).forEach(row => this._updateLastColumnForRow(row));
+    _updateFirstAndLastColumn() {
+      Array.from(this.shadowRoot.querySelectorAll('tr')).forEach(row => this._updateFirstAndLastColumnForRow(row));
     }
 
-    _updateLastColumnForRow(row) {
+    _updateFirstAndLastColumnForRow(row) {
       Array.from(row.querySelectorAll('[part~="cell"]:not([part~="details-cell"])'))
         .sort((a, b) => {
           return a._column._order - b._column._order;
         }).forEach((cell, cellIndex, children) => {
+          this._toggleAttribute('first-column', cellIndex === 0, cell);
           this._toggleAttribute('last-column', cellIndex === children.length - 1, cell);
         });
     }

--- a/src/vaadin-grid.html
+++ b/src/vaadin-grid.html
@@ -273,6 +273,7 @@ This program is available under Apache License Version 2.0, available at https:/
      * `reorder-status` | Reflects the status of a cell while columns are being reordered | cell
      * `frozen` | Frozen cell | cell
      * `last-frozen` | Last frozen cell | cell
+   * * `first-column` | First visible cell on a row | cell
      * `last-column` | Last visible cell on a row | cell
      * `selected` | Selected row | row
      * `expanded` | Expanded row | row
@@ -409,7 +410,7 @@ This program is available under Apache License Version 2.0, available at https:/
         }
 
         Polymer.RenderStatus.beforeNextRender(this, () => {
-          this._updateLastColumn();
+          this._updateFirstAndLastColumn();
           this._resetKeyboardNavigation();
         });
         return rows;
@@ -541,7 +542,7 @@ This program is available under Apache License Version 2.0, available at https:/
         this.appendChild(contentsFragment);
 
         this._frozenCellsChanged();
-        this._updateLastColumnForRow(row);
+        this._updateFirstAndLastColumnForRow(row);
       }
 
       _updateScrollerItem(row, index) {
@@ -588,7 +589,7 @@ This program is available under Apache License Version 2.0, available at https:/
 
         this._resizeHandler();
         this._frozenCellsChanged();
-        this._updateLastColumn();
+        this._updateFirstAndLastColumn();
         this._resetKeyboardNavigation();
         this._a11yUpdateHeaderRows();
         this._a11yUpdateFooterRows();

--- a/test/column-reordering.html
+++ b/test/column-reordering.html
@@ -406,7 +406,7 @@
         it('should update last-column attribute (details open)', () => {
           grid.openItemDetails(getRows(grid.$.items)[0].item);
           dragOver(headerContent[2], headerContent[3]);
-          const  cell = getCellByCellContent(headerContent[2]);
+          const cell = getCellByCellContent(headerContent[2]);
           expect(cell.hasAttribute('last-column')).to.be.true;
         });
 

--- a/test/column-reordering.html
+++ b/test/column-reordering.html
@@ -370,6 +370,26 @@
           expectVisualOrder(grid, [2, 4, 3, 1]);
         });
 
+        it('should update first-column attribute', () => {
+          let cell = getCellByCellContent(headerContent[0]);
+          expect(cell.hasAttribute('first-column')).to.be.true;
+          cell = getContainerCell(grid.$.items, 0, 0);
+          expect(cell.hasAttribute('first-column')).to.be.true;
+        });
+
+        it('should update first-column attribute', () => {
+          dragOver(headerContent[2], headerContent[0]);
+          const cell = getCellByCellContent(headerContent[2]);
+          expect(cell.hasAttribute('first-column')).to.be.true;
+        });
+
+        it('should update first-column attribute (details open)', () => {
+          grid.openItemDetails(getRows(grid.$.items)[0].item);
+          dragOver(headerContent[2], headerContent[0]);
+          const cell = getCellByCellContent(headerContent[2]);
+          expect(cell.hasAttribute('first-column')).to.be.true;
+        });
+
         it('should update last-column attribute', () => {
           let cell = getCellByCellContent(headerContent[3]);
           expect(cell.hasAttribute('last-column')).to.be.true;
@@ -386,8 +406,7 @@
         it('should update last-column attribute (details open)', () => {
           grid.openItemDetails(getRows(grid.$.items)[0].item);
           dragOver(headerContent[2], headerContent[3]);
-          let cell = getCellByCellContent(headerContent[2]);
-          cell = getCellByCellContent(headerContent[2]);
+          const  cell = getCellByCellContent(headerContent[2]);
           expect(cell.hasAttribute('last-column')).to.be.true;
         });
 


### PR DESCRIPTION
Enables theming to target the first column in the grid.

I think this is a small enhancement to the current “theming” feature, and could be released in a patch release. Not sure how strict our semver rules are, if this is considered a new feature and would require a minor version.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-grid/1444)
<!-- Reviewable:end -->
