### PR TITLE
Add cellClassNameGenerator API

### DIFF
--- a/demo/demos.json
+++ b/demo/demos.json
@@ -123,6 +123,17 @@
   }
   ,
   {
+    "name": "Styling",
+    "url": "grid-styling-demos",
+    "src": "grid-styling-demos.html",
+    "meta": {
+      "title": "vaadin-grid – Styling",
+      "description": "",
+      "image": ""
+    }
+  }
+  ,
+  {
     "name": "Theme Variants",
     "url": "grid-theme-demos",
     "src": "grid-theme-demos.html",

--- a/demo/grid-styling-demos.html
+++ b/demo/grid-styling-demos.html
@@ -32,8 +32,6 @@
               let classes = rowData.item.gender;
               if (column.path === 'email') {
                 classes += ' email';
-              } else if (column.path === 'name.first' && rowData.item.name.title === 'mrs') {
-                classes += ' mrs';
               }
               return classes;
             };
@@ -46,19 +44,15 @@
               <style>
                 /* Background needs a stronger selector to not be overridden */
                 [part~="cell"].female {
-                  background: var(--lumo-primary-color-10pct);
+                  background: rgb(255, 240, 240);
                 }
 
                 [part~="cell"].male {
-                  background: var(--lumo-contrast-5pct);
+                  background: rgb(245, 245, 255);
                 }
 
                 .email {
                   font-style: italic;
-                }
-
-                .mrs {
-                  font-weight: bold;
                 }
               </style>
           </template>
@@ -71,9 +65,8 @@
     <vaadin-demo-snippet id='grid-styling-demos-regenerate-classes'>
       <template preserve-content>
 
-        <vaadin-button style="margin-bottom: 20px" id="change-title-btn">Change Title</vaadin-button>
-
-        <vaadin-grid aria-label="Styling Grid With Cell Class Generator Example" id="grid" size="200">
+        <vaadin-grid aria-label="Updating Cell Class Generator Example" id="grid" size="200">
+          <vaadin-grid-column id="check" flex-grow="0" width="60px"></vaadin-grid-column>
           <vaadin-grid-column path="name.first" header="First name"></vaadin-grid-column>
           <vaadin-grid-column path="name.last" header="Last name"></vaadin-grid-column>
           <vaadin-grid-column path="email"></vaadin-grid-column>
@@ -84,26 +77,57 @@
             const grid = document.querySelector('vaadin-grid');
             grid.items = Vaadin.GridDemo.users;
 
-            const changeTitleBtn = document.querySelector('#change-title-btn');
-            changeTitleBtn.addEventListener('click', function() {
-              grid.items[0].name.title = grid.items[0].name.title === 'ms' ? 'mrs' : 'ms';
+            const checkColumn = document.querySelector('#check');
+            checkColumn.renderer = function(root, column, rowData) {
+              if (!root.firstElementChild) {
+                root.innerHTML = '<vaadin-checkbox></vaadin-checkbox>';
+                root.firstElementChild.addEventListener('checked-changed', function(e) {
+                  root.item.checked = e.detail.value;
 
-              // Classes are re-generated also by clearCache() and render(),
-              // but this function is lighter as it doesn't do anything extra.
-              grid.generateClassNames();
-            });
+                  // Classes are re-generated also by clearCache() and render(),
+                  // but this function is lighter as it doesn't do anything extra.
+                  grid.generateClassNames();
+                });
+              }
+              root.item = rowData.item;
+              root.firstElementChild.checked = rowData.item.checked;
+            };
 
             grid.cellClassNameGenerator = function(rowData, column) {
               let classes = rowData.item.gender;
               if (column.path === 'email') {
                 classes += ' email';
-              } else if (column.path === 'name.first' && rowData.item.name.title === 'mrs') {
-                classes += ' mrs';
+              } else if (column.path === 'name.first' && rowData.item.checked) {
+                classes += ' checked';
               }
               return classes;
             };
           });
         </script>
+
+        <!-- Place in index.html or in a separate HTML import -->
+        <dom-module id="my-grid-styles" theme-for="vaadin-grid">
+          <template>
+              <style>
+                /* Background needs a stronger selector to not be overridden */
+                [part~="cell"].female {
+                  background: rgb(255, 240, 240);
+                }
+
+                [part~="cell"].male {
+                  background: rgb(245, 245, 255);
+                }
+
+                .email {
+                  font-style: italic;
+                }
+
+                .checked {
+                  font-weight: bold;
+                }
+              </style>
+          </template>
+        </dom-module>
       </template>
     </vaadin-demo-snippet>
 

--- a/demo/grid-styling-demos.html
+++ b/demo/grid-styling-demos.html
@@ -46,7 +46,7 @@
               <style>
                 /* Background needs a stronger selector to not be overridden */
                 [part~="cell"].female {
-                    background: var(--lumo-primary-color-10pct);
+                  background: var(--lumo-primary-color-10pct);
                 }
 
                 [part~="cell"].male {

--- a/demo/grid-styling-demos.html
+++ b/demo/grid-styling-demos.html
@@ -41,20 +41,20 @@
         <!-- Place in index.html or in a separate HTML import -->
         <dom-module id="my-grid-styles" theme-for="vaadin-grid">
           <template>
-              <style>
-                /* Background needs a stronger selector to not be overridden */
-                [part~="cell"].female {
-                  background: rgb(255, 240, 240);
-                }
+            <style>
+              /* Background needs a stronger selector to not be overridden */
+              [part~="cell"].female {
+                background: rgb(255, 240, 240);
+              }
 
-                [part~="cell"].male {
-                  background: rgb(245, 245, 255);
-                }
+              [part~="cell"].male {
+                background: rgb(245, 245, 255);
+              }
 
-                .email {
-                  font-style: italic;
-                }
-              </style>
+              .email {
+                font-style: italic;
+              }
+            </style>
           </template>
         </dom-module>
       </template>
@@ -115,24 +115,24 @@
         <!-- Place in index.html or in a separate HTML import -->
         <dom-module id="my-grid-styles" theme-for="vaadin-grid">
           <template>
-              <style>
-                /* Background needs a stronger selector to not be overridden */
-                [part~="cell"].female {
-                  background: rgb(255, 240, 240);
-                }
+            <style>
+              /* Background needs a stronger selector to not be overridden */
+              [part~="cell"].female {
+                background: rgb(255, 240, 240);
+              }
 
-                [part~="cell"].male {
-                  background: rgb(245, 245, 255);
-                }
+              [part~="cell"].male {
+                background: rgb(245, 245, 255);
+              }
 
-                .email {
-                  font-style: italic;
-                }
+              .email {
+                font-style: italic;
+              }
 
-                .checked {
-                  font-weight: bold;
-                }
-              </style>
+              .checked {
+                font-weight: bold;
+              }
+            </style>
           </template>
         </dom-module>
       </template>

--- a/demo/grid-styling-demos.html
+++ b/demo/grid-styling-demos.html
@@ -1,0 +1,119 @@
+<dom-module id="grid-styling-demos">
+  <template>
+    <style include="vaadin-component-demo-shared-styles">
+      :host {
+        display: block;
+      }
+    </style>
+
+    <p>Read more about writing custom CSS for themable elements from the 
+      <a href="https://github.com/vaadin/vaadin-themable-mixin/wiki">
+        styling and theming documentation
+      </a>.
+    </p>
+
+    <h3>Generating Class Names for Grid Cells</h3>
+
+    <vaadin-demo-snippet id='grid-styling-demos-cell-class-generator'>
+      <template preserve-content>
+
+        <vaadin-grid aria-label="Styling Grid With Cell Class Generator Example" id="grid" size="200">
+          <vaadin-grid-column path="name.first" header="First name"></vaadin-grid-column>
+          <vaadin-grid-column path="name.last" header="Last name"></vaadin-grid-column>
+          <vaadin-grid-column path="email"></vaadin-grid-column>
+        </vaadin-grid>
+
+        <script>
+          window.addDemoReadyListener('#grid-styling-demos-cell-class-generator', function(document) {
+            const grid = document.querySelector('vaadin-grid');
+            grid.items = Vaadin.GridDemo.users;
+
+            grid.cellClassNameGenerator = function(rowData, column) {
+              let classes = rowData.item.gender;
+              if (column.path === 'email') {
+                classes += ' email';
+              } else if (column.path === 'name.first' && rowData.item.name.title === 'mrs') {
+                classes += ' mrs';
+              }
+              return classes;
+            };
+          });
+        </script>
+
+        <!-- Place in index.html or in a separate HTML import -->
+        <dom-module id="my-grid-styles" theme-for="vaadin-grid">
+          <template>
+              <style>
+                /* Background needs a stronger selector to not be overridden */
+                [part~="cell"].female {
+                    background: var(--lumo-primary-color-10pct);
+                }
+
+                [part~="cell"].male {
+                  background: var(--lumo-contrast-5pct);
+                }
+
+                .email {
+                  font-style: italic;
+                }
+
+                .mrs {
+                  font-weight: bold;
+                }
+              </style>
+          </template>
+        </dom-module>
+      </template>
+    </vaadin-demo-snippet>
+
+    <h3>Updating Styles After Changes in the Data</h3>
+
+    <vaadin-demo-snippet id='grid-styling-demos-regenerate-classes'>
+      <template preserve-content>
+
+        <vaadin-button style="margin-bottom: 20px" id="change-title-btn">Change Title</vaadin-button>
+
+        <vaadin-grid aria-label="Styling Grid With Cell Class Generator Example" id="grid" size="200">
+          <vaadin-grid-column path="name.first" header="First name"></vaadin-grid-column>
+          <vaadin-grid-column path="name.last" header="Last name"></vaadin-grid-column>
+          <vaadin-grid-column path="email"></vaadin-grid-column>
+        </vaadin-grid>
+
+        <script>
+          window.addDemoReadyListener('#grid-styling-demos-regenerate-classes', function(document) {
+            const grid = document.querySelector('vaadin-grid');
+            grid.items = Vaadin.GridDemo.users;
+
+            const changeTitleBtn = document.querySelector('#change-title-btn');
+            changeTitleBtn.addEventListener('click', function() {
+              grid.items[0].name.title = grid.items[0].name.title === 'ms' ? 'mrs' : 'ms';
+
+              // Classes are re-generated also by clearCache() and render(),
+              // but this function is lighter as it doesn't do anything extra.
+              grid.generateClassNames();
+            });
+
+            grid.cellClassNameGenerator = function(rowData, column) {
+              let classes = rowData.item.gender;
+              if (column.path === 'email') {
+                classes += ' email';
+              } else if (column.path === 'name.first' && rowData.item.name.title === 'mrs') {
+                classes += ' mrs';
+              }
+              return classes;
+            };
+          });
+        </script>
+      </template>
+    </vaadin-demo-snippet>
+
+  </template>
+  <script>
+    class GridStylingDemos extends DemoReadyEventEmitter(GridDemo(Polymer.Element)) {
+      static get is() {
+        return 'grid-styling-demos';
+      }
+    }
+    customElements.define(GridStylingDemos.is, GridStylingDemos);
+  </script>
+</dom-module>

--- a/demo/grid-styling-demos.html
+++ b/demo/grid-styling-demos.html
@@ -77,12 +77,19 @@
             const grid = document.querySelector('vaadin-grid');
             grid.items = Vaadin.GridDemo.users;
 
+            const checkedItems = [];
+
             const checkColumn = document.querySelector('#check');
             checkColumn.renderer = function(root, column, rowData) {
               if (!root.firstElementChild) {
                 root.innerHTML = '<vaadin-checkbox></vaadin-checkbox>';
                 root.firstElementChild.addEventListener('checked-changed', function(e) {
-                  root.item.checked = e.detail.value;
+                  const index = checkedItems.indexOf(root.item);
+                  if (e.detail.value && index === -1) {
+                    checkedItems.push(root.item);
+                  } else if (!e.detail.value && index > -1) {
+                    checkedItems.splice(index, 1);
+                  }
 
                   // Classes are re-generated also by clearCache() and render(),
                   // but this function is lighter as it doesn't do anything extra.
@@ -90,14 +97,14 @@
                 });
               }
               root.item = rowData.item;
-              root.firstElementChild.checked = rowData.item.checked;
+              root.firstElementChild.checked = checkedItems.indexOf(rowData.item) > -1;
             };
 
             grid.cellClassNameGenerator = function(rowData, column) {
               let classes = rowData.item.gender;
               if (column.path === 'email') {
                 classes += ' email';
-              } else if (column.path === 'name.first' && rowData.item.checked) {
+              } else if (column.path === 'name.first' && checkedItems.indexOf(rowData.item) > -1) {
                 classes += ' checked';
               }
               return classes;

--- a/demo/index.html
+++ b/demo/index.html
@@ -27,24 +27,24 @@
   <!-- Used in the styling examples, keep in sync -->
   <dom-module id="grid-styling-demo-theme" theme-for="vaadin-grid">
     <template>
-        <style>
-          /* Background needs a stronger selector to not be overridden */
-          [part~="cell"].female {
-            background: rgb(255, 240, 240);
-          }
+      <style>
+        /* Background needs a stronger selector to not be overridden */
+        [part~="cell"].female {
+          background: rgb(255, 240, 240);
+        }
 
-          [part~="cell"].male {
-            background: rgb(245, 245, 255);
-          }
+        [part~="cell"].male {
+          background: rgb(245, 245, 255);
+        }
 
-          .email {
-            font-style: italic;
-          }
+        .email {
+          font-style: italic;
+        }
 
-          .checked {
-            font-weight: bold;
-          }
-        </style>
+        .checked {
+          font-weight: bold;
+        }
+      </style>
     </template>
   </dom-module>
 

--- a/demo/index.html
+++ b/demo/index.html
@@ -30,18 +30,18 @@
         <style>
           /* Background needs a stronger selector to not be overridden */
           [part~="cell"].female {
-            background: var(--lumo-primary-color-10pct);
+            background: rgb(255, 240, 240);
           }
 
           [part~="cell"].male {
-            background: var(--lumo-contrast-5pct);
+            background: rgb(245, 245, 255);
           }
 
           .email {
             font-style: italic;
           }
 
-          .mrs {
+          .checked {
             font-weight: bold;
           }
         </style>

--- a/demo/index.html
+++ b/demo/index.html
@@ -24,6 +24,30 @@
   <link rel="import" href="../../iron-ajax/iron-ajax.html">
   <link rel="import" href="../../vaadin-lumo-styles/icons.html">
 
+  <!-- Used in the styling examples, keep in sync -->
+  <dom-module id="grid-styling-demo-theme" theme-for="vaadin-grid">
+    <template>
+        <style>
+          /* Background needs a stronger selector to not be overridden */
+          [part~="cell"].female {
+              background: var(--lumo-primary-color-10pct);
+          }
+
+          [part~="cell"].male {
+            background: var(--lumo-contrast-5pct);
+          }
+
+          .email {
+            font-style: italic;
+          }
+
+          .mrs {
+            font-weight: bold;
+          }
+        </style>
+    </template>
+  </dom-module>
+
   <custom-style>
     <style include="vaadin-component-demo-shared-styles"></style>
   </custom-style>

--- a/demo/index.html
+++ b/demo/index.html
@@ -30,7 +30,7 @@
         <style>
           /* Background needs a stronger selector to not be overridden */
           [part~="cell"].female {
-              background: var(--lumo-primary-color-10pct);
+            background: var(--lumo-primary-color-10pct);
           }
 
           [part~="cell"].male {

--- a/src/vaadin-grid-styling-mixin.html
+++ b/src/vaadin-grid-styling-mixin.html
@@ -57,11 +57,15 @@ This program is available under Apache License Version 2.0, available at https:/
 
     _generateClassNames(row, rowData) {
       Array.from(row.children).forEach(cell => {
-        cell.__generatedClasses && cell.classList.remove(...cell.__generatedClasses);
+        if (cell.__generatedClasses) {
+          cell.__generatedClasses.forEach(className => cell.classList.remove(className));
+        }
         if (this.cellClassNameGenerator) {
           const result = this.cellClassNameGenerator(rowData, cell._column);
           cell.__generatedClasses = result && result.split(' ');
-          cell.__generatedClasses && cell.classList.add(...cell.__generatedClasses);
+          if (cell.__generatedClasses) {
+            cell.__generatedClasses.forEach(className => cell.classList.add(className));
+          }
         }
       });
     }

--- a/src/vaadin-grid-styling-mixin.html
+++ b/src/vaadin-grid-styling-mixin.html
@@ -30,15 +30,18 @@ This program is available under Apache License Version 2.0, available at https:/
          *   - `rowData.selected` Selected state.
          * - `column` The `<vaadin-grid-column>` element.
          */
-        cellClassNameGenerator: {
-          type: Function,
-          observer(newValue, oldValue) {
-            if (newValue || oldValue) {
-              this.generateClassNames();
-            }
-          }
-        }
+        cellClassNameGenerator: Function
       };
+    }
+
+    static get observers() {
+      return [
+        '__cellClassNameGeneratorChanged(cellClassNameGenerator)'
+      ];
+    }
+
+    __cellClassNameGeneratorChanged(cellClassGenerator) {
+      this.generateClassNames();
     }
 
     /**

--- a/src/vaadin-grid-styling-mixin.html
+++ b/src/vaadin-grid-styling-mixin.html
@@ -30,18 +30,15 @@ This program is available under Apache License Version 2.0, available at https:/
          *   - `rowData.selected` Selected state.
          * - `column` The `<vaadin-grid-column>` element.
          */
-        cellClassNameGenerator: Function
+        cellClassNameGenerator: {
+          type: Function,
+          observer(newValue, oldValue) {
+            if (newValue || oldValue) {
+              this.generateClassNames();
+            }
+          }
+        }
       };
-    }
-
-    static get observers() {
-      return [
-        '__cellClassNameGeneratorChanged(cellClassNameGenerator)'
-      ];
-    }
-
-    __cellClassNameGeneratorChanged(cellClassGenerator) {
-      this.generateClassNames();
     }
 
     /**

--- a/src/vaadin-grid-styling-mixin.html
+++ b/src/vaadin-grid-styling-mixin.html
@@ -51,7 +51,7 @@ This program is available under Apache License Version 2.0, available at https:/
      * the conditions change.
      */
     generateClassNames() {
-      Array.from(this.$.items.children).forEach(
+      Array.from(this.$.items.children).filter(row => !row.hidden).forEach(
         row => this._generateClassNames(row, this.__getRowModel(row)));
     }
 

--- a/src/vaadin-grid-styling-mixin.html
+++ b/src/vaadin-grid-styling-mixin.html
@@ -59,7 +59,7 @@ This program is available under Apache License Version 2.0, available at https:/
         }
         if (this.cellClassNameGenerator) {
           const result = this.cellClassNameGenerator(rowData, cell._column);
-          cell.__generatedClasses = result && result.split(' ');
+          cell.__generatedClasses = result && result.split(' ').filter(className => className.length > 0);
           if (cell.__generatedClasses) {
             cell.__generatedClasses.forEach(className => cell.classList.add(className));
           }

--- a/src/vaadin-grid-styling-mixin.html
+++ b/src/vaadin-grid-styling-mixin.html
@@ -1,0 +1,69 @@
+<!--
+@license
+Copyright (c) 2018 Vaadin Ltd.
+This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+-->
+<script>
+  window.Vaadin = window.Vaadin || {};
+  window.Vaadin.Grid = window.Vaadin.Grid || {};
+
+  /**
+   * @polymerMixin
+   */
+  Vaadin.Grid.StylingMixin = superClass => class StylingMixin extends superClass {
+
+    static get properties() {
+      return {
+        /**
+         * A function that allows generating CSS class names for grid cells
+         * based on their row and column. The return value should be the generated
+         * class name as a string, or multiple class names separated by whitespace
+         * characters.
+         *
+         * Receives two arguments:
+         * - `rowData` The object with the properties related with
+         *   the rendered item, contains:
+         *   - `rowData.index` The index of the item.
+         *   - `rowData.item` The item.
+         *   - `rowData.expanded` Sublevel toggle state.
+         *   - `rowData.level` Level of the tree represented with a horizontal offset of the toggle button.
+         *   - `rowData.selected` Selected state.
+         * - `column` The `<vaadin-grid-column>` element.
+         */
+        cellClassNameGenerator: Function
+      };
+    }
+
+    static get observers() {
+      return [
+        '__cellClassNameGeneratorChanged(cellClassNameGenerator)'
+      ];
+    }
+
+    __cellClassNameGeneratorChanged(cellClassGenerator) {
+      this.generateClassNames();
+    }
+
+    /**
+     * Runs the `cellClassNameGenerator` for the visible cells.
+     * If the generator depends on varying conditions, you need to
+     * call this function manually in order to update the styles when
+     * the conditions change.
+     */
+    generateClassNames() {
+      Array.from(this.$.items.children).forEach(
+        row => this._generateClassNames(row, this.__getRowModel(row)));
+    }
+
+    _generateClassNames(row, rowData) {
+      Array.from(row.children).forEach(cell => {
+        cell.__generatedClasses && cell.classList.remove(...cell.__generatedClasses);
+        if (this.cellClassNameGenerator) {
+          const result = this.cellClassNameGenerator(rowData, cell._column);
+          cell.__generatedClasses = result && result.split(' ');
+          cell.__generatedClasses && cell.classList.add(...cell.__generatedClasses);
+        }
+      });
+    }
+  };
+</script>

--- a/src/vaadin-grid.html
+++ b/src/vaadin-grid.html
@@ -19,6 +19,7 @@ This program is available under Apache License Version 2.0, available at https:/
 <link rel="import" href="vaadin-grid-scroll-mixin.html">
 <link rel="import" href="vaadin-grid-selection-mixin.html">
 <link rel="import" href="vaadin-grid-sort-mixin.html">
+<link rel="import" href="vaadin-grid-styling-mixin.html">
 <link rel="import" href="vaadin-grid-keyboard-navigation-mixin.html">
 <link rel="import" href="vaadin-grid-column-reordering-mixin.html">
 <link rel="import" href="vaadin-grid-column.html">
@@ -318,7 +319,8 @@ This program is available under Apache License Version 2.0, available at https:/
                                 Vaadin.Grid.ColumnReorderingMixin(
                                   Vaadin.Grid.ColumnResizingMixin(
                                     Vaadin.Grid.DetailedEventMixin(
-                                      Vaadin.Grid.ScrollerElement)))))))))))))))) {
+                                      Vaadin.Grid.StylingMixin(
+                                        Vaadin.Grid.ScrollerElement))))))))))))))))) {
 
       static get is() {
         return 'vaadin-grid';
@@ -608,6 +610,7 @@ This program is available under Apache License Version 2.0, available at https:/
         if (this._rowDetailsTemplate || this.rowDetailsRenderer) {
           this._toggleDetailsCell(row, item);
         }
+        this._generateClassNames(row, model);
 
         Array.from(row.children).forEach(cell => {
           if (cell._renderer) {

--- a/src/vaadin-grid.html
+++ b/src/vaadin-grid.html
@@ -300,6 +300,8 @@ This program is available under Apache License Version 2.0, available at https:/
      * @mixes Vaadin.Grid.SortMixin
      * @mixes Vaadin.Grid.KeyboardNavigationMixin
      * @mixes Vaadin.Grid.ColumnReorderingMixin
+     * @mixes Vaadin.Grid.DetailedEventMixin
+     * @mixes Vaadin.Grid.StylingMixin
      * @demo demo/index.html
      */
     class GridElement extends

--- a/test/class-name-generator.html
+++ b/test/class-name-generator.html
@@ -1,0 +1,116 @@
+<!doctype html>
+
+<html>
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+
+  <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+  <script src="../../web-component-tester/browser.js"></script>
+  <script src="../../iron-test-helpers/mock-interactions.js"></script>
+
+  <link rel="import" href="helpers.html">
+  <link rel="import" href="../all-imports.html">
+</head>
+
+<body>
+
+  <script>
+    describe('class name generator', () => {
+      let grid, firstCell, initialCellClasses;
+
+      beforeEach(() => {
+
+        grid = document.createElement('vaadin-grid');
+        grid.size = 200;
+        grid.dataProvider = infiniteDataProvider;
+
+        [0, 1].forEach(i => {
+          const column = document.createElement('vaadin-grid-column');
+          grid.appendChild(column);
+          column.path = 'value';
+          column.header = 'col' + i;
+        });
+        document.body.appendChild(grid);
+        flushGrid(grid);
+
+        firstCell = getContainerCell(grid.$.items, 0, 0);
+
+        // Polyfills may add some extra classes to cells
+        initialCellClasses = Array.from(firstCell.classList);
+      });
+
+      afterEach(() => {
+        document.body.removeChild(grid);
+      });
+
+      const assertClassList = (cell, expectedClasses) =>
+        expect(Array.from(cell.classList)).to.deep.equal(initialCellClasses.concat(expectedClasses));
+
+      it('should add classes for cells', () => {
+        grid.cellClassNameGenerator = (rowData, column) => 'foo';
+        assertClassList(firstCell, ['foo']);
+        assertClassList(getContainerCell(grid.$.items, 1, 1), ['foo']);
+      });
+
+      it('should add all classes separated by whitespaces', () => {
+        grid.cellClassNameGenerator = (rowData, column) => 'foo bar baz';
+        assertClassList(firstCell, ['foo', 'bar', 'baz']);
+      });
+
+      it('should not remove existing classes', () => {
+        firstCell.classList.add('bar');
+        grid.cellClassNameGenerator = (rowData, column) => 'foo';
+        assertClassList(firstCell, ['bar', 'foo']);
+      });
+
+      it('should remove old generated classes', () => {
+        grid.cellClassNameGenerator = (rowData, column) => 'foo';
+        grid.cellClassNameGenerator = (rowData, column) => 'bar';
+        assertClassList(firstCell, ['bar']);
+      });
+
+      it('should provide rowData and column as parameters', () => {
+        grid.cellClassNameGenerator = (rowData, column) =>
+          rowData.index + ' ' + rowData.item.value + ' ' + column.header;
+        assertClassList(getContainerCell(grid.$.items, 5, 1), ['5', 'foo5', 'col1']);
+        assertClassList(getContainerCell(grid.$.items, 10, 0), ['10', 'foo10', 'col0']);
+      });
+
+      it('should add classes when loading new items', function(done) {
+        grid.cellClassNameGenerator = (rowData, column) => rowData.item.value;
+        scrollToEnd(grid, () => {
+          const rows = getRows(grid.$.items);
+          const lastRow = rows[rows.length - 1];
+          const cell = lastRow.firstElementChild;
+          assertClassList(cell, ['foo199']);
+          done();
+        });
+      });
+
+      it('should not throw with falsy return value', () => {
+        expect(() => grid.cellClassNameGenerator = (rowData, column) => {}).not.to.throw(Error);
+      });
+
+      it('should clear generated classes with falsy return value', () => {
+        grid.cellClassNameGenerator = (rowData, column) => 'foo';
+        grid.cellClassNameGenerator = (rowData, column) => {};
+        assertClassList(firstCell, []);
+      });
+
+      ['generateClassNames', 'clearCache', 'render'].forEach(funcName => {
+        it(`should update classes on ${funcName}`, () => {
+          let condition = false;
+          grid.cellClassNameGenerator = (rowData, column) => condition && 'foo';
+          condition = true;
+          assertClassList(firstCell, []);
+          grid[funcName]();
+          assertClassList(firstCell, ['foo']);
+        });
+      });
+    });
+  </script>
+
+</body>
+</html>

--- a/test/class-name-generator.html
+++ b/test/class-name-generator.html
@@ -119,6 +119,11 @@
         grid.cellClassNameGenerator = spy;
         expect(spy).to.not.be.called;
       });
+
+      it('should not throw with extra whitespace in the result', () => {
+        expect(() => grid.cellClassNameGenerator = (rowData, column) => ' foo  bar ').not.to.throw(Error);
+        assertClassList(firstCell, ['foo', 'bar']);
+      });
     });
   </script>
 

--- a/test/class-name-generator.html
+++ b/test/class-name-generator.html
@@ -16,33 +16,28 @@
 
 <body>
 
+  <test-fixture id="grid">
+    <template>
+      <vaadin-grid size="200">
+        <vaadin-grid-column path="value" header="col0"></vaadin-grid-column>
+        <vaadin-grid-column path="value" header="col1"></vaadin-grid-column>
+      </vaadin-grid>
+    </template>
+  </test-fixture>
+
   <script>
     describe('class name generator', () => {
       let grid, firstCell, initialCellClasses;
 
       beforeEach(() => {
-
-        grid = document.createElement('vaadin-grid');
-        grid.size = 200;
+        grid = fixture('grid');
         grid.dataProvider = infiniteDataProvider;
-
-        [0, 1].forEach(i => {
-          const column = document.createElement('vaadin-grid-column');
-          grid.appendChild(column);
-          column.path = 'value';
-          column.header = 'col' + i;
-        });
-        document.body.appendChild(grid);
         flushGrid(grid);
 
         firstCell = getContainerCell(grid.$.items, 0, 0);
 
         // Polyfills may add some extra classes to cells
         initialCellClasses = Array.from(firstCell.classList);
-      });
-
-      afterEach(() => {
-        document.body.removeChild(grid);
       });
 
       const assertClassList = (cell, expectedClasses) =>

--- a/test/class-name-generator.html
+++ b/test/class-name-generator.html
@@ -94,6 +94,12 @@
         assertClassList(firstCell, []);
       });
 
+      it('should clear generated classes with falsy property value', () => {
+        grid.cellClassNameGenerator = (rowData, column) => 'foo';
+        grid.cellClassNameGenerator = undefined;
+        assertClassList(firstCell, []);
+      });
+
       ['generateClassNames', 'clearCache', 'render'].forEach(funcName => {
         it(`should update classes on ${funcName}`, () => {
           let condition = false;

--- a/test/class-name-generator.html
+++ b/test/class-name-generator.html
@@ -104,6 +104,15 @@
           assertClassList(firstCell, ['foo']);
         });
       });
+
+      it('should not run generator for hidden rows', () => {
+        grid.items = [];
+        expect(grid.$.items.firstElementChild).to.have.property('hidden', true);
+
+        const spy = sinon.spy();
+        grid.cellClassNameGenerator = spy;
+        expect(spy).to.not.be.called;
+      });
     });
   </script>
 

--- a/test/test-suites.js
+++ b/test/test-suites.js
@@ -4,6 +4,7 @@ window.VaadinGridSuites = [
   'accessibility.html',
   'array-data-provider.html',
   'basic.html',
+  'class-name-generator.html',
   'column-group.html',
   'column-groups.html',
   'column-reordering.html',


### PR DESCRIPTION
Allows defining a function that adds CSS class names to the cells in grid's body, based on the corresponding `rowData` and column.

Resolves #1481

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-grid/1488)
<!-- Reviewable:end -->
