### PR TITLE
perf: skip scrollToIndex(0) on _effectiveSize changes (#1722)

### DIFF
--- a/src/vaadin-grid-scroller.html
+++ b/src/vaadin-grid-scroller.html
@@ -131,7 +131,9 @@ This program is available under Apache License Version 2.0, available at https:/
         this._virtualCount = Math.min(this.items.length, size) || 0;
 
         if (this._scrollTop === 0) {
-          this._accessIronListAPI(() => this._scrollToIndex(Math.min(size - 1, fvi)));
+          if (fvi > 0) {
+            this._accessIronListAPI(() => this._scrollToIndex(Math.min(size - 1, fvi)));
+          }
           this._iterateItems((pidx, vidx) => {
             const row = this._physicalItems[pidx];
             if (row.index === fvi) {


### PR DESCRIPTION
scrollToIndex causes two calls to costly _assignModels, even when nothing actually changed.

This causes a lot of extra computation, especially with the Flow component method TreeGrid::expandRecursively,
which repeatedly changes _effectiveSize, which in turn resets the scroll position.