### PR TITLE
Don't re-apply the existing text content

### DIFF
--- a/src/vaadin-grid-column.html
+++ b/src/vaadin-grid-column.html
@@ -360,21 +360,25 @@ This program is available under Apache License Version 2.0, available at https:/
     _pathOrHeaderChanged(path, header, headerCell, footerCell, cells, renderer, headerRenderer, bodyTemplate, headerTemplate) {
       const hasHeaderText = header !== undefined && header !== null;
       if (!headerRenderer && !headerTemplate && hasHeaderText && headerCell) {
-        headerCell._content.textContent = header;
+        this.__setTextContent(headerCell._content, header);
         headerCell.parentElement.hidden = false;
       }
 
       if (path && cells.value) {
         if (!renderer && !bodyTemplate) {
-          const pathRenderer = (root, owner, {item}) => root.textContent = this.get(path, item);
+          const pathRenderer = (root, owner, {item}) => this.__setTextContent(root, this.get(path, item));
           this.__setColumnTemplateOrRenderer(undefined, pathRenderer, cells.value);
         }
 
         if (!headerRenderer && !headerTemplate && !hasHeaderText && headerCell) {
-          headerCell._content.textContent = this._generateHeader(path);
+          this.__setTextContent(headerCell._content, this._generateHeader(path));
           headerCell.parentElement.hidden = false;
         }
       }
+    }
+
+    __setTextContent(node, textContent) {
+      node.textContent !== textContent && (node.textContent = textContent);
     }
 
     _generateHeader(path) {

--- a/test/column.html
+++ b/test/column.html
@@ -254,6 +254,41 @@
             expect(emptyColumn.renderer).not.to.be.called;
           });
 
+          it('should not reapply the existing text content', done => {
+            emptyColumn.path = '';
+            const content = getBodyCellContent(grid, 0, 2);
+            const spy = sinon.spy();
+            Object.defineProperty(content, 'textContent', {
+              set: spy,
+              get: () => {
+                return spy.called ? spy.getCalls().pop().args[0] : '';
+              }
+            });
+            emptyColumn.path = 'value';
+            flush(() => {
+              expect(spy.callCount).to.equal(1);
+              done();
+            });
+          });
+
+          it('should not reapply the existing header text content', done => {
+            const content = getHeaderCellContent(grid, 1, 2);
+            const spy = sinon.spy();
+            Object.defineProperty(content, 'textContent', {
+              set: spy,
+              get: () => {
+                return spy.called ? spy.getCalls().pop().args[0] : '';
+              }
+            });
+            emptyColumn.path = 'header';
+            const callCount = spy.callCount;
+            emptyColumn.header = null;
+            flush(() => {
+              expect(spy.callCount).to.equal(callCount);
+              done();
+            });
+          });
+
         });
 
         describe('header', () => {
@@ -310,6 +345,25 @@
             grid.removeChild(grid.querySelector('vaadin-grid-column-group'));
             flushGrid(grid);
             expect(getContainerCell(grid.$.header, 0, 0).parentElement.hidden).to.be.true;
+          });
+
+          it('should not reapply the existing header text content', done => {
+            const content = getHeaderCellContent(grid, 1, 2);
+            const spy = sinon.spy();
+            Object.defineProperty(content, 'textContent', {
+              set: spy,
+              get: () => {
+                return spy.called ? spy.getCalls().pop().args[0] : '';
+              }
+            });
+            emptyColumn.header = null;
+            emptyColumn.path = 'foo';
+            const callCount = spy.callCount;
+            emptyColumn.header = 'Foo';
+            flush(() => {
+              expect(spy.callCount).to.equal(callCount);
+              done();
+            });
           });
 
         });


### PR DESCRIPTION
Fixes #1479 

This change decreased the initial loading time of a grid with 192 columns from 13 seconds to 8 seconds on IE11.

No noticeable change in loading time with Chrome.

Thanks for the tip @asyncLiz

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-grid/1487)
<!-- Reviewable:end -->
