### PR TITLE
Use animation frame timing in scroller for pool increase

### DIFF
--- a/src/vaadin-grid-scroller.html
+++ b/src/vaadin-grid-scroller.html
@@ -179,7 +179,7 @@ This program is available under Apache License Version 2.0, available at https:/
         } else if (this._optPhysicalSize !== Infinity) {
           this._debounceIncreasePool = Polymer.Debouncer.debounce(
             this._debounceIncreasePool,
-            Polymer.Async.idlePeriod,
+            Polymer.Async.animationFrame,
             () => {
               this._updateMetrics();
               const remainingPhysicalSize = this._optPhysicalSize - this._physicalSize;


### PR DESCRIPTION
Fix scroller to use animationFrame timing instead of idlePeriod in order to avoid delays when new rows are expected to appear to the viewport. This especially affects mobile browsers.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-grid/1604)
<!-- Reviewable:end -->
