### PR TITLE
Unpin webcomponentsjs to test against 1.3.0 and 2.2.0

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -49,7 +49,7 @@
     "wct.conf.js"
   ],
   "devDependencies": {
-    "webcomponentsjs": "1.2.0",
+    "webcomponentsjs": "^1.3.0",
     "web-component-tester": "^6.1.5",
     "iron-test-helpers": "^v2.0.0",
     "paper-input": "^v2.0.0",

--- a/magi-p3-post.json
+++ b/magi-p3-post.json
@@ -1,9 +1,0 @@
-{
-  "files": ["package.json"],
-  "from": [
-    "\"resolutions\": {"
-  ],
-  "to": [
-    "\"resolutions\": {\n\"@webcomponents/webcomponentsjs\": \"2.0.0\","
-  ]
-}


### PR DESCRIPTION
The polyfill has been pinned for reasons, PR is to verify whether tests pass in 1.3.0 and 2.2.0 or not.