### PR TITLE
ci: run for branches but not tags [skip ci]

### DIFF
--- a/.github/workflows/firefox.yml
+++ b/.github/workflows/firefox.yml
@@ -2,8 +2,10 @@ name: firefox
 
 on:
   push:
+    branches:
+      - '**'
     tags-ignore:
-      - 'v**'
+      - '*.*'
 
 jobs:
   unit-tests:

--- a/.github/workflows/safari.yml
+++ b/.github/workflows/safari.yml
@@ -2,8 +2,10 @@ name: safari
 
 on:
   push:
+    branches:
+      - '**'
     tags-ignore:
-      - 'v**'
+      - '*.*'
 
 jobs:
   unit-tests:

--- a/.github/workflows/visual.yml
+++ b/.github/workflows/visual.yml
@@ -2,8 +2,10 @@ name: visual
 
 on:
   push:
+    branches:
+      - '**'
     tags-ignore:
-      - 'v**'
+      - '*.*'
 
 jobs:
   visual-tests:


### PR DESCRIPTION
The previously merged PR was incorrect as it disabled the push build altogether 😕  This one should fix it.