### PR TITLE
Fix Javascript error when filtering grid with a large dataset 

### DIFF
--- a/src/vaadin-grid-scroller.html
+++ b/src/vaadin-grid-scroller.html
@@ -270,6 +270,8 @@ This program is available under Apache License Version 2.0, available at https:/
         const oldOffset = this._vidxOffset;
         if (this._accessIronListAPI(() => this._maxScrollTop) && this._virtualCount < this._effectiveSize) {
           this._adjustVirtualIndexOffset(delta);
+        } else {
+            this._vidxOffset = 0;
         }
         if (this._vidxOffset !== oldOffset) {
           this._update();

--- a/src/vaadin-grid-scroller.html
+++ b/src/vaadin-grid-scroller.html
@@ -271,7 +271,7 @@ This program is available under Apache License Version 2.0, available at https:/
         if (this._accessIronListAPI(() => this._maxScrollTop) && this._virtualCount < this._effectiveSize) {
           this._adjustVirtualIndexOffset(delta);
         } else {
-            this._vidxOffset = 0;
+          this._vidxOffset = 0;
         }
         if (this._vidxOffset !== oldOffset) {
           this._update();

--- a/test/filtering-huge-grid.html
+++ b/test/filtering-huge-grid.html
@@ -1,0 +1,122 @@
+<!doctype html>
+
+<html>
+
+<head>
+  <meta charset="UTF-8">
+  <title>filtering huge grid test</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+
+  <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+  <script src="../../web-component-tester/browser.js"></script>
+  <link rel="import" href="../../test-fixture/test-fixture.html">
+
+  <link rel="import" href="helpers.html">
+
+  <link rel="import" href="../vaadin-grid.html">
+  <link rel="import" href="../vaadin-grid-column.html">
+  <link rel="import" href="../vaadin-grid-filter.html">
+</head>
+
+<body>
+
+  <dom-module id="x-grid">
+    <template>
+      <style>
+        .item {
+          height: 30px;
+        }
+
+        vaadin-grid-cell-content {
+          /* Override Lumo theme */
+          padding: 0 !important;
+        }
+      </style>
+      <vaadin-grid id="grid" style="height: 300px;">
+        <vaadin-grid-column>
+          <template class="header">
+            <div>Value</div>
+            <vaadin-grid-filter path="value">
+            </vaadin-grid-filter>
+          </template>
+          <template>[[item.value]]</template>
+        </vaadin-grid-column>
+      </vaadin-grid>
+    </template>
+    <script>
+      customElements.whenDefined('vaadin-grid').then(() => {
+        Polymer({
+          is: 'x-grid'
+        });
+      });
+    </script>
+  </dom-module>
+
+  <test-fixture id="table">
+    <template>
+      <x-grid></x-grid>
+    </template>
+  </test-fixture>
+
+  <script>
+
+    describe('filtering', function() {
+      let container, grid, filter;
+      const maxgridsize = 300000;
+      this.timeout(3000000);
+
+      before(done => ensureDefined('x-grid', done));
+
+      describe('items', () => {
+        beforeEach(done => {
+          container = fixture('table');
+          grid = container.$.grid;
+          grid.size = maxgridsize;
+          grid.dataProvider = (params, callback) => {
+            let numberOfElements = maxgridsize;
+            params.filters.forEach(function(filter) {
+              if (isNaN(filter.value)) {
+                numberOfElements = maxgridsize;
+              } else {
+                numberOfElements = filter.value;
+              }
+            });
+            grid.size = numberOfElements;
+            var response = [];
+            for (var i = 0; i <= params.pageSize; i++) {
+              var element = params.page * params.pageSize + i;
+              if (element < grid.size) {
+                response.push({value: 'item' + element});
+              }
+            }
+            callback(response);
+          };
+          expect(getCellContent(getFirstVisibleItem(grid)).textContent).to.contain('item0');
+          done();
+
+        });
+
+        it('should be able to manually scroll to the bottom', done => {
+          grid.scrollToIndex(maxgridsize);
+          expect(getCellContent(getFirstVisibleItem(grid)).textContent).to.contain('item299975');
+
+          filter = getHeaderCellContent(grid, 0, 0).querySelector('vaadin-grid-filter');
+          const filterTextField = filter.$.filter;
+
+          listenOnce(filter, 'filter-changed', e => {
+            expect(filter.value).to.eql('1');
+            this.timeout(() => {
+              expect(getCellContent(getFirstVisibleItem(grid)).textContent).to.contain('item0');
+              done();
+            }, 1);
+
+          });
+          filterTextField.value = '1';
+        });
+      });
+    });
+  </script>
+
+</body>
+
+</html>

--- a/test/filtering-huge-grid.html
+++ b/test/filtering-huge-grid.html
@@ -4,7 +4,7 @@
 
 <head>
   <meta charset="UTF-8">
-  <title>filtering huge grid test</title>
+  <title>Filtering huge grid test</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
 
   <script src="../../webcomponentsjs/webcomponents-lite.js"></script>

--- a/test/filtering-huge-grid.html
+++ b/test/filtering-huge-grid.html
@@ -62,8 +62,7 @@
 
     describe('filtering', function() {
       let container, grid, filter;
-      const maxgridsize = 300000;
-      this.timeout(3000000);
+      const maxgridsize = 150000;
 
       before(done => ensureDefined('x-grid', done));
 
@@ -91,25 +90,23 @@
             }
             callback(response);
           };
-          expect(getCellContent(getFirstVisibleItem(grid)).textContent).to.contain('item0');
           done();
-
         });
 
         it('should be able to manually scroll to the bottom', done => {
+          expect(getCellContent(getFirstVisibleItem(grid)).textContent).to.contain('item0');
           grid.scrollToIndex(maxgridsize);
-          expect(getCellContent(getFirstVisibleItem(grid)).textContent).to.contain('item299975');
+          expect(getCellContent(getFirstVisibleItem(grid)).textContent).to.contain('item149975');
 
           filter = getHeaderCellContent(grid, 0, 0).querySelector('vaadin-grid-filter');
           const filterTextField = filter.$.filter;
 
           listenOnce(filter, 'filter-changed', e => {
             expect(filter.value).to.eql('1');
-            this.timeout(() => {
+            setTimeout(() => {
               expect(getCellContent(getFirstVisibleItem(grid)).textContent).to.contain('item0');
               done();
-            }, 1);
-
+            });
           });
           filterTextField.value = '1';
         });

--- a/test/test-suites.js
+++ b/test/test-suites.js
@@ -36,7 +36,8 @@ window.VaadinGridSuites = [
   'sorting.html',
   'style-scope.html',
   'templates.html',
-  'renderers.html'
+  'renderers.html',
+  'filtering-huge-grid.html'
 ];
 
 if (isPolymer2) {


### PR DESCRIPTION
Here is a change for the grid to reset the _vidxOffset when the _effectiveSize is less than virtual count.

It should fix this ticket:
https://github.com/vaadin/vaadin-grid-flow/issues/1053

