### PR TITLE
fix: use offsetWidth for column auto width calculation (#1745)

### DIFF
--- a/src/vaadin-grid.html
+++ b/src/vaadin-grid.html
@@ -463,8 +463,7 @@ This program is available under Apache License Version 2.0, available at https:/
           col._currentWidth = 0;
           // Note: _allCells only contains cells which are currently rendered in DOM
           col._allCells.forEach(c => {
-            const cellWidth = Math.ceil(c.getBoundingClientRect().width);
-            col._currentWidth = Math.max(col._currentWidth, cellWidth);
+            col._currentWidth = Math.max(col._currentWidth, c.offsetWidth);
           });
         });
         // [write] Set column widths to fit widest measured content

--- a/test/column-auto-width.html
+++ b/test/column-auto-width.html
@@ -84,6 +84,16 @@
         });
       });
 
+      it('should have correct column widths when the grid is visually scaled', done => {
+        grid.style.transform = 'scale(0.5)';
+        grid.items = testItems;
+
+        whenColumnWidthsCalculated(() => {
+          expectColumnWidthsToBeOk(columns);
+          done();
+        });
+      });
+
       it('should have correct column widths when using lazy dataProvider', done => {
         grid.dataProvider = (params, callback) => {
           requestAnimationFrame(() => {


### PR DESCRIPTION
This is a cherry-pick to `5.6` branch for Vaadin 14.2 and 16.