### PR TITLE
Cherry-pick Rerender grid after loading items. (#1694) into 5.5

### DIFF
--- a/src/vaadin-grid-data-provider-mixin.html
+++ b/src/vaadin-grid-data-provider-mixin.html
@@ -154,6 +154,7 @@ This program is available under Apache License Version 2.0, available at https:/
     static get observers() {
       return [
         '_sizeChanged(size)',
+        '_itemIdPathChanged(itemIdPath)',
         '_expandedItemsChanged(expandedItems.*)'
       ];
     }
@@ -231,13 +232,27 @@ This program is available under Apache License Version 2.0, available at https:/
     }
 
     _isExpanded(item) {
-      return this.expandedItems && this._getItemIndexInArray(item, this.expandedItems) > -1;
+      return this.__expandedKeys.has(this.getItemId(item));
     }
 
     _expandedItemsChanged(e) {
+      this.__cacheExpandedKeys();
       this._cache.updateSize();
       this._effectiveSize = this._cache.effectiveSize;
       this._assignModels();
+    }
+
+    _itemIdPathChanged(e) {
+      this.__cacheExpandedKeys();
+    }
+
+    __cacheExpandedKeys() {
+      if (this.expandedItems) {
+        this.__expandedKeys = new Set();
+        this.expandedItems.forEach(item => {
+          this.__expandedKeys.add(this.getItemId(item));
+        });
+      }
     }
 
     /**
@@ -294,11 +309,13 @@ This program is available under Apache License Version 2.0, available at https:/
             }
           }
 
+          const currentItems = Array.from(this.$.items.children).map(row => row._item);
+
           // Populate the cache with new items
           items.forEach((item, itemsIndex) => {
             const itemIndex = page * this.pageSize + itemsIndex;
             cache.items[itemIndex] = item;
-            if (this._isExpanded(item)) {
+            if (this._isExpanded(item) && currentItems.indexOf(item) > -1) {
               // Force synchronous data request for expanded item sub-cache
               cache.ensureSubCacheForScaledIndex(itemIndex);
             }
@@ -308,24 +325,21 @@ This program is available under Apache License Version 2.0, available at https:/
 
           delete cache.pendingRequests[page];
 
-          if (!this._cache.isLoading()) {
-            // All active requests have finished, update the effective size and rows
-            this._setLoading(false);
-            this._cache.updateSize();
-            this._effectiveSize = this._cache.effectiveSize;
+          this._setLoading(false);
+          this._cache.updateSize();
+          this._effectiveSize = this._cache.effectiveSize;
 
-            Array.from(this.$.items.children)
-              .filter(row => !row.hidden)
-              .forEach(row => {
-                const cachedItem = this._cache.getItemForIndex(row.index);
-                if (cachedItem) {
-                  this._toggleAttribute('loading', false, row);
-                  this._updateItem(row, cachedItem);
-                }
-              });
+          Array.from(this.$.items.children)
+            .filter(row => !row.hidden)
+            .forEach(row => {
+              const cachedItem = this._cache.getItemForIndex(row.index);
+              if (cachedItem) {
+                this._toggleAttribute('loading', false, row);
+                this._updateItem(row, cachedItem);
+              }
+            });
 
-            this._increasePoolIfNeeded(0);
-          }
+          this._increasePoolIfNeeded(0);
 
           this.__itemsReceived();
         });

--- a/test/data-provider.html
+++ b/test/data-provider.html
@@ -331,7 +331,7 @@
             expect(grid.dataProvider.getCall(2).args[0].parentItem.value).to.equal('foo7');
           });
 
-          it('should request expanded items first pages before rendering', () => {
+          it('should render when new items are received', () => {
             generateItemIds = true;
             // Reset pageSize to 50 so we get 1 data request / cache level
             grid.pageSize = 50;
@@ -349,10 +349,21 @@
 
             expect(grid.dataProvider.callCount).to.equal(2);
 
-            // Effective size should not have changed in between the data requests
-            expect(renderSpy.called).to.be.false;
-            expect(increasePoolSpy.callCount).to.equal(1);
-            expect(updateItemSpy.callCount).to.be.below(70);
+            // Effective size should change in between the data requests
+            expect(renderSpy.called).to.be.true;
+            expect(increasePoolSpy.callCount).to.above(1);
+            expect(updateItemSpy.callCount).to.be.below(90);
+          });
+
+          it('should keep item expanded on itemIdPath change', () => {
+            grid.dataProvider = finiteDataProvider;
+            expect(grid.itemIdPath).to.be.null;
+            expect(isIndexExpanded(grid, 0)).to.be.false;
+            expandIndex(grid, 0);
+            expect(isIndexExpanded(grid, 0)).to.be.true;
+            grid.itemIdPath = 'id';
+            grid.render();
+            expect(isIndexExpanded(grid, 0)).to.be.true;
           });
 
           ['renderer', 'template'].forEach(type => {


### PR DESCRIPTION
Fixes https://github.com/vaadin/vaadin-grid-flow/issues/476

- Grid is re-rendered after every callback. Undoes #1491
- ensureSubCacheForScaledIndex is only called for items in $.items.children
- _isExpanded now uses a Set to lookup item ids.