### PR TITLE
perf: Debounce effective size update

### DIFF
--- a/src/vaadin-grid-data-provider-mixin.html
+++ b/src/vaadin-grid-data-provider-mixin.html
@@ -370,6 +370,7 @@ This program is available under Apache License Version 2.0, available at https:/
           delete cache.pendingRequests[page];
 
           if (!this._cache.isLoading()) {
+            // All active requests have finished, update the effective size and rows
             this._setLoading(false);
             this._cache.updateSize();
             this._effectiveSize = this._cache.effectiveSize;

--- a/src/vaadin-grid-data-provider-mixin.html
+++ b/src/vaadin-grid-data-provider-mixin.html
@@ -369,21 +369,23 @@ This program is available under Apache License Version 2.0, available at https:/
 
           delete cache.pendingRequests[page];
 
-          this._setLoading(false);
-          this._cache.updateSize();
-          this._effectiveSize = this._cache.effectiveSize;
+          if (!this._cache.isLoading()) {
+            this._setLoading(false);
+            this._cache.updateSize();
+            this._effectiveSize = this._cache.effectiveSize;
 
-          Array.from(this.$.items.children)
-            .filter(row => !row.hidden)
-            .forEach(row => {
-              const cachedItem = this._cache.getItemForIndex(row.index);
-              if (cachedItem) {
-                this._toggleAttribute('loading', false, row);
-                this._updateItem(row, cachedItem);
-              }
-            });
+            Array.from(this.$.items.children)
+              .filter(row => !row.hidden)
+              .forEach(row => {
+                const cachedItem = this._cache.getItemForIndex(row.index);
+                if (cachedItem) {
+                  this._toggleAttribute('loading', false, row);
+                  this._updateItem(row, cachedItem);
+                }
+              });
 
-          this._increasePoolIfNeeded(0);
+            this._increasePoolIfNeeded(0);
+          }
 
           this.__itemsReceived();
         });

--- a/src/vaadin-grid-data-provider-mixin.html
+++ b/src/vaadin-grid-data-provider-mixin.html
@@ -369,8 +369,8 @@ This program is available under Apache License Version 2.0, available at https:/
 
           delete cache.pendingRequests[page];
 
-          this._debouncerApplyNewData = Polymer.Debouncer.debounce(
-            this._debouncerApplyNewData,
+          this._debouncerApplyCachedData = Polymer.Debouncer.debounce(
+            this._debouncerApplyCachedData,
             Polymer.Async.timeOut.after(0),
             () => {
               this._setLoading(false);
@@ -392,7 +392,7 @@ This program is available under Apache License Version 2.0, available at https:/
           );
 
           if (!this._cache.isLoading()) {
-            this._debouncerApplyNewData.flush();
+            this._debouncerApplyCachedData.flush();
           }
 
           this.__itemsReceived();

--- a/src/vaadin-grid-data-provider-mixin.html
+++ b/src/vaadin-grid-data-provider-mixin.html
@@ -369,23 +369,30 @@ This program is available under Apache License Version 2.0, available at https:/
 
           delete cache.pendingRequests[page];
 
+          this._debouncerApplyNewData = Polymer.Debouncer.debounce(
+            this._debouncerApplyNewData,
+            Polymer.Async.timeOut.after(0),
+            () => {
+              this._setLoading(false);
+              this._cache.updateSize();
+              this._effectiveSize = this._cache.effectiveSize;
+
+              Array.from(this.$.items.children)
+                .filter(row => !row.hidden)
+                .forEach(row => {
+                  const cachedItem = this._cache.getItemForIndex(row.index);
+                  if (cachedItem) {
+                    this._toggleAttribute('loading', false, row);
+                    this._updateItem(row, cachedItem);
+                  }
+                });
+
+              this._increasePoolIfNeeded(0);
+            }
+          );
+
           if (!this._cache.isLoading()) {
-            // All active requests have finished, update the effective size and rows
-            this._setLoading(false);
-            this._cache.updateSize();
-            this._effectiveSize = this._cache.effectiveSize;
-
-            Array.from(this.$.items.children)
-              .filter(row => !row.hidden)
-              .forEach(row => {
-                const cachedItem = this._cache.getItemForIndex(row.index);
-                if (cachedItem) {
-                  this._toggleAttribute('loading', false, row);
-                  this._updateItem(row, cachedItem);
-                }
-              });
-
-            this._increasePoolIfNeeded(0);
+            this._debouncerApplyNewData.flush();
           }
 
           this.__itemsReceived();

--- a/test/data-provider.html
+++ b/test/data-provider.html
@@ -472,6 +472,60 @@
                 expect(grid._cache.getItemForIndex(i)).to.deep.equal({level: 0, value: `foo${i}`});
               }
             });
+
+            it('should not render synchronously until all data requests have finished', done => {
+              generateItemIds = true;
+              grid.itemIdPath = 'id';
+
+              grid.dataProvider = (params, callback) => {
+                if (!params.parentItem) {
+                  // Resolve normally for root level items
+                  finiteDataProvider(params, callback);
+                } else {
+                  if (params.parentItem.value === 'foo0' && params.page === 0) {
+                    // Resolve asynchronoysly for the first expanded item only
+                    setTimeout(() => {
+                      finiteDataProvider(params, callback);
+                      // Only the root-level items (10) should be rendered at this point even though the
+                      // data request for the first expanded item resolved
+                      expect(grid._effectiveSize).to.equal(10);
+                      done();
+                    }, 0);
+                  }
+                }
+              };
+
+              expandIndex(grid, 0);
+              expandIndex(grid, 1);
+            });
+
+            it('should render asynchronously even if all data requests have not finished', (done) => {
+              generateItemIds = true;
+              grid.itemIdPath = 'id';
+
+              grid.dataProvider = (params, callback) => {
+                if (!params.parentItem) {
+                  // Resolve normally for root level items
+                  finiteDataProvider(params, callback);
+                } else {
+                  if (params.parentItem.value === 'foo0' && params.page === 0) {
+                    // Resolve asynchronoysly for the first expanded item only
+                    setTimeout(() => {
+                      finiteDataProvider(params, callback);
+                      flushGrid(grid);
+                      // The root-level items (10) and the first child item children (10), 20 in total,
+                      // should be rendered at this point even though the data request for the second expanded
+                      // item hasn't still been resolved
+                      expect(grid._effectiveSize).to.equal(20);
+                      done();
+                    }, 0);
+                  }
+                }
+              };
+
+              expandIndex(grid, 0);
+              expandIndex(grid, 1);
+            });
           });
 
           it('should increase full size', () => {

--- a/test/helpers.html
+++ b/test/helpers.html
@@ -44,8 +44,8 @@
     if (grid._debouncerHiddenChanged) {
       grid._debouncerHiddenChanged.flush();
     }
-    if (grid._debouncerApplyNewData) {
-      grid._debouncerApplyNewData.flush();
+    if (grid._debouncerApplyCachedData) {
+      grid._debouncerApplyCachedData.flush();
     }
   };
 

--- a/test/helpers.html
+++ b/test/helpers.html
@@ -44,6 +44,9 @@
     if (grid._debouncerHiddenChanged) {
       grid._debouncerHiddenChanged.flush();
     }
+    if (grid._debouncerApplyNewData) {
+      grid._debouncerApplyNewData.flush();
+    }
   };
 
   window.getCell = (grid, index) => {


### PR DESCRIPTION
The change makes the grid to not update its `_effectiveSize` on every data provider callback but defer the change until all the requests have finished.

This change together with https://github.com/vaadin/vaadin-grid-flow/pull/1084 should have a positive impact especially on TreeGrid performance.

Related to https://github.com/vaadin/vaadin-grid-flow/issues/802