### PR TITLE
fix: Double-check optimal size before adding new physical rows

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -75,8 +75,8 @@
     "iron-a11y-keys-behavior": "^v2.0.0",
     "iron-a11y-announcer": "^v2.0.0",
     "vaadin-themable-mixin": "vaadin/vaadin-themable-mixin#^1.6.1",
-    "vaadin-checkbox": "vaadin/vaadin-checkbox#^2.4.0-alpha1",
-    "vaadin-text-field": "vaadin/vaadin-text-field#^2.7.0-alpha1",
+    "vaadin-checkbox": "vaadin/vaadin-checkbox#~2.4.0-alpha3",
+    "vaadin-text-field": "vaadin/vaadin-text-field#~2.7.0-alpha4",
     "vaadin-lumo-styles": "vaadin/vaadin-lumo-styles#^1.6.0",
     "vaadin-material-styles": "vaadin/vaadin-material-styles#^1.3.2",
     "vaadin-element-mixin": "vaadin/vaadin-element-mixin#^2.4.1"

--- a/src/vaadin-grid-scroller.html
+++ b/src/vaadin-grid-scroller.html
@@ -203,7 +203,7 @@ This program is available under Apache License Version 2.0, available at https:/
                 estimatedMissingRowCount = Math.max(0, this._effectiveSize - this._physicalCount);
               }
 
-              if (this._physicalSize && estimatedMissingRowCount > 0) {
+              if (this._physicalSize && estimatedMissingRowCount > 0 && this._optPhysicalSize !== Infinity) {
                 super._increasePoolIfNeeded(estimatedMissingRowCount);
                 // Ensure the rows are in order after increasing pool
                 this.__reorderChildNodes();

--- a/test/physical-count.html
+++ b/test/physical-count.html
@@ -140,7 +140,28 @@
         expect(spy).not.to.be.called;
       });
 
+      it('should not add unlimited amount of physical rows', () => {
+        const itemCount = 50;
+        grid.items = buildDataSet(itemCount);
+        flushGrid(grid);
 
+        // Repro for a really special bug:
+
+        // 1: notifyResize will trigger _increasePoolIfNeeded
+        grid.notifyResize();
+        // 2: Hide grid
+        grid.hidden = true;
+        // 3: notifyResize will trigger updateViewportBoundaries which sets _viewPortHeight to 0 because grid is not rendered
+        grid.notifyResize();
+        // 4: Restore grid to render tree
+        grid.hidden = false;
+        // 5: Finally flush the grid, and finish the async callback started at phase 1.
+        // _optPhysicalSize will be Infinity at this point so unlimited amount of rows would get added!
+        // Only thing that limits it is the grid.items count.
+        flushGrid(grid);
+
+        expect(grid.$.items.childElementCount).to.be.below(itemCount);
+      });
     });
   </script>
 


### PR DESCRIPTION
Fixes an issue identified in https://github.com/Artur-/grid-perfo

The issue occurs mainly in Flow apps where the grid might be initialized in one place and then moved under another parent by the router during init. This can produce an uncommon chain of events that causes an issue with an infinite number of physical rows getting created. The attached [test](https://github.com/vaadin/vaadin-grid/pull/1755/files#diff-d7ad21c1b763ad361efa7d9629e4522cR143) tries to replicate the steps.