### PR TITLE
refactor: remove IE11 innerText workaround

### DIFF
--- a/src/vaadin-grid-column-reordering-mixin.d.ts
+++ b/src/vaadin-grid-column-reordering-mixin.d.ts
@@ -23,8 +23,6 @@ interface ColumnReorderingMixin {
 
   _updateGhostPosition(eventClientX: number, eventClientY: number): void;
 
-  _getInnerText(e: Element): string;
-
   _updateGhost(cell: HTMLElement): HTMLElement;
 
   _setSiblingsReorderStatus(column: GridColumnElement, status: string): void;

--- a/src/vaadin-grid-column-reordering-mixin.js
+++ b/src/vaadin-grid-column-reordering-mixin.js
@@ -243,33 +243,13 @@ export const ColumnReorderingMixin = (superClass) =>
     }
 
     /**
-     * @param {!Element} e
-     * @return {string}
-     * @protected
-     */
-    _getInnerText(e) {
-      if (e.localName) {
-        // Custom implementation needed since IE11 doesn't respect the spec in case of hidden elements
-        if (getComputedStyle(e).display === 'none') {
-          return '';
-        } else {
-          return Array.from(e.childNodes)
-            .map((n) => this._getInnerText(n))
-            .join('');
-        }
-      } else {
-        return e.textContent;
-      }
-    }
-
-    /**
      * @param {!HTMLElement} cell
      * @return {!HTMLElement}
      * @protected
      */
     _updateGhost(cell) {
       const ghost = this._reorderGhost;
-      ghost.textContent = this._getInnerText(cell._content);
+      ghost.textContent = cell._content.innerText;
       const style = window.getComputedStyle(cell);
       [
         'boxSizing',

--- a/web-test-runner.config.js
+++ b/web-test-runner.config.js
@@ -17,7 +17,7 @@ const config = {
     threshold: {
       statements: 97,
       branches: 58,
-      functions: 96,
+      functions: 95,
       lines: 97
     }
   }


### PR DESCRIPTION
We no longer support IE11 and legacy Edge so let's revert the workaround implemented at #1214