### PR TITLE
ci: support skipping, ignore master [skip ci]

### DIFF
--- a/.github/workflows/sauce-p2-desktop.yml
+++ b/.github/workflows/sauce-p2-desktop.yml
@@ -1,10 +1,14 @@
 name: sauce-p2-desktop
 
-on: [push]
+on:
+  push:
+    branches-ignore:
+      - 'master'
 
 jobs:
   tests:
     runs-on: ubuntu-latest
+    if: "! contains(toJSON(github.event.commits.*.message), '[skip ci]')"
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/sauce-p2-mobile.yml
+++ b/.github/workflows/sauce-p2-mobile.yml
@@ -1,10 +1,14 @@
 name: sauce-p2-mobile
 
-on: [push]
+on:
+  push:
+    branches-ignore:
+      - 'master'
 
 jobs:
   tests:
     runs-on: ubuntu-latest
+    if: "! contains(toJSON(github.event.commits.*.message), '[skip ci]')"
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/sauce-p3-desktop.yml
+++ b/.github/workflows/sauce-p3-desktop.yml
@@ -1,10 +1,14 @@
 name: sauce-p3-desktop
 
-on: [push]
+on:
+  push:
+    branches-ignore:
+      - 'master'
 
 jobs:
   tests:
     runs-on: ubuntu-latest
+    if: "! contains(toJSON(github.event.commits.*.message), '[skip ci]')"
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/sauce-p3-mobile.yml
+++ b/.github/workflows/sauce-p3-mobile.yml
@@ -1,10 +1,14 @@
 name: sauce-p3-mobile
 
-on: [push]
+on:
+  push:
+    branches-ignore:
+      - 'master'
 
 jobs:
   tests:
     runs-on: ubuntu-latest
+    if: "! contains(toJSON(github.event.commits.*.message), '[skip ci]')"
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/sauce-visual.yml
+++ b/.github/workflows/sauce-visual.yml
@@ -1,10 +1,14 @@
 name: sauce-visual
 
-on: [push]
+on:
+  push:
+    branches-ignore:
+      - 'master'
 
 jobs:
   visual-tests:
     runs-on: ubuntu-latest
+    if: "! contains(toJSON(github.event.commits.*.message), '[skip ci]')"
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Looks like there are duplicate builds on master when pushing directly with `magi-cli`. Let's fix that.

Any code merged to master should be green anyways, so we don't need to run build twice.