### PR TITLE
Cut down the initial row pool by half (optimize first render)

### DIFF
--- a/src/vaadin-grid-scroller.html
+++ b/src/vaadin-grid-scroller.html
@@ -192,7 +192,7 @@ This program is available under Apache License Version 2.0, available at https:/
 
         if (!this._initialPoolCreated) {
           this._initialPoolCreated = true;
-          super._increasePoolIfNeeded(25);
+          super._increasePoolIfNeeded(12);
         } else if (this._optPhysicalSize !== Infinity) {
           this._debounceIncreasePool = Polymer.Debouncer.debounce(
             this._debounceIncreasePool,

--- a/test/filtering.html
+++ b/test/filtering.html
@@ -171,10 +171,10 @@
         scrollToEnd(grid);
 
         setTimeout(() => {
-          grid._filters[0].value = '99';
+          grid._filters[0].value = '09';
           flushFilters(grid);
           requestAnimationFrame(() => {
-            expect(grid.$.items.querySelectorAll('tr:not([hidden])')).to.have.length(19);
+            expect(grid.$.items.querySelectorAll('tr:not([hidden])')).to.have.length(9);
             done();
           });
         }, 200);

--- a/test/physical-count.html
+++ b/test/physical-count.html
@@ -85,13 +85,13 @@
 
         grid.style.display = 'none';
 
-        expect(grid._physicalItems.length).to.eql(25);
+        expect(grid._physicalItems.length).to.eql(12);
 
         grid.style.display = '';
         grid._resizeHandler();
         flushGrid(grid);
 
-        expect(grid._physicalItems.length).to.be.above(25);
+        expect(grid._physicalItems.length).to.be.above(12);
       });
 
       it('pool should not increase if the scroller has no size', () => {
@@ -106,7 +106,7 @@
         grid._update();
         grid._increasePoolIfNeeded();
 
-        expect(grid._physicalCount).to.equal(25);
+        expect(grid._physicalCount).to.equal(12);
       });
 
       it('should minimize physical count', () => {


### PR DESCRIPTION
The initial physical row count for the grid is 25 by default. If the individual rows are physically higher or the grid's height is lower than normal, the grid viewport (with padding) could easily be covered with fewer physical rows than 25. This PR reduces the initial row count to 12.