### PR TITLE
Cherry-pick to 5.5: Calculate column widths on attach and on column-tree-changed (#1705)

### DIFF
--- a/src/vaadin-grid.html
+++ b/src/vaadin-grid.html
@@ -415,6 +415,11 @@ This program is available under Apache License Version 2.0, available at https:/
         this.addEventListener('animationend', this._onAnimationEnd);
       }
 
+      connectedCallback() {
+        super.connectedCallback();
+        this.recalculateColumnWidths();
+      }
+
       __hasRowsWithClientHeight() {
         return !!Array.from(this.$.items.children).filter(row => row.clientHeight).length;
       }
@@ -717,6 +722,8 @@ This program is available under Apache License Version 2.0, available at https:/
         this._resetKeyboardNavigation();
         this._a11yUpdateHeaderRows();
         this._a11yUpdateFooterRows();
+
+        this.recalculateColumnWidths();
       }
 
       _updateItem(row, item) {

--- a/test/column-auto-width.html
+++ b/test/column-auto-width.html
@@ -39,6 +39,7 @@
     describe('column auto-width', function() {
       let grid;
       let columns;
+      let spy;
       const testItems = [
         {a: 'fubar', b: 'foo', c: 'foo', d: 'a'},
         {a: 'foo', b: 'foo bar baz', c: 'foo', d: 'bar'},
@@ -66,7 +67,7 @@
 
       beforeEach(done => {
         grid = fixture('auto-width');
-        sinon.spy(grid, '_recalculateColumnWidths');
+        spy = sinon.spy(grid, '_recalculateColumnWidths');
         columns = grid.querySelectorAll('vaadin-grid-column');
         // Show the grid and wait for animationend event ("vaadin-grid-appear")
         // to ensure the grid is in a consistent state before starting each test
@@ -92,7 +93,8 @@
             );
           });
         };
-
+        spy.reset();
+        expect(grid._recalculateColumnWidths.called).to.be.false;
         whenColumnWidthsCalculated(() => {
           expectColumnWidthsToBeOk(columns);
           done();
@@ -106,6 +108,8 @@
         requestAnimationFrame(() => {
           grid.hidden = false;
 
+          spy.reset();
+          expect(grid._recalculateColumnWidths.called).to.be.false;
           whenColumnWidthsCalculated(() => {
             expectColumnWidthsToBeOk(columns);
             done();


### PR DESCRIPTION
Fixes vaadin/vaadin-grid-flow#906