### PR TITLE
fix: don't expand on tree toggle focusable content click

### DIFF
--- a/src/vaadin-grid-active-item-mixin.html
+++ b/src/vaadin-grid-active-item-mixin.html
@@ -82,6 +82,15 @@ This program is available under Apache License Version 2.0, available at https:/
      * @protected
      */
     _isFocusable(target) {
+      return Vaadin.GridElement._isFocusable(target);
+    }
+
+    /**
+     * @param {!Element} target
+     * @return {boolean}
+     * @protected
+     */
+    static _isFocusable(target) {
       if (!target.parentNode) {
         return false;
       }

--- a/src/vaadin-grid-tree-toggle.html
+++ b/src/vaadin-grid-tree-toggle.html
@@ -183,6 +183,9 @@ This program is available under Apache License Version 2.0, available at https:/
         if (this.leaf) {
           return;
         }
+        if (Vaadin.GridElement._isFocusable(e.target)) {
+          return;
+        }
 
         e.preventDefault();
         this.expanded = !this.expanded;

--- a/test/tree-toggle.html
+++ b/test/tree-toggle.html
@@ -24,6 +24,14 @@
     </template>
   </test-fixture>
 
+  <test-fixture id="toggle-with-content">
+    <template>
+      <vaadin-grid-tree-toggle>
+        <input><div>foo</div>
+      </vaadin-grid-tree-toggle>
+    </template>
+  </test-fixture>
+
   <test-fixture id="column">
     <template>
       <vaadin-grid>
@@ -66,13 +74,27 @@
         expect(clickEvent.defaultPrevented).to.be.false;
       });
 
-      it('should toggle on click if not ', () => {
+      it('should toggle on click', () => {
         let clickEvent = click(toggle);
         expect(toggle.expanded).to.be.true;
         expect(clickEvent.defaultPrevented).to.be.true;
 
         clickEvent = click(toggle);
         expect(toggle.expanded).to.be.false;
+        expect(clickEvent.defaultPrevented).to.be.true;
+      });
+
+      it('should not toggle on internal focusable click', () => {
+        toggle = fixture('toggle-with-content');
+        let clickEvent = click(toggle.querySelector('input'));
+        expect(toggle.expanded).to.be.false;
+        expect(clickEvent.defaultPrevented).to.be.false;
+      });
+
+      it('should toggle on internal non-focusable element click', () => {
+        toggle = fixture('toggle-with-content');
+        let clickEvent = click(toggle.querySelector('div'));
+        expect(toggle.expanded).to.be.true;
         expect(clickEvent.defaultPrevented).to.be.true;
       });
 

--- a/test/tree-toggle.html
+++ b/test/tree-toggle.html
@@ -86,14 +86,14 @@
 
       it('should not toggle on internal focusable click', () => {
         toggle = fixture('toggle-with-content');
-        let clickEvent = click(toggle.querySelector('input'));
+        const clickEvent = click(toggle.querySelector('input'));
         expect(toggle.expanded).to.be.false;
         expect(clickEvent.defaultPrevented).to.be.false;
       });
 
       it('should toggle on internal non-focusable element click', () => {
         toggle = fixture('toggle-with-content');
-        let clickEvent = click(toggle.querySelector('div'));
+        const clickEvent = click(toggle.querySelector('div'));
         expect(toggle.expanded).to.be.true;
         expect(clickEvent.defaultPrevented).to.be.true;
       });


### PR DESCRIPTION
Related https://github.com/vaadin/vaadin-grid-flow/issues/1009