### PR TITLE
Improve scrolling performance on Edge

### DIFF
--- a/src/vaadin-grid-scroll-mixin.html
+++ b/src/vaadin-grid-scroll-mixin.html
@@ -52,7 +52,12 @@ This program is available under Apache License Version 2.0, available at https:/
           }
         },
 
-        _rowWithFocusedElement: Element
+        _rowWithFocusedElement: Element,
+
+        _deltaYAcc: {
+          type: Number,
+          value: 0
+        }
 
       };
     }
@@ -102,6 +107,23 @@ This program is available under Apache License Version 2.0, available at https:/
         // Mode 1 == scrolling by lines instead of pixels
         deltaY *= this._physicalAverage;
       }
+
+      if (this._wheelAnimationFrame) {
+        // Skip new wheel events while one is being processed
+        this._deltaYAcc += deltaY;
+        e.preventDefault();
+        return;
+      }
+
+      deltaY += this._deltaYAcc;
+      this._deltaYAcc = 0;
+
+      this._wheelAnimationFrame = true;
+      this._debouncerWheelAnimationFrame = Polymer.Debouncer.debounce(
+        this._debouncerWheelAnimationFrame,
+        Polymer.Async.animationFrame,
+        () => this._wheelAnimationFrame = false
+      );
 
       var momentum = Math.abs(e.deltaX) + Math.abs(deltaY);
 

--- a/src/vaadin-grid-scroll-mixin.html
+++ b/src/vaadin-grid-scroll-mixin.html
@@ -153,9 +153,11 @@ This program is available under Apache License Version 2.0, available at https:/
      * cell content that handles the scroll delta
      */
     _hasScrolledAncestor(el, deltaX, deltaY) {
-      if (this._canScroll(el, deltaX, deltaY)) {
+      if (el.localName === 'vaadin-grid-cell-content') {
+        return false;
+      } else if (this._canScroll(el, deltaX, deltaY)) {
         return true;
-      } else if (el.localName !== 'vaadin-grid-cell-content' && el !== this && el.parentElement) {
+      } else if (el !== this && el.parentElement) {
         return this._hasScrolledAncestor(el.parentElement, deltaX, deltaY);
       }
     }

--- a/src/vaadin-grid-styles.html
+++ b/src/vaadin-grid-styles.html
@@ -187,20 +187,6 @@ This program is available under Apache License Version 2.0, available at https:/
         pointer-events: none;
       }
 
-      [scrolling][safari] #outerscroller,
-      [scrolling][firefox] #outerscroller {
-        pointer-events: auto;
-      }
-
-      [ios] #outerscroller {
-        pointer-events: auto;
-        z-index: -3;
-      }
-
-      [ios][scrolling] #outerscroller {
-        z-index: 0;
-      }
-
       /* Reordering styles */
       :host([reordering]) [part~="cell"] ::slotted(vaadin-grid-cell-content),
       :host([reordering]) [part~="resize-handle"],
@@ -327,6 +313,29 @@ This program is available under Apache License Version 2.0, available at https:/
       }
     </style>
   `);
+
+  const safari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
+  const firefox = navigator.userAgent.toLowerCase().indexOf('firefox') > -1;
+
+  if (safari || firefox) {
+    const scrollingStyles = document.createElement('style');
+    scrollingStyles.textContent = `
+      [scrolling][safari] #outerscroller,
+      [scrolling][firefox] #outerscroller {
+        pointer-events: auto;
+      }
+
+      [ios] #outerscroller {
+        pointer-events: auto;
+        z-index: -3;
+      }
+
+      [ios][scrolling] #outerscroller {
+        z-index: 0;
+      }
+    `;
+    VaadinGridStyles.querySelector('template').content.appendChild(scrollingStyles);
+  }
 
   VaadinGridStyles.register('vaadin-grid-styles');
 </script>

--- a/src/vaadin-grid-styles.html
+++ b/src/vaadin-grid-styles.html
@@ -67,12 +67,6 @@ This program is available under Apache License Version 2.0, available at https:/
         outline: none;
       }
 
-      /* Avoid jumpy headers on Edge & IE */
-      [wheel-scrolling][edge] #table,
-      [wheel-scrolling][ie] #table {
-        z-index: auto;
-      }
-
       #header {
         display: block;
         position: absolute;

--- a/test/scrolling-mode.html
+++ b/test/scrolling-mode.html
@@ -48,6 +48,7 @@
         e.deltaY = deltaY;
         e.deltaX = deltaX;
         getBodyCellContent(grid, 0, 0).dispatchEvent(e);
+        grid._debouncerWheelAnimationFrame.flush();
         return e;
       }
 
@@ -116,6 +117,32 @@
         wheel(1, 0);
         wheel(-1, 0);
         expect(wheel(-100, 0).defaultPrevented).to.be.true;
+      });
+
+      it('should skip a wheel event while processing the previous one', () => {
+        wheel(0, 1);
+        grid._wheelAnimationFrame = true;
+        expect(wheel(0, 1).defaultPrevented).to.be.true;
+        expect(grid.$.table.scrollTop).to.equal(1);
+      });
+
+      it('should accumulate delta Y while wheeling during animation frame', () => {
+        wheel(0, 1);
+        grid._wheelAnimationFrame = true;
+        wheel(0, 1);
+        grid._wheelAnimationFrame = false;
+        wheel(0, 1);
+        expect(grid.$.table.scrollTop).to.equal(3);
+      });
+
+      it('should clear accumulated delta', () => {
+        wheel(0, 1);
+        grid._wheelAnimationFrame = true;
+        wheel(0, 1);
+        grid._wheelAnimationFrame = false;
+        wheel(0, 1);
+        wheel(0, 1);
+        expect(grid.$.table.scrollTop).to.equal(4);
       });
 
       it('should not throw on table wheel', () => {

--- a/test/scrolling-mode.html
+++ b/test/scrolling-mode.html
@@ -186,13 +186,6 @@
         grid.$.table.scrollLeft = 1;
       });
 
-      it('should avoid jumpy headers on Edge while wheel scrolling', () => {
-        grid._edge = true;
-        expect(window.getComputedStyle(grid.$.table).zIndex).not.to.equal('auto');
-        wheel(grid, 0, 0);
-        expect(window.getComputedStyle(grid.$.table).zIndex).to.equal('auto');
-      });
-
       it('should not sync outer scroller on IOS', done => {
         grid._ios = true;
         const spy = sinon.spy(grid.$.outerscroller, 'syncOuterScroller');


### PR DESCRIPTION
Fixes https://github.com/vaadin/vaadin-grid/issues/1249

This PR aims to improve scrolling performance especially on Edge browser. The following changes were made:
1. While wheel scrolling, any wheel events that occur between animation frames don't get immediately processed but their delta is collected to be processed with the wheel event after the next frame.
2. Some browser specific styles, especially those that target `[scrolling]` state, are loaded only for the relevant browsers
3. An optimization style that targets grid in `[wheel-scrolling]` state is removed as it's no longer needed

For comparison, try the following demos (on Edge). Especially the hiccups that occur when scrolling starts should have reduced:
- Before: https://canyon-quality.glitch.me/
- After: https://material-tailor.glitch.me/

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-grid/1562)
<!-- Reviewable:end -->
