### PR TITLE
Revert "perf: skip scrollToIndex(0) on _effectiveSize changes"

### DIFF
--- a/src/vaadin-grid-scroller.html
+++ b/src/vaadin-grid-scroller.html
@@ -131,9 +131,7 @@ This program is available under Apache License Version 2.0, available at https:/
         this._virtualCount = Math.min(this.items.length, size) || 0;
 
         if (this._scrollTop === 0) {
-          if (fvi > 0) {
-            this._accessIronListAPI(() => this._scrollToIndex(Math.min(size - 1, fvi)));
-          }
+          this._accessIronListAPI(() => this._scrollToIndex(Math.min(size - 1, fvi)));
           this._iterateItems((pidx, vidx) => {
             const row = this._physicalItems[pidx];
             if (row.index === fvi) {


### PR DESCRIPTION
Reverts vaadin/vaadin-grid#1722

#1722 caused a regression in TreeGridHugeTreeNavigationIT.keyboard_navigation, focus is lost while navigating with keyboard.