### PR TITLE
refactor: rename row data to model [skip ci]

### DIFF
--- a/@types/interfaces.d.ts
+++ b/@types/interfaces.d.ts
@@ -3,13 +3,13 @@ import { GridElement } from '../src/vaadin-grid.js';
 
 export type GridBodyRenderer = (
   root: HTMLElement,
-  column: GridColumnElement,
-  rowData: GridRowData
+  column?: GridColumnElement,
+  model?: GridItemModel
 ) => void;
 
 export type GridCellClassNameGenerator = (
   column: GridColumnElement,
-  rowData: GridRowData
+  model: GridItemModel
 ) => void;
 
 export type GridColumnTextAlign = 'start' | 'center' | 'end' | null;
@@ -32,7 +32,7 @@ export type GridDataProvider = (
   callback: GridDataProviderCallback
 ) => void;
 
-export type GridDragAndDropFilter = (rowData: GridRowData) => void;
+export type GridDragAndDropFilter = (model: GridItemModel) => void;
 
 export type GridDropMode = 'between' | 'on-top' | 'on-top-or-between' | 'on-grid';
 
@@ -54,12 +54,12 @@ export interface GridEventContext {
 
 export type GridHeaderFooterRenderer = (
   root: HTMLElement,
-  column: GridColumnElement
+  column?: GridColumnElement
 ) => void;
 
 export type GridItem = string | { [key: string]: unknown };
 
-export interface GridRowData {
+export interface GridItemModel {
   index: number;
   item: GridItem;
   selected?: boolean;
@@ -70,8 +70,8 @@ export interface GridRowData {
 
 export type GridRowDetailsRenderer = (
   root: HTMLElement,
-  grid: GridElement,
-  rowData: GridRowData
+  grid?: GridElement,
+  model?: GridItemModel
 ) => void;
 
 export type GridSorterDirection = 'asc' | 'desc' | null;

--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@
 
   <script>
     // Customize the "Address" column's renderer
-    document.querySelector('#addresscolumn').renderer = (root, grid, rowData) => {
-      root.textContent = `${rowData.item.address.street}, ${rowData.item.address.city}`;
+    document.querySelector('#addresscolumn').renderer = (root, grid, model) => {
+      root.textContent = `${model.item.address.street}, ${model.item.address.city}`;
     };
 
     // Populate the grid with data

--- a/demo/grid-basic-demos.html
+++ b/demo/grid-basic-demos.html
@@ -77,33 +77,33 @@
             const columns = document.querySelectorAll('vaadin-grid-column');
 
             // Use renderers to populate the cell content
-            columns[0].renderer = function(root, column, rowData) {
-              root.textContent = rowData.index;
+            columns[0].renderer = function(root, column, model) {
+              root.textContent = model.index;
             };
             columns[0].headerRenderer = columns[0].footerRenderer = function(root, column) {
               root.textContent = '#';
             };
 
-            columns[1].renderer = function(root, column, rowData) {
-              root.textContent = rowData.item.name.first;
+            columns[1].renderer = function(root, column, model) {
+              root.textContent = model.item.name.first;
             };
             columns[1].headerRenderer = columns[1].footerRenderer = function(root, column) {
               root.textContent = 'First name';
             };
 
-            columns[2].renderer = function(root, column, rowData) {
-              root.textContent = rowData.item.name.last;
+            columns[2].renderer = function(root, column, model) {
+              root.textContent = model.item.name.last;
             };
             columns[2].headerRenderer = columns[2].footerRenderer = function(root, column) {
               root.textContent = 'Last name';
             };
 
-            columns[3].renderer = function(root, column, rowData) {
+            columns[3].renderer = function(root, column, model) {
               // Check if there is a container generated with the previous renderer call to update its content instead of recreation
               if (!root.firstElementChild) {
                 root.innerHTML = '<div style="white-space: normal"></div>';
               }
-              root.firstElementChild.textContent = rowData.item.location.street + ', ' + rowData.item.location.city;
+              root.firstElementChild.textContent = model.item.location.street + ', ' + model.item.location.city;
             };
             columns[3].headerRenderer = columns[3].footerRenderer = function(root, column) {
               root.textContent = 'Address';

--- a/demo/grid-columns-demos.html
+++ b/demo/grid-columns-demos.html
@@ -46,15 +46,15 @@
             const grid = document.querySelector('vaadin-grid');
 
             const columns = document.querySelectorAll('vaadin-grid-column');
-            columns[0].renderer = function(root, column, rowData) {
-              root.textContent = rowData.index;
+            columns[0].renderer = function(root, column, model) {
+              root.textContent = model.index;
             };
-            columns[1].renderer = function(root, column, rowData) {
+            columns[1].renderer = function(root, column, model) {
               if (!root.firstElementChild) {
                 root.innerHTML = '<iron-image width="25" height="25" sizing="cover"></iron-image>';
               }
-              root.firstElementChild.alt = rowData.item.name.first + ' ' + rowData.item.name.last;
-              root.firstElementChild.src = rowData.item.picture.thumbnail;
+              root.firstElementChild.alt = model.item.name.first + ' ' + model.item.name.last;
+              root.firstElementChild.src = model.item.picture.thumbnail;
             };
 
             grid.items = Vaadin.GridDemo.users;
@@ -102,16 +102,16 @@
             document.querySelector('vaadin-grid').items = Vaadin.GridDemo.users;
 
             const columns = document.querySelectorAll('vaadin-grid-column');
-            columns[0].renderer = function(root, column, rowData) {
-              root.textContent = rowData.index;
+            columns[0].renderer = function(root, column, model) {
+              root.textContent = model.index;
             };
 
-            columns[1].renderer = function(root, column, rowData) {
+            columns[1].renderer = function(root, column, model) {
               if (!root.firstElementChild) {
                 root.innerHTML = '<iron-image width="30" height="30" sizing="cover"></iron-image>';
               }
-              root.firstElementChild.alt = rowData.item.name.first + ' ' + rowData.item.name.last;
-              root.firstElementChild.src = rowData.item.picture.thumbnail;
+              root.firstElementChild.alt = model.item.name.first + ' ' + model.item.name.last;
+              root.firstElementChild.src = model.item.picture.thumbnail;
             };
           });
         </script>
@@ -153,16 +153,16 @@
             document.querySelector('vaadin-grid').items = Vaadin.GridDemo.users;
 
             const columns = document.querySelectorAll('vaadin-grid-column');
-            columns[0].renderer = function(root, column, rowData) {
-              root.textContent = rowData.index;
+            columns[0].renderer = function(root, column, model) {
+              root.textContent = model.index;
             };
 
-            columns[1].renderer = function(root, column, rowData) {
+            columns[1].renderer = function(root, column, model) {
               if (!root.firstElementChild) {
                 root.innerHTML = '<iron-image width="30" height="30" sizing="cover"></iron-image>';
               }
-              root.firstElementChild.alt = rowData.item.name.first + ' ' + rowData.item.name.last;
-              root.firstElementChild.src = rowData.item.picture.thumbnail;
+              root.firstElementChild.alt = model.item.name.first + ' ' + model.item.name.last;
+              root.firstElementChild.src = model.item.picture.thumbnail;
             };
           });
         </script>
@@ -196,16 +196,16 @@
             document.querySelector('vaadin-grid').items = Vaadin.GridDemo.users;
 
             const columns = document.querySelectorAll('vaadin-grid-column');
-            columns[0].renderer = function(root, column, rowData) {
-              root.textContent = rowData.index;
+            columns[0].renderer = function(root, column, model) {
+              root.textContent = model.index;
             };
 
-            columns[1].renderer = function(root, column, rowData) {
+            columns[1].renderer = function(root, column, model) {
               if (!root.firstElementChild) {
                 root.innerHTML = '<iron-image width="30" height="30" sizing="cover"></iron-image>';
               }
-              root.firstElementChild.alt = rowData.item.name.first + ' ' + rowData.item.name.last;
-              root.firstElementChild.src = rowData.item.picture.thumbnail;
+              root.firstElementChild.alt = model.item.name.first + ' ' + model.item.name.last;
+              root.firstElementChild.src = model.item.picture.thumbnail;
             };
 
             const contextMenu = document.querySelector('vaadin-context-menu');
@@ -269,16 +269,16 @@
             document.querySelector('vaadin-grid').items = Vaadin.GridDemo.users;
 
             const columns = document.querySelectorAll('vaadin-grid-column');
-            columns[0].renderer = function(root, column, rowData) {
-              root.textContent = rowData.index;
+            columns[0].renderer = function(root, column, model) {
+              root.textContent = model.index;
             };
 
-            columns[1].renderer = function(root, column, rowData) {
+            columns[1].renderer = function(root, column, model) {
               if (!root.firstElementChild) {
                 root.innerHTML = '<iron-image width="30" height="30" sizing="cover"></iron-image>';
               }
-              root.firstElementChild.alt = rowData.item.name.first + ' ' + rowData.item.name.last;
-              root.firstElementChild.src = rowData.item.picture.thumbnail;
+              root.firstElementChild.alt = model.item.name.first + ' ' + model.item.name.last;
+              root.firstElementChild.src = model.item.picture.thumbnail;
             };
           });
         </script>

--- a/demo/grid-crud-demos.html
+++ b/demo/grid-crud-demos.html
@@ -72,7 +72,7 @@
             };
 
             columns[0].renderer =
-            columns[1].renderer = function(root, column, rowData) {
+            columns[1].renderer = function(root, column, model) {
               let textField = root.firstElementChild;
               if (!textField) {
                 textField = window.document.createElement('vaadin-text-field');
@@ -80,17 +80,17 @@
               }
               const property = column == columns[0] ? 'first' : 'last';
               // set an id so as we can find it in the dom when clicking on action buttons.
-              textField.id = property + rowData.index;
-              textField.value = rowData.item.name[property];
+              textField.id = property + model.index;
+              textField.value = model.item.name[property];
               textField.readonly = true;
               textField.setAttribute('focus-target', true);
             };
 
-            columns[2].renderer = function(root, column, rowData) {
-              root.textContent = rowData.item.name.first + '.' + rowData.item.name.last + '@example.com';
+            columns[2].renderer = function(root, column, model) {
+              root.textContent = model.item.name.first + '.' + model.item.name.last + '@example.com';
             };
 
-            columns[3].renderer = function(root, column, rowData) {
+            columns[3].renderer = function(root, column, model) {
               let wrapper = root.firstElementChild;
               if (!wrapper) {
                 root.innerHTML =
@@ -134,7 +134,7 @@
               }
 
               // We reuse rendered content, but maintain a property with the index for actions
-              wrapper.idx = rowData.index;
+              wrapper.idx = model.index;
             };
 
             function updateTextFieldsVisibility(index, editing) {

--- a/demo/grid-drag-and-drop-demos.html
+++ b/demo/grid-drag-and-drop-demos.html
@@ -397,15 +397,15 @@
               cb(items.slice(start, start + params.pageSize), items.length);
             };
 
-            grid.dragFilter = function(rowData) {
+            grid.dragFilter = function(model) {
               // Disallow dragging supervisors
-              return !rowData.item.subordinates;
+              return !model.item.subordinates;
             };
 
-            grid.dropFilter = function(rowData) {
-              return rowData.item.subordinates // Only support dropping on top of supervisors
-                && rowData.item.subordinates.length < 4 // Don't allow more than 4 subordinates
-                && rowData.item.subordinates.indexOf(draggedUser) === -1; // Disallow dropping on own supervisor
+            grid.dropFilter = function(model) {
+              return model.item.subordinates // Only support dropping on top of supervisors
+                && model.item.subordinates.length < 4 // Don't allow more than 4 subordinates
+                && model.item.subordinates.indexOf(draggedUser) === -1; // Disallow dropping on own supervisor
             };
 
             grid.expandedItems = Array.from(supervisors);

--- a/demo/grid-row-details-demos.html
+++ b/demo/grid-row-details-demos.html
@@ -28,7 +28,7 @@
           }
         </style>
 
-        <vaadin-grid aria-label="Toggling and Rendering Details Using JavaScrtipt Example" size="200">
+        <vaadin-grid aria-label="Toggling and Rendering Details Using JavaScript Example" size="200">
           <vaadin-grid-column path="name.first" header="First name"></vaadin-grid-column>
           <vaadin-grid-column path="name.last" header="Last name"></vaadin-grid-column>
           <vaadin-grid-column path="email"></vaadin-grid-column>
@@ -40,7 +40,7 @@
             const grid = document.querySelector('vaadin-grid');
             grid.items = Vaadin.GridDemo.users;
 
-            grid.rowDetailsRenderer = function(root, grid, rowData) {
+            grid.rowDetailsRenderer = function(root, grid, model) {
               if (!root.firstElementChild) {
                 root.innerHTML =
                 '<div class="details">' +
@@ -48,9 +48,9 @@
                 '<small></small></p>' +
                 '</div>';
               }
-              root.firstElementChild.querySelector('img').src = rowData.item.picture.large;
-              root.firstElementChild.querySelector('span').textContent = 'Hi! My name is ' + rowData.item.name.first + '!';
-              root.firstElementChild.querySelector('small').textContent = rowData.item.email;
+              root.firstElementChild.querySelector('img').src = model.item.picture.large;
+              root.firstElementChild.querySelector('span').textContent = 'Hi! My name is ' + model.item.name.first + '!';
+              root.firstElementChild.querySelector('small').textContent = model.item.email;
 
               // If the bounds of the image weren't known/specified beforehand, grid would need to
               // be notified of an asynchronous size change once the image gets loaded.
@@ -60,7 +60,7 @@
             };
 
             const detailsToggleColumn = document.querySelector('#details');
-            detailsToggleColumn.renderer = function(root, column, rowData) {
+            detailsToggleColumn.renderer = function(root, column, model) {
               if (!root.firstElementChild) {
                 root.innerHTML = '<vaadin-checkbox>Show Details</vaadin-checkbox>';
                 root.firstElementChild.addEventListener('checked-changed', function(e) {
@@ -71,7 +71,7 @@
                   }
                 });
               }
-              root.item = rowData.item;
+              root.item = model.item;
               root.firstElementChild.checked = grid.detailsOpenedItems.indexOf(root.item) > -1;
             };
           });

--- a/demo/grid-selection-demos.html
+++ b/demo/grid-selection-demos.html
@@ -87,7 +87,7 @@
       functionality without having to include all the items to <code>selectedItems</code>.
     </p>
     <p>
-      The <code>selected</code> property of the <code>rowData</code> renderer parameter is used
+      The <code>selected</code> property of the <code>model</code> renderer parameter is used
       here to reflect the item's selection state to a checkbox on the corresponding row.
     </p>
     <vaadin-demo-snippet id="grid-selection-demos-custom-select-all-with-data-provider" when-defined="vaadin-grid">
@@ -133,7 +133,7 @@
               checkbox.indeterminate = indeterminate;
             };
 
-            column.renderer = function(cell, column, rowData) {
+            column.renderer = function(cell, column, model) {
               var checkbox = cell.firstElementChild;
               if (!checkbox) {
                 checkbox = window.document.createElement('vaadin-checkbox');
@@ -149,8 +149,8 @@
                 });
                 cell.appendChild(checkbox);
               }
-              checkbox.__item = rowData.item;
-              checkbox.checked = inverted !== rowData.selected;
+              checkbox.__item = model.item;
+              checkbox.checked = inverted !== model.selected;
             };
           });
         </script>
@@ -196,11 +196,11 @@
 
             const columns = document.querySelectorAll('vaadin-grid-column');
 
-            columns[0].renderer = function(root, column, rowData) {
+            columns[0].renderer = function(root, column, model) {
               root.textContent = 'Space activates';
             };
 
-            columns[1].renderer = function(root, column, rowData) {
+            columns[1].renderer = function(root, column, model) {
               root.innerHTML = '';
               const alertBtn = window.document.createElement('button');
               alertBtn.textContent = 'Button';
@@ -213,7 +213,7 @@
               root.appendChild(textNode);
             };
 
-            columns[2].renderer = function(root, column, rowData) {
+            columns[2].renderer = function(root, column, model) {
               root.innerHTML = '';
               const alertBlock = window.document.createElement('div');
               alertBlock.textContent = 'Div';
@@ -226,7 +226,7 @@
               root.appendChild(textNode);
             };
 
-            columns[3].renderer = function(root, column, rowData) {
+            columns[3].renderer = function(root, column, model) {
               root.innerHTML = '';
               const alertBlock = window.document.createElement('div');
               alertBlock.textContent = 'Div with preventDefault';

--- a/demo/grid-styling-demos.html
+++ b/demo/grid-styling-demos.html
@@ -48,8 +48,8 @@
             const grid = document.querySelector('vaadin-grid');
             grid.items = Vaadin.GridDemo.users;
 
-            grid.cellClassNameGenerator = function(column, rowData) {
-              let classes = rowData.item.subscribed == 'true' ? 'subscribed' : 'not-subscribed';
+            grid.cellClassNameGenerator = function(column, model) {
+              let classes = model.item.subscribed == 'true' ? 'subscribed' : 'not-subscribed';
               if (column.path === 'email') {
                 classes += ' email';
               }
@@ -105,7 +105,7 @@
             const checkedItems = [];
 
             const checkColumn = document.querySelector('#check');
-            checkColumn.renderer = function(root, column, rowData) {
+            checkColumn.renderer = function(root, column, model) {
               if (!root.firstElementChild) {
                 root.innerHTML = '<vaadin-checkbox></vaadin-checkbox>';
                 root.firstElementChild.addEventListener('checked-changed', function(e) {
@@ -121,15 +121,15 @@
                   grid.generateCellClassNames();
                 });
               }
-              root.item = rowData.item;
-              root.firstElementChild.checked = checkedItems.indexOf(rowData.item) > -1;
+              root.item = model.item;
+              root.firstElementChild.checked = checkedItems.indexOf(model.item) > -1;
             };
 
-            grid.cellClassNameGenerator = function(column, rowData) {
-              let classes = rowData.item.subscribed == 'true' ? 'subscribed' : 'not-subscribed';
+            grid.cellClassNameGenerator = function(column, model) {
+              let classes = model.item.subscribed == 'true' ? 'subscribed' : 'not-subscribed';
               if (column.path === 'email') {
                 classes += ' email';
-              } else if (column.path === 'name.first' && checkedItems.indexOf(rowData.item) > -1) {
+              } else if (column.path === 'name.first' && checkedItems.indexOf(model.item) > -1) {
                 classes += ' checked';
               }
               return classes;

--- a/demo/grid-tree-demos.html
+++ b/demo/grid-tree-demos.html
@@ -80,7 +80,7 @@
             const grid = document.querySelector('vaadin-grid');
             const column = grid.querySelector('vaadin-grid-column');
 
-            column.renderer = function(root, col, rowData) {
+            column.renderer = function(root, col, model) {
               let toggler = root.firstElementChild;
               if (!toggler) {
                 toggler = window.document.createElement('vaadin-grid-tree-toggle');
@@ -90,11 +90,11 @@
                 root.appendChild(toggler);
               }
 
-              toggler.item = rowData.item;
-              toggler.leaf = !rowData.item.hasChildren;
-              toggler.expanded = rowData.expanded;
-              toggler.level = rowData.level;
-              toggler.textContent = rowData.item.name;
+              toggler.item = model.item;
+              toggler.leaf = !model.item.hasChildren;
+              toggler.expanded = model.expanded;
+              toggler.level = model.level;
+              toggler.textContent = model.item.name;
             };
 
             grid.dataProvider = function(params, callback) {

--- a/gen-tsd.json
+++ b/gen-tsd.json
@@ -35,7 +35,7 @@
       "GridFilter",
       "GridHeaderFooterRenderer",
       "GridItem",
-      "GridRowData",
+      "GridItemModel",
       "GridRowDetailsRenderer",
       "GridSorterDirection",
       "GridSorter"

--- a/src/vaadin-grid-column.html
+++ b/src/vaadin-grid-column.html
@@ -302,10 +302,10 @@ This program is available under Apache License Version 2.0, available at https:/
     }
 
     /** @private */
-    __runRenderer(renderer, cell, rowData) {
+    __runRenderer(renderer, cell, model) {
       const args = [cell._content, this];
-      if (rowData && rowData.item) {
-        args.push(rowData);
+      if (model && model.item) {
+        args.push(model);
       }
       renderer.apply(this, args);
     }
@@ -651,13 +651,13 @@ This program is available under Apache License Version 2.0, available at https:/
            *
            * - `root` The cell content DOM element. Append your content to it.
            * - `column` The `<vaadin-grid-column>` element.
-           * - `rowData` The object with the properties related with
+           * - `model` The object with the properties related with
            *   the rendered item, contains:
-           *   - `rowData.index` The index of the item.
-           *   - `rowData.item` The item.
-           *   - `rowData.expanded` Sublevel toggle state.
-           *   - `rowData.level` Level of the tree represented with a horizontal offset of the toggle button.
-           *   - `rowData.selected` Selected state.
+           *   - `model.index` The index of the item.
+           *   - `model.item` The item.
+           *   - `model.expanded` Sublevel toggle state.
+           *   - `model.level` Level of the tree represented with a horizontal offset of the toggle button.
+           *   - `model.selected` Selected state.
            *
            * @type {GridBodyRenderer | null | undefined}
            */

--- a/src/vaadin-grid-drag-and-drop-mixin.html
+++ b/src/vaadin-grid-drag-and-drop-mixin.html
@@ -52,13 +52,13 @@ This program is available under Apache License Version 2.0, available at https:/
            * if dragging of the row should be disabled.
            *
            * Receives one argument:
-           * - `rowData` The object with the properties related with
+           * - `model` The object with the properties related with
            *   the rendered item, contains:
-           *   - `rowData.index` The index of the item.
-           *   - `rowData.item` The item.
-           *   - `rowData.expanded` Sublevel toggle state.
-           *   - `rowData.level` Level of the tree represented with a horizontal offset of the toggle button.
-           *   - `rowData.selected` Selected state.
+           *   - `model.index` The index of the item.
+           *   - `model.item` The item.
+           *   - `model.expanded` Sublevel toggle state.
+           *   - `model.level` Level of the tree represented with a horizontal offset of the toggle button.
+           *   - `model.selected` Selected state.
            *
            * @type {GridDragAndDropFilter | null | undefined}
            */
@@ -69,13 +69,13 @@ This program is available under Apache License Version 2.0, available at https:/
            * if dropping on the row should be disabled.
            *
            * Receives one argument:
-           * - `rowData` The object with the properties related with
+           * - `model` The object with the properties related with
            *   the rendered item, contains:
-           *   - `rowData.index` The index of the item.
-           *   - `rowData.item` The item.
-           *   - `rowData.expanded` Sublevel toggle state.
-           *   - `rowData.level` Level of the tree represented with a horizontal offset of the toggle button.
-           *   - `rowData.selected` Selected state.
+           *   - `model.index` The index of the item.
+           *   - `model.item` The item.
+           *   - `model.expanded` Sublevel toggle state.
+           *   - `model.level` Level of the tree represented with a horizontal offset of the toggle button.
+           *   - `model.selected` Selected state.
            *
            * @type {GridDragAndDropFilter | null | undefined}
            */
@@ -382,12 +382,12 @@ This program is available under Apache License Version 2.0, available at https:/
 
       /**
        * @param {!HTMLElement} row
-       * @param {!GridRowData} rowData
+       * @param {!GridItemModel} model
        * @protected
        */
-      _filterDragAndDrop(row, rowData) {
-        const dragDisabled = !this.rowsDraggable || (this.dragFilter && !this.dragFilter(rowData));
-        const dropDisabled = !this.dropMode || (this.dropFilter && !this.dropFilter(rowData));
+      _filterDragAndDrop(row, model) {
+        const dragDisabled = !this.rowsDraggable || (this.dragFilter && !this.dragFilter(model));
+        const dropDisabled = !this.dropMode || (this.dropFilter && !this.dropFilter(model));
 
         const draggableElements = window.ShadyDOM
           ? [row]

--- a/src/vaadin-grid-row-details-mixin.html
+++ b/src/vaadin-grid-row-details-mixin.html
@@ -39,10 +39,10 @@ This program is available under Apache License Version 2.0, available at https:/
          *
          * - `root` The row details content DOM element. Append your content to it.
          * - `grid` The `<vaadin-grid>` element.
-         * - `rowData` The object with the properties related with
+         * - `model` The object with the properties related with
          *   the rendered item, contains:
-         *   - `rowData.index` The index of the item.
-         *   - `rowData.item` The item.
+         *   - `model.index` The index of the item.
+         *   - `model.item` The item.
          *
          * @type {GridRowDetailsRenderer | null | undefined}
          */

--- a/src/vaadin-grid-styling-mixin.html
+++ b/src/vaadin-grid-styling-mixin.html
@@ -22,13 +22,13 @@ This program is available under Apache License Version 2.0, available at https:/
          *
          * Receives two arguments:
          * - `column` The `<vaadin-grid-column>` element (`undefined` for details-cell).
-         * - `rowData` The object with the properties related with
+         * - `model` The object with the properties related with
          *   the rendered item, contains:
-         *   - `rowData.index` The index of the item.
-         *   - `rowData.item` The item.
-         *   - `rowData.expanded` Sublevel toggle state.
-         *   - `rowData.level` Level of the tree represented with a horizontal offset of the toggle button.
-         *   - `rowData.selected` Selected state.
+         *   - `model.index` The index of the item.
+         *   - `model.item` The item.
+         *   - `model.expanded` Sublevel toggle state.
+         *   - `model.level` Level of the tree represented with a horizontal offset of the toggle button.
+         *   - `model.selected` Selected state.
          *
          * @type {GridCellClassNameGenerator | null | undefined}
          */
@@ -58,13 +58,13 @@ This program is available under Apache License Version 2.0, available at https:/
     }
 
     /** @private */
-    _generateCellClassNames(row, rowData) {
+    _generateCellClassNames(row, model) {
       Array.from(row.children).forEach(cell => {
         if (cell.__generatedClasses) {
           cell.__generatedClasses.forEach(className => cell.classList.remove(className));
         }
         if (this.cellClassNameGenerator) {
-          const result = this.cellClassNameGenerator(cell._column, rowData);
+          const result = this.cellClassNameGenerator(cell._column, model);
           cell.__generatedClasses = result && result.split(' ').filter(className => className.length > 0);
           if (cell.__generatedClasses) {
             cell.__generatedClasses.forEach(className => cell.classList.add(className));

--- a/src/vaadin-grid.html
+++ b/src/vaadin-grid.html
@@ -104,13 +104,13 @@ This program is available under Apache License Version 2.0, available at https:/
      * For custom content `vaadin-grid-column` element provides you with three types of `renderer` callback functions: `headerRenderer`,
      * `renderer` and `footerRenderer`.
      *
-     * Each of those renderer functions provides `root`, `column`, `rowData` arguments when applicable.
+     * Each of those renderer functions provides `root`, `column`, `model` arguments when applicable.
      * Generate DOM content, append it to the `root` element and control the state
      * of the host element by accessing `column`. Before generating new content,
      * users are able to check if there is already content in `root` for reusing it.
      *
      * Renderers are called on initialization of new column cells and each time the
-     * related row data is updated. DOM generated during the renderer call can be reused
+     * related row model is updated. DOM generated during the renderer call can be reused
      * in the next renderer call and will be provided with the `root` argument.
      * On first call it will be empty.
      *
@@ -132,22 +132,22 @@ This program is available under Apache License Version 2.0, available at https:/
      * columns[0].headerRenderer = function(root) {
      *   root.textContent = 'Name';
      * };
-     * columns[0].renderer = function(root, column, rowData) {
-     *   root.textContent = rowData.item.name;
+     * columns[0].renderer = function(root, column, model) {
+     *   root.textContent = model.item.name;
      * };
      *
      * columns[1].headerRenderer = function(root) {
      *   root.textContent = 'Surname';
      * };
-     * columns[1].renderer = function(root, column, rowData) {
-     *   root.textContent = rowData.item.surname;
+     * columns[1].renderer = function(root, column, model) {
+     *   root.textContent = model.item.surname;
      * };
      *
      * columns[2].headerRenderer = function(root) {
      *   root.textContent = 'Role';
      * };
-     * columns[2].renderer = function(root, column, rowData) {
-     *   root.textContent = rowData.item.role;
+     * columns[2].renderer = function(root, column, model) {
+     *   root.textContent = model.item.role;
      * };
      * ```
      *
@@ -879,7 +879,7 @@ This program is available under Apache License Version 2.0, available at https:/
 
       /**
        * @param {!HTMLTableRowElement} row
-       * @return {!GridRowData}
+       * @return {!GridItemModel}
        * @protected
        */
       __getRowModel(row) {

--- a/test/class-name-generator.html
+++ b/test/class-name-generator.html
@@ -44,39 +44,39 @@
         expect(Array.from(cell.classList)).to.deep.equal(initialCellClasses.concat(expectedClasses));
 
       it('should add classes for cells', () => {
-        grid.cellClassNameGenerator = (column, rowData) => 'foo';
+        grid.cellClassNameGenerator = (column, model) => 'foo';
         assertClassList(firstCell, ['foo']);
         assertClassList(getContainerCell(grid.$.items, 1, 1), ['foo']);
       });
 
       it('should add all classes separated by whitespaces', () => {
-        grid.cellClassNameGenerator = (column, rowData) => 'foo bar baz';
+        grid.cellClassNameGenerator = (column, model) => 'foo bar baz';
         assertClassList(firstCell, ['foo', 'bar', 'baz']);
       });
 
       it('should not remove existing classes', () => {
         firstCell.classList.add('bar');
-        grid.cellClassNameGenerator = (column, rowData) => 'foo';
+        grid.cellClassNameGenerator = (column, model) => 'foo';
         assertClassList(firstCell, ['bar', 'foo']);
       });
 
       it('should remove old generated classes', () => {
-        grid.cellClassNameGenerator = (column, rowData) => 'foo';
-        grid.cellClassNameGenerator = (column, rowData) => 'bar';
+        grid.cellClassNameGenerator = (column, model) => 'foo';
+        grid.cellClassNameGenerator = (column, model) => 'bar';
         assertClassList(firstCell, ['bar']);
       });
 
-      it('should provide column and rowData as parameters', () => {
-        grid.cellClassNameGenerator = (column, rowData) =>
-          rowData.index + ' ' + rowData.item.value + ' ' + column.header;
+      it('should provide column and model as parameters', () => {
+        grid.cellClassNameGenerator = (column, model) =>
+          model.index + ' ' + model.item.value + ' ' + column.header;
         assertClassList(getContainerCell(grid.$.items, 5, 1), ['5', 'foo5', 'col1']);
         assertClassList(getContainerCell(grid.$.items, 10, 0), ['10', 'foo10', 'col0']);
       });
 
       it('should be called for details cell with undefined column', done => {
-        grid.rowDetailsRenderer = (root, grid, rowData) => {};
-        grid.cellClassNameGenerator = (column, rowData) =>
-          rowData.index + ' ' + column;
+        grid.rowDetailsRenderer = (root, grid, model) => {};
+        grid.cellClassNameGenerator = (column, model) =>
+          model.index + ' ' + column;
         requestAnimationFrame(() => {
           assertClassList(getContainerCell(grid.$.items, 0, 2), ['0', 'undefined']);
           done();
@@ -84,7 +84,7 @@
       });
 
       it('should add classes when loading new items', function(done) {
-        grid.cellClassNameGenerator = (column, rowData) => rowData.item.value;
+        grid.cellClassNameGenerator = (column, model) => model.item.value;
         scrollToEnd(grid, () => {
           const rows = getRows(grid.$.items);
           const lastRow = rows[rows.length - 1];
@@ -95,17 +95,17 @@
       });
 
       it('should not throw with falsy return value', () => {
-        expect(() => grid.cellClassNameGenerator = (column, rowData) => {}).not.to.throw(Error);
+        expect(() => grid.cellClassNameGenerator = (column, model) => {}).not.to.throw(Error);
       });
 
       it('should clear generated classes with falsy return value', () => {
-        grid.cellClassNameGenerator = (column, rowData) => 'foo';
-        grid.cellClassNameGenerator = (column, rowData) => {};
+        grid.cellClassNameGenerator = (column, model) => 'foo';
+        grid.cellClassNameGenerator = (column, model) => {};
         assertClassList(firstCell, []);
       });
 
       it('should clear generated classes with falsy property value', () => {
-        grid.cellClassNameGenerator = (column, rowData) => 'foo';
+        grid.cellClassNameGenerator = (column, model) => 'foo';
         grid.cellClassNameGenerator = undefined;
         assertClassList(firstCell, []);
       });
@@ -113,7 +113,7 @@
       ['generateCellClassNames', 'clearCache', 'render'].forEach(funcName => {
         it(`should update classes on ${funcName}`, () => {
           let condition = false;
-          grid.cellClassNameGenerator = (column, rowData) => condition && 'foo';
+          grid.cellClassNameGenerator = (column, model) => condition && 'foo';
           condition = true;
           assertClassList(firstCell, []);
           grid[funcName]();
@@ -131,7 +131,7 @@
       });
 
       it('should not throw with extra whitespace in the result', () => {
-        expect(() => grid.cellClassNameGenerator = (column, rowData) => ' foo  bar ').not.to.throw(Error);
+        expect(() => grid.cellClassNameGenerator = (column, model) => ' foo  bar ').not.to.throw(Error);
         assertClassList(firstCell, ['foo', 'bar']);
       });
     });

--- a/test/column-auto-width.html
+++ b/test/column-auto-width.html
@@ -128,11 +128,11 @@
       });
 
       it('should have correct column widths when using renderers', done => {
-        columns[0].renderer = function(root, column, rowData) {
-          root.textContent = rowData.index;
+        columns[0].renderer = function(root, column, model) {
+          root.textContent = model.index;
         };
-        columns[1].renderer = function(root, column, rowData) {
-          root.innerHTML = `<div style="width: ${10 + 10 * rowData.index}px; height: 25px; outline: 1px solid green;">`;
+        columns[1].renderer = function(root, column, model) {
+          root.innerHTML = `<div style="width: ${10 + 10 * model.index}px; height: 25px; outline: 1px solid green;">`;
         };
         grid.items = testItems;
 
@@ -146,11 +146,11 @@
 
     describe('async recalculateWidth columns', () => {
       let grid;
-    
+
       beforeEach(() => {
         grid = fixture('aysnc-grid');
       });
-    
+
       it('should recalculate column widths when child items loaded', () => {
         const data = [{name: 'foo', children: [{
           name: 'bar'

--- a/test/event-context.html
+++ b/test/event-context.html
@@ -43,7 +43,7 @@
         column = grid.querySelector('vaadin-grid-column');
         columnGroup = grid.querySelector('vaadin-grid-column-group');
 
-        grid.rowDetailsRenderer = function(root, grid, rowData) {
+        grid.rowDetailsRenderer = function(root, grid, model) {
           root.innerHTML = '<div>details</div>';
         };
         grid.openItemDetails(grid.items[0]);

--- a/vaadin-directory-description.md
+++ b/vaadin-directory-description.md
@@ -19,8 +19,8 @@
 
 <script>
   // Customize the "Address" column's renderer
-  document.querySelector('#addresscolumn').renderer = (root, grid, rowData) => {
-    root.textContent = `${rowData.item.address.street}, ${rowData.item.address.city}`;
+  document.querySelector('#addresscolumn').renderer = (root, grid, model) => {
+    root.textContent = `${model.item.address.street}, ${model.item.address.city}`;
   };
 
   // Populate the grid with data


### PR DESCRIPTION
Fixes #1760 

- Renamed all the `rowData` occurrences to `model` as previously agreed
- Updated `column`, `grid` and `model` renderer arguments to be optional