### PR TITLE
Mobile polyfill adjustments

### DIFF
--- a/src/vaadin-grid-drag-and-drop-mixin.html
+++ b/src/vaadin-grid-drag-and-drop-mixin.html
@@ -92,6 +92,13 @@ This program is available under Apache License Version 2.0, available at https:/
         this.$.table.addEventListener('dragover', this._onDragOver.bind(this));
         this.$.table.addEventListener('dragleave', this._onDragLeave.bind(this));
         this.$.table.addEventListener('drop', this._onDrop.bind(this));
+        this.$.table.addEventListener('dragenter', e => {
+          if (this.dropMode) {
+            e.preventDefault();
+            e.stopPropagation();
+          }
+        });
+
       }
 
       _onDragStart(e) {
@@ -122,7 +129,12 @@ This program is available under Apache License Version 2.0, available at https:/
 
           const rowRect = row.getBoundingClientRect();
           if (!window.ShadyDOM) {
-            e.dataTransfer.setDragImage(row, e.clientX - rowRect.left, e.clientY - rowRect.top);
+            if (this._ios) {
+              e.dataTransfer.setDragImage(row);
+            } else {
+              e.dataTransfer.setDragImage(row, e.clientX - rowRect.left, e.clientY - rowRect.top);
+            }
+
           }
 
           let rows = [row];

--- a/test/drag-and-drop.html
+++ b/test/drag-and-drop.html
@@ -44,7 +44,7 @@ describe('drag and drop', () => {
       composed: true
     });
     event.dataTransfer = {
-      setDragImage: () => {},
+      setDragImage: sinon.spy(),
       setData: (type, data) => dragData[type] = data
     };
     draggable.dispatchEvent(event);
@@ -68,6 +68,16 @@ describe('drag and drop', () => {
       composed: true
     });
     draggable.dispatchEvent(event);
+  };
+
+  const fireDragEnter = (draggable = getDraggable(grid)) => {
+    const event = new Event('dragenter', {
+      bubbles: true,
+      cancelable: true,
+      composed: true
+    });
+    draggable.dispatchEvent(event);
+    return event;
   };
 
   const fireDrop = (draggable = getDraggable(grid)) => {
@@ -320,6 +330,20 @@ describe('drag and drop', () => {
         expect(dragData.type).to.eql('text/plain');
       });
 
+      if (!window.ShadyDOM) {
+        it('should genrate drag image with offset', () => {
+          grid._ios = false;
+          const event = fireDragStart();
+          expect(event.dataTransfer.setDragImage.getCall(0).args.length).to.equal(3);
+        });
+
+        it('should genrate drag image without offset', () => {
+          grid._ios = true;
+          const event = fireDragStart();
+          expect(event.dataTransfer.setDragImage.getCall(0).args.length).to.equal(1);
+        });
+      }
+
     });
 
     describe('dragend', () => {
@@ -475,6 +499,28 @@ describe('drag and drop', () => {
         expect(row.hasAttribute('dragover')).to.be.true;
         fireDragLeave();
         expect(row.hasAttribute('dragover')).to.be.false;
+      });
+
+    });
+
+    describe('dragenter', () => {
+
+      // The dragenter event needs to be cancelled to enable the mobile polyfill
+      it('should stop and cancel the native event', () => {
+        grid.dropMode = 'between';
+        const spy = sinon.spy();
+        grid.addEventListener('dragenter', spy);
+        const event = fireDragEnter();
+        expect(spy.called).to.be.false;
+        expect(event.defaultPrevented).to.be.true;
+      });
+
+      it('should not stop and cancel the native event', () => {
+        const spy = sinon.spy();
+        grid.addEventListener('dragenter', spy);
+        const event = fireDragEnter();
+        expect(spy.called).to.be.true;
+        expect(event.defaultPrevented).to.be.false;
       });
 
     });

--- a/theme/lumo/vaadin-grid-styles.html
+++ b/theme/lumo/vaadin-grid-styles.html
@@ -148,7 +148,11 @@
         border-radius: var(--lumo-border-radius-s) 0 0 var(--lumo-border-radius-s);
       }
 
-      [part~="row"][dragstart]:not([dragstart=""])::after {
+      [ios] [part~="row"][dragstart] [part~="cell"] {
+        background: var(--lumo-primary-color-50pct);
+      }
+
+      #scroller:not([ios]) [part~="row"][dragstart]:not([dragstart=""])::after {
         display: block;
         position: absolute;
         left: var(--_grid-drag-start-x);

--- a/theme/material/vaadin-grid-styles.html
+++ b/theme/material/vaadin-grid-styles.html
@@ -184,7 +184,11 @@
         box-shadow: none !important;
       }
 
-      [part~="row"][dragstart]:not([dragstart=""])::after {
+      [ios] [part~="row"][dragstart] [part~="cell"] {
+        background: var(--material-primary-color);
+      }
+
+      #scroller:not([ios]) [part~="row"][dragstart]:not([dragstart=""])::after {
         display: block;
         position: absolute;
         left: var(--_grid-drag-start-x);


### PR DESCRIPTION
On mobile Safari (with the polyfill)
- "dragenter" needs to be canceled in order for the drag operation to take place
- Drag image offsets work differently, they're not needed with the polyfill
- The drag image is merely the box of the dragged row `<tr>`, so it needs a background color in order for it not to be invisible
- The dragged row count indicator isn't included in the drag image, so hide it altogether to avoid fouc

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-grid/1614)
<!-- Reviewable:end -->
