### PR TITLE
Don't try to reorder children if pool is not increased

### DIFF
--- a/src/vaadin-grid-a11y-mixin.html
+++ b/src/vaadin-grid-a11y-mixin.html
@@ -107,7 +107,7 @@ This program is available under Apache License Version 2.0, available at https:/
         while (cellContent && cellContent.localName !== 'vaadin-grid-cell-content') {
           cellContent = cellContent.parentNode;
         }
-        if (cellContent) {
+        if (cellContent && cellContent.assignedSlot) {
           const cell = cellContent.assignedSlot.parentNode;
           cell.setAttribute('aria-sort', {
             'asc': 'ascending',

--- a/src/vaadin-grid-scroller.html
+++ b/src/vaadin-grid-scroller.html
@@ -183,7 +183,12 @@ This program is available under Apache License Version 2.0, available at https:/
             () => {
               this._updateMetrics();
               const remainingPhysicalSize = this._optPhysicalSize - this._physicalSize;
-              const estimatedMissingRowCount = Math.ceil(remainingPhysicalSize / this._physicalAverage);
+              let estimatedMissingRowCount = Math.ceil(remainingPhysicalSize / this._physicalAverage);
+
+              if (this._physicalCount + estimatedMissingRowCount > this._effectiveSize) {
+                // Do not increase the physical item count above the this._effectiveSize
+                estimatedMissingRowCount = Math.max(0, this._effectiveSize - this._physicalCount);
+              }
 
               if (this._physicalSize && estimatedMissingRowCount > 0) {
                 super._increasePoolIfNeeded(estimatedMissingRowCount);

--- a/test/physical-count.html
+++ b/test/physical-count.html
@@ -128,6 +128,18 @@
         expect(spy.callCount).to.equal(2);
       });
 
+      it('should not try to reorder children if pool is not increased', () => {
+        grid = fixture('default');
+        grid.items = ['foo', 'bar'];
+        flushGrid(grid);
+
+        const spy = sinon.spy(grid, '__reorderChildNodes');
+        grid.items = ['foo'];
+        flushGrid(grid);
+
+        expect(spy).not.to.be.called;
+      });
+
 
     });
   </script>


### PR DESCRIPTION
This fixes some issues that occurred in the Flow counterpart tests. Note: Couldn't find a proper isolated test case for the fix at "vaadin-grid-a11y-mixin.html".

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-grid/1474)
<!-- Reviewable:end -->
