### PR TITLE
Remove unnecessary theme variant

### DIFF
--- a/theme/material/vaadin-grid-styles.html
+++ b/theme/material/vaadin-grid-styles.html
@@ -107,7 +107,7 @@
 
       /* Column resizing */
 
-      :host(:not([theme~="column-dividers"])) [part~="cell"]:not([last-frozen]) [part="resize-handle"] {
+      [part~="cell"]:not([last-frozen]) [part="resize-handle"] {
         border-right: 1px solid var(--material-divider-color);
         right: -1px;
       }


### PR DESCRIPTION
The Material theme does not have a `column-dividers` theme variant.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-grid/1520)
<!-- Reviewable:end -->
