### PR TITLE
ci: do not trigger build for tags [skip ci]

### DIFF
--- a/.github/workflows/firefox.yml
+++ b/.github/workflows/firefox.yml
@@ -1,6 +1,9 @@
 name: firefox
 
-on: [push]
+on:
+  push:
+    tags-ignore:
+      - 'v**'
 
 jobs:
   unit-tests:

--- a/.github/workflows/safari.yml
+++ b/.github/workflows/safari.yml
@@ -1,6 +1,9 @@
 name: safari
 
-on: [push]
+on:
+  push:
+    tags-ignore:
+      - 'v**'
 
 jobs:
   unit-tests:

--- a/.github/workflows/visual.yml
+++ b/.github/workflows/visual.yml
@@ -1,6 +1,9 @@
 name: visual
 
-on: [push]
+on:
+  push:
+    tags-ignore:
+      - 'v**'
 
 jobs:
   visual-tests:


### PR DESCRIPTION
Currently when doing `magi release` there are two builds: one for commit and another one for git tag.

This causes duplicate builds exceeding SauceLabs limit of 5 tunnels and results in a failure.

Looks like `tags-ignore` [config option](https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#example-ignoring-branches-and-tags) should help.