### PR TITLE
Give user choice to supply a custom sorting function

### DIFF
--- a/src/vaadin-grid-array-data-provider-mixin.html
+++ b/src/vaadin-grid-array-data-provider-mixin.html
@@ -119,9 +119,9 @@ This program is available under Apache License Version 2.0, available at https:/
     _multiSort(a, b) {
       return this._sorters.map(sort => {
         if (sort.direction === 'asc') {
-          return this._compare(Polymer.Base.get(sort.path, a), Polymer.Base.get(sort.path, b));
+          return sort.cmp ? sort.cmp(a, b) : this._compare(Base.get(sort.path, a), Base.get(sort.path, b));
         } else if (sort.direction === 'desc') {
-          return this._compare(Polymer.Base.get(sort.path, b), Polymer.Base.get(sort.path, a));
+          return sort.cmp ? sort.cmp (b, a) : this._compare(Base.get(sort.path, b), Base.get(sort.path, a));
         }
         return 0;
       }).reduce((p, n) => {

--- a/src/vaadin-grid-array-data-provider-mixin.html
+++ b/src/vaadin-grid-array-data-provider-mixin.html
@@ -119,9 +119,9 @@ This program is available under Apache License Version 2.0, available at https:/
     _multiSort(a, b) {
       return this._sorters.map(sort => {
         if (sort.direction === 'asc') {
-          return sort.cmp ? sort.cmp(a, b) : this._compare(Base.get(sort.path, a), Base.get(sort.path, b));
+          return sort.cmp ? sort.cmp(a, b) : this._compare(Polymer.Base.get(sort.path, a), Polymer.Base.get(sort.path, b));
         } else if (sort.direction === 'desc') {
-          return sort.cmp ? sort.cmp (b, a) : this._compare(Base.get(sort.path, b), Base.get(sort.path, a));
+          return sort.cmp ? sort.cmp (b, a) : this._compare(Polymer.Base.get(sort.path, b), Polymer.Base.get(sort.path, a));
         }
         return 0;
       }).reduce((p, n) => {

--- a/src/vaadin-grid-array-data-provider-mixin.html
+++ b/src/vaadin-grid-array-data-provider-mixin.html
@@ -121,7 +121,7 @@ This program is available under Apache License Version 2.0, available at https:/
         if (sort.direction === 'asc') {
           return sort.cmp ? sort.cmp(a, b) : this._compare(Polymer.Base.get(sort.path, a), Polymer.Base.get(sort.path, b));
         } else if (sort.direction === 'desc') {
-          return sort.cmp ? sort.cmp (b, a) : this._compare(Polymer.Base.get(sort.path, b), Polymer.Base.get(sort.path, a));
+          return sort.cmp ? sort.cmp(b, a) : this._compare(Polymer.Base.get(sort.path, b), Polymer.Base.get(sort.path, a));
         }
         return 0;
       }).reduce((p, n) => {

--- a/src/vaadin-grid-sorter.html
+++ b/src/vaadin-grid-sorter.html
@@ -132,7 +132,7 @@ This program is available under Apache License Version 2.0, available at https:/
             * A custom function to use when sorting the data.
             * Takes two arguments which are items being passed to the grid.
             */
-            cmp : {
+            cmp: {
               type: Function,
               value: undefined
             },

--- a/src/vaadin-grid-sorter.html
+++ b/src/vaadin-grid-sorter.html
@@ -128,7 +128,14 @@ This program is available under Apache License Version 2.0, available at https:/
               notify: true,
               value: null
             },
-
+            /**
+            * A custom function to use when sorting the data.
+            * Takes two arguments which are items being passed to the grid.
+            */
+            cmp : {
+              type: Function,
+              value: undefined
+            },
             /**
              * @type {number | null}
              * @protected


### PR DESCRIPTION
This aims to allow a user to use his own custom comparison functions to sort the data in a vaadin-grid. The function should be supplied to <vaadin-grid-sorter> eg:
```
<vaadin-checkbox>Enable Multi-Sorting</vaadin-checkbox>

<vaadin-grid aria-label="Sorting Example">
  <vaadin-grid-column path="name.first" id="firstnamecolumn"></vaadin-grid-column>
  <vaadin-grid-column path="name.last" id="lastnamecolumn"></vaadin-grid-column>
  <vaadin-grid-column path="email"></vaadin-grid-column>
</vaadin-grid>

<script>
   function customSort(a, b) {
      // example for case insensitive sorting
      // a and b are instances of elements from items array
       return a.name.first.localeCompare(b.name.first, 'en', {sensitivity:"base"});
   }
  customElements.whenDefined('vaadin-grid').then(function() {
    const grid = document.querySelector('vaadin-grid');
    grid.items = Vaadin.GridDemo.users;

    const checkBox = document.querySelector('vaadin-checkbox');
    checkBox.addEventListener('checked-changed', function(event) {
      grid.multiSort = event.detail.value;
    });

    grid.querySelector('#firstnamecolumn').headerRenderer = function(root) {
      root.innerHTML = '<vaadin-grid-sorter path="name.first" cmp="customSort">First name</vaadin-grid-sorter>';
    };

    grid.querySelector('#lastnamecolumn').headerRenderer = function(root) {
      root.innerHTML = '<vaadin-grid-sorter path="name.last" direction="asc">Last name</vaadin-grid-sorter>';
    };
  });
</script>
```