### PR TITLE
[Optimization] Delay requestAnimationFrame() to speed large detailsOpenedItems changes

### DIFF
--- a/src/vaadin-grid-row-details-mixin.html
+++ b/src/vaadin-grid-row-details-mixin.html
@@ -81,7 +81,7 @@ This program is available under Apache License Version 2.0, available at https:/
 
         if (this.detailsOpenedItems.length) {
           Array.from(this.$.items.children).forEach((row, item) => {
-            this._toggleDetailsCell(row, item, false);
+            this._toggleDetailsCell(row, item);
           }, this);
           this._update();
         }
@@ -94,10 +94,11 @@ This program is available under Apache License Version 2.0, available at https:/
         return;
       }
       Array.from(this.$.items.children).forEach(row => {
-        this._toggleDetailsCell(row, row._item, false);
+        this._toggleDetailsCell(row, row._item);
         this._a11yUpdateRowDetailsOpened(row, this._isDetailsOpened(row._item));
         this._toggleAttribute('details-opened', this._isDetailsOpened(row._item), row);
       });
+      this._updateDetailsCellHeights();
       requestAnimationFrame(() => this.notifyResize());
     }
 
@@ -108,7 +109,7 @@ This program is available under Apache License Version 2.0, available at https:/
       this._toggleAttribute('frozen', true, cell);
     }
 
-    _toggleDetailsCell(row, item, requestAnimation) {
+    _toggleDetailsCell(row, item) {
       const cell = row.querySelector('[part~="details-cell"]');
       if (!cell) {
         return;
@@ -133,9 +134,6 @@ This program is available under Apache License Version 2.0, available at https:/
           }
 
           Polymer.flush();
-          if (requestAnimation) {
-            requestAnimationFrame(() => this.notifyResize());
-          }
         }
       }
       if (hiddenChanged) {
@@ -145,9 +143,14 @@ This program is available under Apache License Version 2.0, available at https:/
     }
 
     _updateDetailsCellHeights() {
-      Array.from(this.$.items.querySelectorAll('[part~="details-cell"]:not([hidden])')).forEach(cell => {
-        cell.parentElement.style.setProperty('padding-bottom', `${cell.offsetHeight}px`);
-      });
+      const cellArray = Array.from(this.$.items.querySelectorAll('[part~="details-cell"]:not([hidden])'));
+      const celloffsetHeight = [];
+      for (let iter = 0; iter < cellArray.length; iter++) {
+        celloffsetHeight[iter] = cellArray[iter].offsetHeight;
+      }
+      for (let iter = 0; iter < cellArray.length; iter++) {
+        cellArray[iter].parentElement.style.setProperty('padding-bottom', `${celloffsetHeight[iter]}px`);
+      }
     }
 
     _isDetailsOpened(item) {

--- a/src/vaadin-grid-row-details-mixin.html
+++ b/src/vaadin-grid-row-details-mixin.html
@@ -80,7 +80,9 @@ This program is available under Apache License Version 2.0, available at https:/
         }
 
         if (this.detailsOpenedItems.length) {
-          Array.from(this.$.items.children).forEach(this._toggleDetailsCell, this);
+          Array.from(this.$.items.children).forEach((row, item) => {
+            this._toggleDetailsCell(row, item, false);
+          }, this);
           this._update();
         }
       }
@@ -92,10 +94,11 @@ This program is available under Apache License Version 2.0, available at https:/
         return;
       }
       Array.from(this.$.items.children).forEach(row => {
-        this._toggleDetailsCell(row, row._item);
+        this._toggleDetailsCell(row, row._item, false);
         this._a11yUpdateRowDetailsOpened(row, this._isDetailsOpened(row._item));
         this._toggleAttribute('details-opened', this._isDetailsOpened(row._item), row);
       });
+      requestAnimationFrame(() => this.notifyResize());
     }
 
     _configureDetailsCell(cell) {
@@ -105,7 +108,7 @@ This program is available under Apache License Version 2.0, available at https:/
       this._toggleAttribute('frozen', true, cell);
     }
 
-    _toggleDetailsCell(row, item) {
+    _toggleDetailsCell(row, item, requestAnimation) {
       const cell = row.querySelector('[part~="details-cell"]');
       if (!cell) {
         return;
@@ -130,9 +133,9 @@ This program is available under Apache License Version 2.0, available at https:/
           }
 
           Polymer.flush();
-          row.style.setProperty('padding-bottom', `${cell.offsetHeight}px`);
-
-          requestAnimationFrame(() => this.notifyResize());
+          if (requestAnimation) {
+            requestAnimationFrame(() => this.notifyResize());
+          }
         }
       }
       if (hiddenChanged) {

--- a/src/vaadin-grid.html
+++ b/src/vaadin-grid.html
@@ -716,7 +716,7 @@ This program is available under Apache License Version 2.0, available at https:/
         this._a11yUpdateRowLevel(row, model.level);
         this._toggleAttribute('expanded', model.expanded, row);
         if (this._rowDetailsTemplate || this.rowDetailsRenderer) {
-          this._toggleDetailsCell(row, item, true);
+          this._toggleDetailsCell(row, item);
           this._updateDetailsCellHeights();
         }
         this._generateCellClassNames(row, model);
@@ -745,7 +745,6 @@ This program is available under Apache License Version 2.0, available at https:/
       }
 
       _resizeHandler() {
-        this._updateDetailsCellHeights();
         this._accessIronListAPI(super._resizeHandler, true);
         this._updateHeaderFooterMetrics();
       }

--- a/src/vaadin-grid.html
+++ b/src/vaadin-grid.html
@@ -716,7 +716,8 @@ This program is available under Apache License Version 2.0, available at https:/
         this._a11yUpdateRowLevel(row, model.level);
         this._toggleAttribute('expanded', model.expanded, row);
         if (this._rowDetailsTemplate || this.rowDetailsRenderer) {
-          this._toggleDetailsCell(row, item);
+          this._toggleDetailsCell(row, item, true);
+          this._updateDetailsCellHeights();
         }
         this._generateCellClassNames(row, model);
         this._filterDragAndDrop(row, model);


### PR DESCRIPTION
Don't resize on every details row if we are looping. We can wait for the next frame render. This will help when a large amount of rows is added to `detailsOpenedItems`. Can get a 200%+ speed increase for 100+ details rows. Further optimization may be possible by trying to minimize the times that `offsetHeight` is called on cells as that causes a synchronous style/layout recalc, but that's beyond my ability.