### PR TITLE
test: make tests more reliable with listenOnce

### DIFF
--- a/test/app-localize-behavior.html
+++ b/test/app-localize-behavior.html
@@ -72,7 +72,7 @@
           beforeEach(function(done) {
             container = fixture('grid');
             grid = container.$.grid;
-            container.addEventListener('app-localize-resources-loaded', () => done());
+            listenOnce(container, 'app-localize-resources-loaded', () => done());
           });
 
           it('should localize', () => {

--- a/test/array-data-provider.html
+++ b/test/array-data-provider.html
@@ -238,7 +238,7 @@
           const _warn = console.warn;
           const spy = console.warn = sinon.spy();
 
-          filter.addEventListener('filter-changed', e => {
+          listenOnce(filter, 'filter-changed', e => {
             setTimeout(() => {
               console.warn = _warn;
               expect(spy.called).to.be.true;
@@ -253,7 +253,7 @@
           const _warn = console.warn;
           const spy = console.warn = sinon.spy();
 
-          filter.addEventListener('filter-changed', e => {
+          listenOnce(filter, 'filter-changed', e => {
             setTimeout(() => {
               console.warn = _warn;
               expect(spy.called).to.be.false;
@@ -268,7 +268,7 @@
           const _warn = console.warn;
           const spy = console.warn = sinon.spy();
 
-          filter.addEventListener('filter-changed', e => {
+          listenOnce(filter, 'filter-changed', e => {
             setTimeout(() => {
               console.warn = _warn;
               expect(spy.called).to.be.false;

--- a/test/column-reordering.html
+++ b/test/column-reordering.html
@@ -431,7 +431,7 @@
         });
 
         it('should fire `column-reorder` event with columns', done => {
-          grid.addEventListener('column-reorder', e => {
+          listenOnce(grid, 'column-reorder', e => {
             expect(e.detail.columns.map(column => column.getAttribute('index'))).to.eql(['2', '1', '3', '4']);
             done();
           });

--- a/test/column-resizing.html
+++ b/test/column-resizing.html
@@ -211,7 +211,7 @@
       });
 
       it('should fire column-resize event on column resize', done => {
-        grid.addEventListener('column-resize', (event) => {
+        listenOnce(grid, 'column-resize', (event) => {
           expect(event.detail.resizedColumn).to.equal(grid._getColumns()[0]);
           done();
         });

--- a/test/filtering.html
+++ b/test/filtering.html
@@ -84,7 +84,7 @@
       });
 
       it('should fire `filter-changed` on value change', done => {
-        filter.addEventListener('filter-changed', e => done());
+        listenOnce(filter, 'filter-changed', e => done());
 
         filter.value = 'foo';
       });
@@ -93,12 +93,12 @@
         filter.value = 'foo';
         filter._debouncerFilterChanged.flush();
 
-        filter.addEventListener('filter-changed', e => done());
+        listenOnce(filter, 'filter-changed', e => done());
         filter.path = 'bar';
       });
 
       it('should update value', done => {
-        filter.addEventListener('filter-changed', e => {
+        listenOnce(filter, 'filter-changed', e => {
           expect(filter.value).to.eql('foo');
           done();
         });

--- a/test/outer-scroller.html
+++ b/test/outer-scroller.html
@@ -148,7 +148,7 @@
         });
 
         it('should scroll the target', done => {
-          outerScroller.addEventListener('scroll', () => {
+          listenOnce(outerScroller, 'scroll', () => {
             animationFrameFlush(() => {
               expect(target.scrollLeft).to.equal(100);
               done();
@@ -256,7 +256,7 @@
           });
 
           it('should passtrough pointer events', done => {
-            scroller.addEventListener('mousemove', () => {
+            listenOnce(scroller, 'mousemove', () => {
               expect(outerScrollerAccessible()).to.be.false;
               done();
             });
@@ -265,7 +265,7 @@
           });
 
           it('should not passtrough if and only if scrollbars exist (vertical scrollbar hover)', done => {
-            scroller.addEventListener('mousemove', () => {
+            listenOnce(scroller, 'mousemove', () => {
               expect(outerScrollerAccessible()).to.equal(getScrollbarWidth() > 0);
               done();
             });
@@ -273,7 +273,7 @@
           });
 
           it('should not passtrough if and only if scrollbars exist (horizontal scrollbar hover)', done => {
-            scroller.addEventListener('mousemove', () => {
+            listenOnce(scroller, 'mousemove', () => {
               expect(outerScrollerAccessible()).to.equal(getScrollbarWidth() > 0);
               done();
             });
@@ -282,7 +282,7 @@
 
           it('should not passtrough if hovered after srcoll period', done => {
             grid._scrollHandler();
-            scroller.addEventListener('mousemove', () => {
+            listenOnce(scroller, 'mousemove', () => {
               expect(outerScrollerAccessible()).to.equal(outerScrollerScrollable());
               done();
             });

--- a/test/scrolling-mode.html
+++ b/test/scrolling-mode.html
@@ -191,7 +191,7 @@
         requestAnimationFrame(() => {
           flushGrid(grid);
           const scroller = grid.$.scroller;
-          grid.$.table.addEventListener('scroll', () => {
+          listenOnce(grid.$.table, 'scroll', () => {
             expect(scroller.hasAttribute('scrolling')).to.be.false;
             requestAnimationFrame(() => {
               expect(scroller.hasAttribute('scrolling')).to.be.true;
@@ -205,7 +205,7 @@
       it('should not sync outer scroller on IOS', done => {
         grid._ios = true;
         const spy = sinon.spy(grid.$.outerscroller, 'syncOuterScroller');
-        grid.$.table.addEventListener('scroll', () => {
+        listenOnce(grid.$.table, 'scroll', () => {
           expect(spy.called).to.be.false;
           done();
         });

--- a/test/selecting.html
+++ b/test/selecting.html
@@ -109,7 +109,7 @@
         });
 
         it('should notify', done => {
-          grid.addEventListener('selected-items-changed', () => done());
+          listenOnce(grid, 'selected-items-changed', () => done());
           grid.selectedItems = [cachedItems[1]];
         });
       });

--- a/test/sorting.html
+++ b/test/sorting.html
@@ -123,7 +123,7 @@
         });
 
         it('should fire a sorter-changed event', done => {
-          sorter.addEventListener('sorter-changed', () => done());
+          listenOnce(sorter, 'sorter-changed', () => done());
           sorter.direction = 'asc';
         });
 
@@ -458,7 +458,7 @@
           });
 
           it('should notify direction property change from the internal vaadin-grid-sorter', done => {
-            sortColumn.addEventListener('direction-changed', e => {
+            listenOnce(sortColumn, 'direction-changed', e => {
               expect(e.detail.value).to.equal('desc');
               done();
             });

--- a/test/style-scope.html
+++ b/test/style-scope.html
@@ -174,7 +174,7 @@
 
             expect(window.getComputedStyle(content).color).to.equal('rgb(255, 0, 0)');
 
-            table.addEventListener('scroll', () => {
+            listenOnce(table, 'scroll', () => {
               flushGrid(grid);
               expect(window.getComputedStyle(content).color).to.equal('rgb(255, 0, 0)');
               done();


### PR DESCRIPTION
Prefer to use `listenOnce` helper in tests (instead of `addEventListener` without removing). This might help with the flakyness of grid tests.

Similar change as in https://github.com/vaadin/vaadin-text-field/issues/403 (related discussion: https://vaadin.slack.com/archives/G6QQTHU8Z/p1565167761008900)