### PR TITLE
fix(scrolling): implementation of WheelEvent deltaMode (#1648)

### DIFF
--- a/src/vaadin-grid-scroll-mixin.html
+++ b/src/vaadin-grid-scroll-mixin.html
@@ -64,7 +64,8 @@ This program is available under Apache License Version 2.0, available at https:/
 
     static get observers() {
       return [
-        '_scrollHeightUpdated(_estScrollHeight)'
+        '_scrollHeightUpdated(_estScrollHeight)',
+        '_scrollViewportHeightUpdated(_viewportHeight)'
       ];
     }
 
@@ -75,6 +76,28 @@ This program is available under Apache License Version 2.0, available at https:/
 
     get _scrollTop() {
       return this.$.table.scrollTop;
+    }
+
+    constructor() {
+      super();
+      this._scrollLineHeight = this._getScrollLineHeight();
+    }
+
+    /**
+     * @returns {Number|undefined} - The browser's default font-size in pixels
+     */
+    _getScrollLineHeight() {
+      const el = document.createElement('div');
+      el.style.fontSize = 'initial';
+      el.style.display = 'none';
+      document.body.appendChild(el);
+      const fontSize = window.getComputedStyle(el).fontSize;
+      document.body.removeChild(el);
+      return fontSize ? window.parseInt(fontSize) : undefined;
+    }
+
+    _scrollViewportHeightUpdated(_viewportHeight) {
+      this._scrollPageHeight = _viewportHeight - this.$.header.clientHeight - this.$.footer.clientHeight - this._scrollLineHeight;
     }
 
     ready() {
@@ -109,12 +132,15 @@ This program is available under Apache License Version 2.0, available at https:/
         return;
       }
 
-      var table = this.$.table;
+      const table = this.$.table;
 
-      var deltaY = e.deltaY;
-      if (e.deltaMode === 1) {
-        // Mode 1 == scrolling by lines instead of pixels
-        deltaY *= this._physicalAverage;
+      let deltaY = e.deltaY;
+      if (e.deltaMode === WheelEvent.DOM_DELTA_LINE) {
+        // Scrolling by "lines of text" instead of pixels
+        deltaY *= this._scrollLineHeight;
+      } else if (e.deltaMode === WheelEvent.DOM_DELTA_PAGE) {
+        // Scrolling by "pages" instead of pixels
+        deltaY *= this._scrollPageHeight;
       }
 
       if (this._wheelAnimationFrame) {

--- a/test/scrolling-mode.html
+++ b/test/scrolling-mode.html
@@ -43,14 +43,31 @@
         return window.getComputedStyle(element).position === 'fixed';
       }
 
-      function wheel(deltaX, deltaY) {
+      function wheel(deltaX, deltaY, deltaMode = WheelEvent.DOM_DELTA_PIXEL) {
         const e = new CustomEvent('wheel', {bubbles: true, cancelable: true});
         e.deltaY = deltaY;
         e.deltaX = deltaX;
+        e.deltaMode = deltaMode;
         getBodyCellContent(grid, 0, 0).dispatchEvent(e);
         grid._debouncerWheelAnimationFrame.flush();
         return e;
       }
+
+      it('should scroll by pixels when deltaMode is DOM_DELTA_PIXEL (default)', () => {
+        wheel(0, 1, WheelEvent.DOM_DELTA_PIXEL);
+        expect(grid.$.table.scrollTop).to.equal(1);
+      });
+
+      it('should scroll by lines when deltaMode is DOM_DELTA_LINE', () => {
+        wheel(0, 1, WheelEvent.DOM_DELTA_LINE);
+        expect(grid.$.table.scrollTop).to.equal(16);
+      });
+
+      it('should scroll by pages when deltaMode is DOM_DELTA_PAGE', () => {
+        wheel(0, 1, WheelEvent.DOM_DELTA_PAGE);
+        expect(grid._scrollPageHeight).to.be.above(1);
+        expect(grid.$.table.scrollTop).to.equal(grid._scrollPageHeight);
+      });
 
       it('should have the right amount of scrollbars/scrollers', () => {
         let scrollbars = 0;


### PR DESCRIPTION
Fix implementation of WheelEvent.DOM_DELTA_LINE to scroll by "lines of
text" instead of by average height of grid rows. This old implementation
caused bad UX especially in cases where the grid rows are very tall.

Implement missing mode WheelEvent.DOM_DELTA_PAGE to scroll by "pages"
instead of pixels. When this was this missing, Firefox on Windows was
scrolling only 1 pixel at a time (super slowly) if the user had set
mouse settings to scroll by one page at a time.

It seems that Firefox is the only browser that implements scrolling with
DOM_DELTA_LINE or DOM_DELTA_PAGE modes depending on OS mouse settings.
On macOS Firefox seems to default to scrolling by 1 line at a time in
DOM_DELTA_LINE mode. On Windows it respects the mouse settings which can
be set to scroll by a selected amount of lines at a time or a single
page at a time. On Windows 10 the default is 3 lines at a time. The
height of a single line is defined as the default font size in the
browser settings. This usually defaults to 16px in modern browsers.

Edge, IE11, Chrome and Safari seem to always use DOM_DELTA_PIXEL mode
instead so this fix doesn't affect them.

Fixes #1645