### PR TITLE
Remove aria-level from grid cells

### DIFF
--- a/src/vaadin-grid-a11y-mixin.html
+++ b/src/vaadin-grid-a11y-mixin.html
@@ -70,10 +70,6 @@ This program is available under Apache License Version 2.0, available at https:/
     }
 
     _a11yUpdateRowLevel(row, level) {
-      Array.from(row.children).forEach(cell =>
-        // aria-level indexing starts from 1
-        cell.setAttribute('aria-level', level + 1)
-      );
       row.setAttribute('aria-level', level + 1);
     }
 

--- a/test/data-provider.html
+++ b/test/data-provider.html
@@ -400,13 +400,13 @@
           });
 
           it('should toggle aria-level attribute on the row', () => {
-            expect(getRowCells(getRows(grid.$.items)[2])[0].getAttribute('aria-level')).to.equal('1');
+            expect(getRowCells(getRows(grid.$.items)[2])[0].getAttribute('aria-level')).to.equal(null);
             expect(getRows(grid.$.items)[2].getAttribute('aria-level')).to.equal('1');
             expandIndex(grid, 0);
-            expect(getRowCells(getRows(grid.$.items)[2])[0].getAttribute('aria-level')).to.equal('2');
+            expect(getRowCells(getRows(grid.$.items)[2])[0].getAttribute('aria-level')).to.equal(null);
             expect(getRows(grid.$.items)[2].getAttribute('aria-level')).to.equal('2');
             expandIndex(grid, 1);
-            expect(getRowCells(getRows(grid.$.items)[2])[0].getAttribute('aria-level')).to.equal('3');
+            expect(getRowCells(getRows(grid.$.items)[2])[0].getAttribute('aria-level')).to.equal(null);
             expect(getRows(grid.$.items)[2].getAttribute('aria-level')).to.equal('3');
           });
 


### PR DESCRIPTION
role="gridcell" does not support aria-level attribute: https://www.w3.org/WAI/PF/aria/roles#gridcell
Fails to lighthouse a11y test

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-grid/1456)
<!-- Reviewable:end -->
