### PR TITLE
Swap parameter order in cellClassNameGenerator

### DIFF
--- a/demo/grid-styling-demos.html
+++ b/demo/grid-styling-demos.html
@@ -48,7 +48,7 @@
             const grid = document.querySelector('vaadin-grid');
             grid.items = Vaadin.GridDemo.users;
 
-            grid.cellClassNameGenerator = function(rowData, column) {
+            grid.cellClassNameGenerator = function(column, rowData) {
               let classes = rowData.item.gender;
               if (column.path === 'email') {
                 classes += ' email';
@@ -125,7 +125,7 @@
               root.firstElementChild.checked = checkedItems.indexOf(rowData.item) > -1;
             };
 
-            grid.cellClassNameGenerator = function(rowData, column) {
+            grid.cellClassNameGenerator = function(column, rowData) {
               let classes = rowData.item.gender;
               if (column.path === 'email') {
                 classes += ' email';

--- a/src/vaadin-grid-styling-mixin.html
+++ b/src/vaadin-grid-styling-mixin.html
@@ -21,6 +21,7 @@ This program is available under Apache License Version 2.0, available at https:/
          * characters.
          *
          * Receives two arguments:
+         * - `column` The `<vaadin-grid-column>` element.
          * - `rowData` The object with the properties related with
          *   the rendered item, contains:
          *   - `rowData.index` The index of the item.
@@ -28,7 +29,6 @@ This program is available under Apache License Version 2.0, available at https:/
          *   - `rowData.expanded` Sublevel toggle state.
          *   - `rowData.level` Level of the tree represented with a horizontal offset of the toggle button.
          *   - `rowData.selected` Selected state.
-         * - `column` The `<vaadin-grid-column>` element.
          */
         cellClassNameGenerator: Function
       };
@@ -61,7 +61,7 @@ This program is available under Apache License Version 2.0, available at https:/
           cell.__generatedClasses.forEach(className => cell.classList.remove(className));
         }
         if (this.cellClassNameGenerator) {
-          const result = this.cellClassNameGenerator(rowData, cell._column);
+          const result = this.cellClassNameGenerator(cell._column, rowData);
           cell.__generatedClasses = result && result.split(' ').filter(className => className.length > 0);
           if (cell.__generatedClasses) {
             cell.__generatedClasses.forEach(className => cell.classList.add(className));

--- a/test/class-name-generator.html
+++ b/test/class-name-generator.html
@@ -44,37 +44,37 @@
         expect(Array.from(cell.classList)).to.deep.equal(initialCellClasses.concat(expectedClasses));
 
       it('should add classes for cells', () => {
-        grid.cellClassNameGenerator = (rowData, column) => 'foo';
+        grid.cellClassNameGenerator = (column, rowData) => 'foo';
         assertClassList(firstCell, ['foo']);
         assertClassList(getContainerCell(grid.$.items, 1, 1), ['foo']);
       });
 
       it('should add all classes separated by whitespaces', () => {
-        grid.cellClassNameGenerator = (rowData, column) => 'foo bar baz';
+        grid.cellClassNameGenerator = (column, rowData) => 'foo bar baz';
         assertClassList(firstCell, ['foo', 'bar', 'baz']);
       });
 
       it('should not remove existing classes', () => {
         firstCell.classList.add('bar');
-        grid.cellClassNameGenerator = (rowData, column) => 'foo';
+        grid.cellClassNameGenerator = (column, rowData) => 'foo';
         assertClassList(firstCell, ['bar', 'foo']);
       });
 
       it('should remove old generated classes', () => {
-        grid.cellClassNameGenerator = (rowData, column) => 'foo';
-        grid.cellClassNameGenerator = (rowData, column) => 'bar';
+        grid.cellClassNameGenerator = (column, rowData) => 'foo';
+        grid.cellClassNameGenerator = (column, rowData) => 'bar';
         assertClassList(firstCell, ['bar']);
       });
 
-      it('should provide rowData and column as parameters', () => {
-        grid.cellClassNameGenerator = (rowData, column) =>
+      it('should provide column and rowData as parameters', () => {
+        grid.cellClassNameGenerator = (column, rowData) =>
           rowData.index + ' ' + rowData.item.value + ' ' + column.header;
         assertClassList(getContainerCell(grid.$.items, 5, 1), ['5', 'foo5', 'col1']);
         assertClassList(getContainerCell(grid.$.items, 10, 0), ['10', 'foo10', 'col0']);
       });
 
       it('should add classes when loading new items', function(done) {
-        grid.cellClassNameGenerator = (rowData, column) => rowData.item.value;
+        grid.cellClassNameGenerator = (column, rowData) => rowData.item.value;
         scrollToEnd(grid, () => {
           const rows = getRows(grid.$.items);
           const lastRow = rows[rows.length - 1];
@@ -85,17 +85,17 @@
       });
 
       it('should not throw with falsy return value', () => {
-        expect(() => grid.cellClassNameGenerator = (rowData, column) => {}).not.to.throw(Error);
+        expect(() => grid.cellClassNameGenerator = (column, rowData) => {}).not.to.throw(Error);
       });
 
       it('should clear generated classes with falsy return value', () => {
-        grid.cellClassNameGenerator = (rowData, column) => 'foo';
-        grid.cellClassNameGenerator = (rowData, column) => {};
+        grid.cellClassNameGenerator = (column, rowData) => 'foo';
+        grid.cellClassNameGenerator = (column, rowData) => {};
         assertClassList(firstCell, []);
       });
 
       it('should clear generated classes with falsy property value', () => {
-        grid.cellClassNameGenerator = (rowData, column) => 'foo';
+        grid.cellClassNameGenerator = (column, rowData) => 'foo';
         grid.cellClassNameGenerator = undefined;
         assertClassList(firstCell, []);
       });
@@ -103,7 +103,7 @@
       ['generateCellClassNames', 'clearCache', 'render'].forEach(funcName => {
         it(`should update classes on ${funcName}`, () => {
           let condition = false;
-          grid.cellClassNameGenerator = (rowData, column) => condition && 'foo';
+          grid.cellClassNameGenerator = (column, rowData) => condition && 'foo';
           condition = true;
           assertClassList(firstCell, []);
           grid[funcName]();
@@ -121,7 +121,7 @@
       });
 
       it('should not throw with extra whitespace in the result', () => {
-        expect(() => grid.cellClassNameGenerator = (rowData, column) => ' foo  bar ').not.to.throw(Error);
+        expect(() => grid.cellClassNameGenerator = (column, rowData) => ' foo  bar ').not.to.throw(Error);
         assertClassList(firstCell, ['foo', 'bar']);
       });
     });


### PR DESCRIPTION
in order to align with the renderer APIs, where the column is passed
before the rowData

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-grid/1498)
<!-- Reviewable:end -->
