### PR TITLE
fix: make GridItem compatible with interfaces

### DIFF
--- a/@types/interfaces.d.ts
+++ b/@types/interfaces.d.ts
@@ -57,7 +57,7 @@ export type GridHeaderFooterRenderer = (
   column?: GridColumnElement
 ) => void;
 
-export type GridItem = string | { [key: string]: unknown };
+export type GridItem = unknown;
 
 export interface GridItemModel {
   index: number;


### PR DESCRIPTION
Set GridItem type to "unknown"

Fix #1764