### PR TITLE
chore: add sinonjs dependency w/ alternative repo

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -52,6 +52,7 @@
   "devDependencies": {
     "webcomponentsjs": "1.2.0",
     "web-component-tester": "^6.1.5",
+    "sinonjs": "Polymer/sinon.js#^1.14.1",
     "iron-test-helpers": "^v2.0.0",
     "paper-input": "^v2.0.0",
     "paper-checkbox": "^v2.0.0",


### PR DESCRIPTION
Repository github.com/blittle/sinon.js was deleted
And bower install fails
Workaround for Polymer/tools#3488
While Polymer/tools#3489 isn't merged and released