### PR TITLE
Don't run renderers for missing header/footer cells (#1735)

### DIFF
--- a/src/vaadin-grid-column.html
+++ b/src/vaadin-grid-column.html
@@ -235,10 +235,10 @@ This program is available under Apache License Version 2.0, available at https:/
     }
 
     _renderHeaderAndFooter() {
-      if (this.headerRenderer) {
+      if (this.headerRenderer && this._headerCell) {
         this.__runRenderer(this.headerRenderer, this._headerCell);
       }
-      if (this.footerRenderer) {
+      if (this.footerRenderer && this._footerCell) {
         this.__runRenderer(this.footerRenderer, this._footerCell);
       }
     }

--- a/test/column.html
+++ b/test/column.html
@@ -182,11 +182,21 @@
             expect(spy.called).to.be.false;
           });
 
-          it('should dettach cells from a hidden column', () => {
+          it('should detach cells from a hidden column', () => {
             const childCountBefore = grid.childElementCount;
             column.hidden = true;
             const childCountAfter = grid.childElementCount;
             expect(childCountAfter).to.be.below(childCountBefore);
+          });
+
+          it('should not throw on render with initially hidden columns with header/footerRenderer', () => {
+            const newColumn = document.createElement('vaadin-grid-column');
+            newColumn.hidden = true;
+            newColumn.headerRenderer = () => {};
+            newColumn.footerRenderer = () => {};
+            grid.appendChild(newColumn);
+            flushGrid(grid);
+            expect(() => grid.render()).not.to.throw(Error);
           });
         });
 


### PR DESCRIPTION
This is a cherry-pick to `5.6` branch.