### PR TITLE
chore(bower): add src imports to main for modulizer [skip ci]

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -28,6 +28,8 @@
     "vaadin-grid-tree-toggle.html",
     "vaadin-grid-tree-column.html",
     "all-imports.html",
+    "src/vaadin-grid.html",
+    "src/vaadin-grid-column.html",
     "theme/material/vaadin-grid.html",
     "theme/material/vaadin-grid-column.html",
     "theme/material/vaadin-grid-column-group.html",


### PR DESCRIPTION
Turns out this is needed to properly extend grid in vaadin/vaadin-grid-pro#7

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-grid/1516)
<!-- Reviewable:end -->
