### PR TITLE
fix: workaround a Safari sticky positioning issue with disappearing header

### DIFF
--- a/src/vaadin-grid-scroll-mixin.html
+++ b/src/vaadin-grid-scroll-mixin.html
@@ -321,6 +321,14 @@ This program is available under Apache License Version 2.0, available at https:/
           body.insertBefore(items[i], items[0]);
         }
       }
+
+      // Due to a rendering bug, reordering the rows can make the sticky header disappear on Safari
+      // if the grid is used inside of a flex box. This is a workaround for the issue.
+      if (this._safari) {
+        const {transform} = this.$.header.style;
+        this.$.header.style.transform = '';
+        setTimeout(() => this.$.header.style.transform = transform);
+      }
     }
 
     /** @protected */

--- a/src/vaadin-grid.html
+++ b/src/vaadin-grid.html
@@ -774,6 +774,18 @@ This program is available under Apache License Version 2.0, available at https:/
             this.$.items.style.paddingBottom = `${this.$.footer.offsetHeight}px`;
           }
         }
+
+        if (this._ios) {
+          const isOldIOS = !window.CSS.supports('position', 'sticky');
+          if (isOldIOS) {
+            // Due to a rendering bug, the sticky header may disappear on an older iOS (10-12) Safari
+            // if the grid is used inside of a flex box. This is a workaround for the issue.
+            this.$.table.style.height = '';
+            this.$.table.style.minHeight = '100%';
+            this.$.table.style.maxHeight = '100%';
+            setTimeout(() => this.$.table.style.height = `${this.$.scroller.offsetHeight}px`);
+          }
+        }
       }
 
       /**

--- a/test/basic.html
+++ b/test/basic.html
@@ -352,6 +352,15 @@
             expect(grid.$.scroller.getBoundingClientRect().width).to.be.closeTo(300 - 2, 1);
           });
 
+          it('should have a visible header after row reorder', () => {
+            grid.querySelector('vaadin-grid-column').header = 'header';
+            grid.scrollToIndex(300);
+            flushGrid(grid);
+            const {left, top} = grid.getBoundingClientRect();
+            const cell = grid._cellFromPoint(left + 1, top + 1);
+            expect(grid.$.header.contains(cell)).to.be.true;
+          });
+
           // Skip this test on iOS 10 since there Safari has a bug that makes this fail (works in iOS 9, 11 and 12)
           (/iPhone OS 10_/.test(navigator.userAgent) ? it.skip : it)('should stretch height', () => {
             expect(grid.getBoundingClientRect().height).to.be.closeTo(200, 1);

--- a/test/basic.html
+++ b/test/basic.html
@@ -352,13 +352,16 @@
             expect(grid.$.scroller.getBoundingClientRect().width).to.be.closeTo(300 - 2, 1);
           });
 
-          it('should have a visible header after row reorder', () => {
+          it('should have a visible header after row reorder', done => {
             grid.querySelector('vaadin-grid-column').header = 'header';
             grid.scrollToIndex(300);
-            flushGrid(grid);
-            const {left, top} = grid.getBoundingClientRect();
-            const cell = grid._cellFromPoint(left + 1, top + 1);
-            expect(grid.$.header.contains(cell)).to.be.true;
+            setTimeout(() => {
+              flushGrid(grid);
+              const {left, top} = grid.getBoundingClientRect();
+              const cell = grid._cellFromPoint(left + 1, top + 1);
+              expect(grid.$.header.contains(cell)).to.be.true;
+              done();
+            });
           });
 
           // Skip this test on iOS 10 since there Safari has a bug that makes this fail (works in iOS 9, 11 and 12)


### PR DESCRIPTION
![disappearing-grid-header](https://user-images.githubusercontent.com/1222264/93898251-adbc2180-fcfb-11ea-89cd-51674089340a.gif)
