### PR TITLE
Use unicode entities for pseudo elements in demos [skip ci]

### DIFF
--- a/demo/grid-basic-demos.html
+++ b/demo/grid-basic-demos.html
@@ -121,11 +121,11 @@
     </p>
     <style>
       .polymer-binding::before {
-        content: "[[";
+        content: "\005B\005B";
       }
 
       .polymer-binding::after {
-        content: "]]";
+        content: "\005D\005D";
       }
     </style>
     <vaadin-demo-snippet id='grid-basic-demos-basic-binding'>


### PR DESCRIPTION
The demos are processed by `polymer-build` for vaadin.com and current bindings produce the error:
```
error [polymer-expression-parse-error] - Unterminated string constant
```
This should be backported to the `5.2` branch, and needs patch release.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-grid/1499)
<!-- Reviewable:end -->
