### PR TITLE
Details broken when hidden

### DIFF
--- a/src/vaadin-grid.html
+++ b/src/vaadin-grid.html
@@ -579,7 +579,7 @@ This program is available under Apache License Version 2.0, available at https:/
         }
         columns
           .filter(column => !column.hidden)
-          .forEach((column, index) => {
+          .forEach((column, index, cols) => {
             let cell;
 
             if (section === 'body') {
@@ -593,7 +593,7 @@ This program is available under Apache License Version 2.0, available at https:/
               cell.setAttribute('part', 'cell body-cell');
               row.appendChild(cell);
 
-              if (index === columns.length - 1 && (this._rowDetailsTemplate || this.rowDetailsRenderer)) {
+              if (index === cols.length - 1 && (this._rowDetailsTemplate || this.rowDetailsRenderer)) {
               // Add details cell as last cell to body rows
                 this._detailsCells = this._detailsCells || [];
                 const detailsCell = this._detailsCells.filter(cell => cell._vacant)[0] || this._createCell('td');

--- a/test/column.html
+++ b/test/column.html
@@ -198,7 +198,7 @@
             flushGrid(grid);
             expect(() => grid.render()).not.to.throw(Error);
           });
-          
+
           it('should not remove details row when a column is hidden', () => {
             grid.rowDetailsRenderer = root => root.textContent = 'row-details';
             grid.detailsOpenedItems = [grid._cache.items[0]];

--- a/test/column.html
+++ b/test/column.html
@@ -198,6 +198,15 @@
             flushGrid(grid);
             expect(() => grid.render()).not.to.throw(Error);
           });
+          
+          it('should not remove details row when a column is hidden', () => {
+            grid.rowDetailsRenderer = root => root.textContent = 'row-details';
+            grid.detailsOpenedItems = [grid._cache.items[0]];
+            column.hidden = true;
+            flushGrid(grid);
+            const details = grid.shadowRoot.querySelector('#items [part~="details-cell"]')._content;
+            expect(details.textContent).to.equal('row-details');
+          });
         });
 
         describe('path', () => {


### PR DESCRIPTION
When a column is hidden , whatever is within ` if (index === columns.length - 1 && (this._rowDetailsTemplate || this.rowDetailsRenderer)) ` body is never called.