### PR TITLE
Don't force render in between data requests

### DIFF
--- a/src/vaadin-grid-data-provider-mixin.html
+++ b/src/vaadin-grid-data-provider-mixin.html
@@ -294,26 +294,38 @@ This program is available under Apache License Version 2.0, available at https:/
             }
           }
 
+          // Populate the cache with new items
           items.forEach((item, itemsIndex) => {
-            cache.items[page * this.pageSize + itemsIndex] = item;
-          });
-          this._cache.updateSize();
-          this._effectiveSize = this._cache.effectiveSize;
-
-          Array.from(this.$.items.children).forEach(row => {
-            const cachedItem = this._cache.getItemForIndex(row.index);
-            if (items.indexOf(cachedItem) > -1) {
-              this._toggleAttribute('loading', false, row);
-              this._updateItem(row, cachedItem);
+            const itemIndex = page * this.pageSize + itemsIndex;
+            cache.items[itemIndex] = item;
+            if (this._isExpanded(item)) {
+              // Force synchronous data request for expanded item sub-cache
+              cache.ensureSubCacheForScaledIndex(itemIndex);
             }
           });
 
           this._hasData = true;
-          this._increasePoolIfNeeded(0);
 
           delete cache.pendingRequests[page];
 
-          this._setLoading(this._cache.isLoading());
+          if (!this._cache.isLoading()) {
+            // All active requests have finished, update the effective size and rows
+            this._setLoading(false);
+            this._cache.updateSize();
+            this._effectiveSize = this._cache.effectiveSize;
+
+            Array.from(this.$.items.children)
+              .filter(row => !row.hidden)
+              .forEach(row => {
+                const cachedItem = this._cache.getItemForIndex(row.index);
+                if (cachedItem) {
+                  this._toggleAttribute('loading', false, row);
+                  this._updateItem(row, cachedItem);
+                }
+              });
+
+            this._increasePoolIfNeeded(0);
+          }
         });
       }
     }

--- a/test/data-provider.html
+++ b/test/data-provider.html
@@ -249,11 +249,16 @@
 
       describe('tree', () => {
 
+        let generateItemIds;
+
         function finiteDataProvider(params, callback) {
           // Provides fixed size data set of 10 items
           infiniteDataProvider(params, (items) => {
             callback(items.map(item => {
               item.level = params.parentItem ? ((params.parentItem.level || 0) + 1) : 0;
+              if (generateItemIds) {
+                item.id = `${item.value}-${item.level}`;
+              }
               return item;
             }), 10);
           });
@@ -283,6 +288,7 @@
         beforeEach(() => {
           grid.pageSize = 5;
           grid.dataProvider = sinon.spy(finiteDataProvider);
+          generateItemIds = false;
         });
 
         describe('first level', () => {
@@ -323,6 +329,32 @@
             expandIndex(grid, 7);
             expect(grid.dataProvider.callCount).to.equal(3);
             expect(grid.dataProvider.getCall(2).args[0].parentItem.value).to.equal('foo7');
+          });
+
+          it('should request expanded items first pages before rendering', () => {
+            generateItemIds = true;
+            // Reset pageSize to 50 so we get 1 data request / cache level
+            grid.pageSize = 50;
+            // Ensure that the expanded item is expanded once new items are received
+            grid.itemIdPath = 'id';
+            // Expand one item so in total 2 requests are expected after clear cache
+            // (main level cache and expanded item subcache)
+            expandIndex(grid, 0);
+
+            grid.dataProvider.reset();
+            const renderSpy = sinon.spy(grid, '_effectiveSizeChanged');
+            const increasePoolSpy = sinon.spy(grid, '_increasePoolIfNeeded');
+            const toggleAttributeSpy = sinon.spy(grid, '_toggleAttribute');
+            const updateItemSpy = sinon.spy(grid, '_updateItem');
+            grid.clearCache();
+
+            expect(grid.dataProvider.callCount).to.equal(2);
+
+            // Effective size should not have changed in between the data requests
+            expect(renderSpy.called).to.be.false;
+            expect(increasePoolSpy.callCount).to.equal(1);
+            expect(toggleAttributeSpy.callCount).to.be.below(90);
+            expect(updateItemSpy.callCount).to.be.below(70);
           });
 
           ['renderer', 'template'].forEach(type => {


### PR DESCRIPTION
When the current data provider callback is invoked by a client app, the received items are included in the grid's cache and the rows are re-rendered.

This works fine in most cases, but when hierarchical data is used and there are lots of pre-opened nodes in the item set, while all the opened sub-levels are populated by separate data requests, grid still gets re-rendered in between all the individual requests causing a performance bottle neck.

| ![screenshot 2018-11-15 13 19 17](https://user-images.githubusercontent.com/1222264/48550612-ef980780-e8db-11e8-8824-7893cfc97b54.png) | ![screenshot 2018-11-15 13 19 50](https://user-images.githubusercontent.com/1222264/48550613-ef980780-e8db-11e8-8477-58037266b10c.png) | ![screenshot 2018-11-15 13 20 23](https://user-images.githubusercontent.com/1222264/48550614-ef980780-e8db-11e8-9bd9-217d2a5c9fe8.png) | ![screenshot 2018-11-15 13 20 42](https://user-images.githubusercontent.com/1222264/48550615-ef980780-e8db-11e8-841f-d926c36d31cf.png) | ![screenshot 2018-11-15 13 21 00](https://user-images.githubusercontent.com/1222264/48550616-ef980780-e8db-11e8-826f-af8807109978.png) | ![screenshot 2018-11-15 13 21 19](https://user-images.githubusercontent.com/1222264/48550617-ef980780-e8db-11e8-92e9-655f34995d74.png) |
|---|---|---|---|---|---|









This PR changes the data provider so that the data requests for any pre-opened items are submitted synchronously and the rendering phase is executed only once all the requests have finished. This improves performance significantly in applications where the data is cached on an additional store from which the grid cache is re-populated (upon `clearCache()` for example).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-grid/1491)
<!-- Reviewable:end -->
