### PR TITLE
Fix filtering example

### DIFF
--- a/demo/grid-filtering-demos.html
+++ b/demo/grid-filtering-demos.html
@@ -81,9 +81,16 @@
                 grid.size = response.size;
 
                 callback(response.result);
+                grid.scrollToIndex(0);
               };
 
-              const index = params.page * params.pageSize;
+              let index = params.page * params.pageSize;
+              params.filters.forEach(item => {
+                if (item.value.length > 0) {
+                  index = 0;
+                }
+              });
+
               let url = 'https://demo.vaadin.com/demo-data/1.0/people?index=' + index + '&count=' + params.pageSize;
 
               // `params.filters` format: [{path: 'lastName', direction: 'asc'}, ...];


### PR DESCRIPTION
- If there is a new filter with a length longer than 0, index should start from 0 (Previous page size should not have an effect)
- On any change in DataProvider size scroll to the top

Currently,filtering demo for lazy loaded items throws 505, when scrollbar is positioned in the bottom of the grid.

Fixes #1770