### PR TITLE
feat: support generics for item type [skip ci]

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,6 +99,6 @@
     "stylelint": "^13.8.0",
     "stylelint-config-prettier": "^8.0.2",
     "stylelint-config-vaadin": "^0.2.7",
-    "typescript": "^4.0.5"
+    "typescript": "^4.1.3"
   }
 }

--- a/src/interfaces.d.ts
+++ b/src/interfaces.d.ts
@@ -1,38 +1,38 @@
 import { GridColumnElement } from './vaadin-grid-column.js';
 import { GridElement } from './vaadin-grid.js';
 
-export type GridBodyRenderer = (
+export type GridBodyRenderer<T> = (
   root: HTMLElement,
-  column?: GridColumnElement,
-  model?: GridItemModel
+  column?: GridColumnElement<T>,
+  model?: GridItemModel<T>
 ) => void;
 
-export type GridCellClassNameGenerator = (
-  column: GridColumnElement,
-  model: GridItemModel
+export type GridCellClassNameGenerator<T> = (
+  column: GridColumnElement<T>,
+  model: GridItemModel<T>
 ) => string;
 
 export type GridColumnTextAlign = 'start' | 'center' | 'end' | null;
 
-export type GridDataProviderCallback = (
-  items: Array<GridItem>,
+export type GridDataProviderCallback<T> = (
+  items: Array<T>,
   size?: number
 ) => void;
 
-export type GridDataProviderParams = {
+export type GridDataProviderParams<T> = {
   page: number;
   pageSize: number;
   filters: Array<GridFilter>;
   sortOrders: Array<GridSorter>;
-  parentItem?: GridItem;
+  parentItem?: T;
 };
 
-export type GridDataProvider = (
-  params: GridDataProviderParams,
-  callback: GridDataProviderCallback
+export type GridDataProvider<T> = (
+  params: GridDataProviderParams<T>,
+  callback: GridDataProviderCallback<T>
 ) => void;
 
-export type GridDragAndDropFilter = (model: GridItemModel) => boolean;
+export type GridDragAndDropFilter<T> = (model: GridItemModel<T>) => boolean;
 
 export type GridDropLocation = 'above' | 'on-top' | 'below' | 'empty';
 
@@ -43,10 +43,10 @@ export interface GridFilter {
   value: string;
 }
 
-export interface GridEventContext {
+export interface GridEventContext<T> {
   section: 'body' | 'header' | 'footer' | 'details';
-  item?: GridItem;
-  column?: GridColumnElement;
+  item?: T;
+  column?: GridColumnElement<T>;
   index?: number;
   selected?: boolean;
   detailsOpened?: boolean;
@@ -54,26 +54,24 @@ export interface GridEventContext {
   level?: number;
 }
 
-export type GridHeaderFooterRenderer = (
+export type GridHeaderFooterRenderer<T> = (
   root: HTMLElement,
-  column?: GridColumnElement
+  column?: GridColumnElement<T>
 ) => void;
 
-export type GridItem = unknown;
-
-export interface GridItemModel {
+export interface GridItemModel<T> {
   index: number;
-  item: GridItem;
+  item: T;
   selected?: boolean;
   expanded?: boolean;
   level?: number;
   detailsOpened?: boolean;
 }
 
-export type GridRowDetailsRenderer = (
+export type GridRowDetailsRenderer<T> = (
   root: HTMLElement,
-  grid?: GridElement,
-  model?: GridItemModel
+  grid?: GridElement<T>,
+  model?: GridItemModel<T>
 ) => void;
 
 export type GridSorterDirection = 'asc' | 'desc' | null;

--- a/src/vaadin-grid-active-item-mixin.d.ts
+++ b/src/vaadin-grid-active-item-mixin.d.ts
@@ -1,5 +1,3 @@
-import { GridItem } from './interfaces';
-
 declare function ActiveItemMixin<T extends new (...args: any[]) => {}>(base: T): T & ActiveItemMixinConstructor;
 
 interface ActiveItemMixinConstructor {
@@ -11,7 +9,7 @@ interface ActiveItemMixin {
    * The item user has last interacted with. Turns to `null` after user deactivates
    * the item by re-interacting with the currently active item.
    */
-  activeItem: GridItem | null;
+  activeItem: unknown | null;
 
   /**
    * We need to listen to click instead of tap because on mobile safari, the

--- a/src/vaadin-grid-active-item-mixin.js
+++ b/src/vaadin-grid-active-item-mixin.js
@@ -14,7 +14,7 @@ export const ActiveItemMixin = (superClass) =>
         /**
          * The item user has last interacted with. Turns to `null` after user deactivates
          * the item by re-interacting with the currently active item.
-         * @type {GridItem}
+         * @type {unknown}
          */
         activeItem: {
           type: Object,

--- a/src/vaadin-grid-array-data-provider-mixin.d.ts
+++ b/src/vaadin-grid-array-data-provider-mixin.d.ts
@@ -1,4 +1,4 @@
-import { GridDataProviderCallback, GridDataProviderParams, GridItem, GridFilter, GridSorter } from './interfaces';
+import { GridDataProviderCallback, GridDataProviderParams, GridFilter, GridSorter } from './interfaces';
 
 declare function ArrayDataProviderMixin<T extends new (...args: any[]) => {}>(
   base: T
@@ -13,9 +13,9 @@ interface ArrayDataProviderMixin {
    * An array containing the items which will be stamped to the column template
    * instances.
    */
-  items: GridItem[] | null | undefined;
+  items: Array<unknown> | null | undefined;
 
-  _arrayDataProvider(opts: GridDataProviderParams | null, cb: GridDataProviderCallback | null): void;
+  _arrayDataProvider(opts: GridDataProviderParams<unknown> | null, cb: GridDataProviderCallback<unknown> | null): void;
 
   /**
    * Check array of filters/sorters for paths validity, console.warn invalid items
@@ -23,7 +23,7 @@ interface ArrayDataProviderMixin {
    * @param arrayToCheck The array of filters/sorters to check
    * @param action The name of action to include in warning (filtering, sorting)
    */
-  _checkPaths(arrayToCheck: Array<GridFilter | GridSorter>, action: string, items: GridItem[]): any;
+  _checkPaths(arrayToCheck: Array<GridFilter | GridSorter>, action: string, items: Array<unknown>): any;
 
   _multiSort(a: unknown | null, b: unknown | null): number;
 
@@ -31,7 +31,7 @@ interface ArrayDataProviderMixin {
 
   _compare(a: unknown | null, b: unknown | null): number;
 
-  _filter(items: GridItem[]): GridItem[];
+  _filter(items: Array<unknown>): Array<unknown>;
 }
 
 export { ArrayDataProviderMixin, ArrayDataProviderMixinConstructor };

--- a/src/vaadin-grid-array-data-provider-mixin.js
+++ b/src/vaadin-grid-array-data-provider-mixin.js
@@ -16,7 +16,7 @@ export const ArrayDataProviderMixin = (superClass) =>
          * An array containing the items which will be stamped to the column template
          * instances.
          *
-         * @type {Array<!GridItem> | undefined}
+         * @type {Array<unknown> | undefined}
          */
         items: Array
       };
@@ -75,7 +75,7 @@ export const ArrayDataProviderMixin = (superClass) =>
      * Check array of filters/sorters for paths validity, console.warn invalid items
      * @param {!Array<!GridFilter | !GridSorter>} arrayToCheck The array of filters/sorters to check
      * @param {string} action The name of action to include in warning (filtering, sorting)
-     * @param {!Array<!GridItem>} items
+     * @param {!Array<unknown>} items
      * @protected
      */
     _checkPaths(arrayToCheck, action, items) {
@@ -159,8 +159,8 @@ export const ArrayDataProviderMixin = (superClass) =>
     }
 
     /**
-     * @param {!Array<!GridItem>} items
-     * @return {!Array<!GridItem>}
+     * @param {!Array<unknown>} items
+     * @return {!Array<unknown>}
      * @protected
      */
     _filter(items) {

--- a/src/vaadin-grid-column-group.d.ts
+++ b/src/vaadin-grid-column-group.d.ts
@@ -40,7 +40,7 @@ declare class GridColumnGroupElement extends ColumnBaseMixin(HTMLElement) {
 
   _updateFlexAndWidth(): void;
 
-  _getChildColumns(el: GridColumnGroupElement): GridColumnElement[];
+  _getChildColumns(el: GridColumnGroupElement): Array<GridColumnElement<unknown>>;
 
   _isColumnElement(node: Node): boolean;
 }

--- a/src/vaadin-grid-column-reordering-mixin.d.ts
+++ b/src/vaadin-grid-column-reordering-mixin.d.ts
@@ -17,7 +17,7 @@ interface ColumnReorderingMixin {
    */
   columnReorderingAllowed: boolean;
 
-  _getColumnsInOrder(): GridColumnElement[];
+  _getColumnsInOrder(): Array<GridColumnElement<unknown>>;
 
   _cellFromPoint(x: number, y: number): HTMLElement | null | undefined;
 
@@ -25,23 +25,23 @@ interface ColumnReorderingMixin {
 
   _updateGhost(cell: HTMLElement): HTMLElement;
 
-  _setSiblingsReorderStatus(column: GridColumnElement, status: string): void;
+  _setSiblingsReorderStatus(column: GridColumnElement<unknown>, status: string): void;
 
   _autoScroller(): void;
 
   _isSwapAllowed(
-    column1: GridColumnElement | null | undefined,
-    column2: GridColumnElement | null | undefined
+    column1: GridColumnElement<unknown> | null | undefined,
+    column2: GridColumnElement<unknown> | null | undefined
   ): boolean | undefined;
 
-  _isSwappableByPosition(targetColumn: GridColumnElement, clientX: number): boolean;
+  _isSwappableByPosition(targetColumn: GridColumnElement<unknown>, clientX: number): boolean;
 
-  _swapColumnOrders(column1: GridColumnElement, column2: GridColumnElement): void;
+  _swapColumnOrders(column1: GridColumnElement<unknown>, column2: GridColumnElement<unknown>): void;
 
   _getTargetColumn(
     targetCell: HTMLElement | null | undefined,
-    draggedColumn: GridColumnElement | null
-  ): GridColumnElement | null | undefined;
+    draggedColumn: GridColumnElement<unknown> | null
+  ): GridColumnElement<unknown> | null | undefined;
 }
 
 export { ColumnReorderingMixin };

--- a/src/vaadin-grid-column.d.ts
+++ b/src/vaadin-grid-column.d.ts
@@ -11,7 +11,8 @@ interface ColumnBaseMixinConstructor {
 export { ColumnBaseMixinConstructor };
 
 interface ColumnBaseMixin {
-  readonly _grid: GridElement | undefined;
+  readonly _grid: GridElement<any> | undefined;
+
   readonly _allCells: HTMLElement[];
 
   /**
@@ -59,7 +60,7 @@ interface ColumnBaseMixin {
    * - `root` The header cell content DOM element. Append your content to it.
    * - `column` The `<vaadin-grid-column>` element.
    */
-  headerRenderer: GridHeaderFooterRenderer | null | undefined;
+  headerRenderer: GridHeaderFooterRenderer<unknown> | null | undefined;
 
   /**
    * Custom function for rendering the footer content.
@@ -68,9 +69,9 @@ interface ColumnBaseMixin {
    * - `root` The footer cell content DOM element. Append your content to it.
    * - `column` The `<vaadin-grid-column>` element.
    */
-  footerRenderer: GridHeaderFooterRenderer | null | undefined;
+  footerRenderer: GridHeaderFooterRenderer<unknown> | null | undefined;
 
-  _findHostGrid(): GridElement | undefined;
+  _findHostGrid(): GridElement<any> | undefined;
 
   _prepareHeaderTemplate(): HTMLTemplateElement | null;
 
@@ -92,8 +93,8 @@ interface ColumnBaseMixin {
     headerCell: HTMLTableCellElement | undefined,
     footerCell: HTMLTableCellElement | undefined,
     cells: object | undefined,
-    renderer: GridBodyRenderer | null | undefined,
-    headerRenderer: GridHeaderFooterRenderer | null | undefined,
+    renderer: GridBodyRenderer<unknown> | null | undefined,
+    headerRenderer: GridHeaderFooterRenderer<unknown> | null | undefined,
     bodyTemplate: HTMLTemplateElement | null | undefined,
     headerTemplate: HTMLTemplateElement | null | undefined
   ): void;
@@ -111,7 +112,7 @@ interface ColumnBaseMixin {
  * to configure the `<vaadin-grid-column>`.
  * ```
  */
-declare class GridColumnElement extends ColumnBaseMixin(HTMLElement) {
+declare class GridColumnElement<Item> extends ColumnBaseMixin(HTMLElement) {
   /**
    * Width of the cells for this column.
    */
@@ -137,7 +138,7 @@ declare class GridColumnElement extends ColumnBaseMixin(HTMLElement) {
    *   - `model.level` Level of the tree represented with a horizontal offset of the toggle button.
    *   - `model.selected` Selected state.
    */
-  renderer: GridBodyRenderer | null | undefined;
+  renderer: GridBodyRenderer<Item> | null | undefined;
 
   /**
    * Path to an item sub-property whose value gets displayed in the column body cells.
@@ -170,7 +171,7 @@ declare class GridColumnElement extends ColumnBaseMixin(HTMLElement) {
 
 declare global {
   interface HTMLElementTagNameMap {
-    'vaadin-grid-column': GridColumnElement;
+    'vaadin-grid-column': GridColumnElement<unknown>;
   }
 }
 

--- a/src/vaadin-grid-data-provider-mixin.d.ts
+++ b/src/vaadin-grid-data-provider-mixin.d.ts
@@ -1,17 +1,17 @@
-import { GridDataProvider, GridItem } from './interfaces';
+import { GridDataProvider } from './interfaces';
 
 declare class ItemCache {
   grid: HTMLElement;
   parentCache: ItemCache | undefined;
-  parentItem: GridItem | undefined;
+  parentItem: unknown | undefined;
   itemCaches: object | null;
   items: object | null;
   effectiveSize: number;
   size: number;
   pendingRequests: object | null;
-  constructor(grid: HTMLElement, parentCache: ItemCache | undefined, parentItem: GridItem | undefined);
+  constructor(grid: HTMLElement, parentCache: ItemCache | undefined, parentItem: unknown | undefined);
   isLoading(): boolean;
-  getItemForIndex(index: number): GridItem | undefined;
+  getItemForIndex(index: number): unknown | undefined;
   updateSize(): void;
   ensureSubCacheForScaledIndex(scaledIndex: number): void;
   getCacheAndIndex(index: number): { cache: ItemCache; scaledIndex: number };
@@ -51,7 +51,7 @@ interface DataProviderMixin {
    *     are requested, total number of items in the requested sublevel.
    *     Optional when tree is not used, required for tree.
    */
-  dataProvider: GridDataProvider | null | undefined;
+  dataProvider: GridDataProvider<any> | null | undefined;
 
   /**
    * `true` while data is being requested from the data provider.
@@ -69,7 +69,7 @@ interface DataProviderMixin {
   /**
    * An array that contains the expanded items.
    */
-  expandedItems: GridItem[];
+  expandedItems: Array<unknown>;
 
   _getItem(index: number, el: HTMLElement | null): void;
 
@@ -77,19 +77,19 @@ interface DataProviderMixin {
    * Returns a value that identifies the item. Uses `itemIdPath` if available.
    * Can be customized by overriding.
    */
-  getItemId(item: GridItem): GridItem | unknown;
+  getItemId(item: unknown): unknown;
 
-  _isExpanded(item: GridItem): boolean;
+  _isExpanded(item: unknown): boolean;
 
   /**
    * Expands the given item tree.
    */
-  expandItem(item: GridItem): void;
+  expandItem(item: unknown): void;
 
   /**
    * Collapses the given item tree.
    */
-  collapseItem(item: GridItem): void;
+  collapseItem(item: unknown): void;
 
   _getIndexLevel(index: number): number;
 
@@ -106,9 +106,9 @@ interface DataProviderMixin {
 
   _ensureFirstPageLoaded(): void;
 
-  _itemsEqual(item1: GridItem, item2: GridItem): boolean;
+  _itemsEqual(item1: unknown, item2: unknown): boolean;
 
-  _getItemIndexInArray(item: GridItem, array: GridItem[]): number;
+  _getItemIndexInArray(item: unknown, array: Array<unknown>): number;
 }
 
 export { DataProviderMixin, DataProviderMixinConstructor, ItemCache };

--- a/src/vaadin-grid-data-provider-mixin.js
+++ b/src/vaadin-grid-data-provider-mixin.js
@@ -13,14 +13,14 @@ export const ItemCache = class ItemCache {
   /**
    * @param {!HTMLElement} grid
    * @param {!ItemCache | undefined} parentCache
-   * @param {!GridItem | undefined} parentItem
+   * @param {unknown} parentItem
    */
   constructor(grid, parentCache, parentItem) {
     /** @type {!HTMLElement} */
     this.grid = grid;
     /** @type {!ItemCache | undefined} */
     this.parentCache = parentCache;
-    /** @type {!GridItem | undefined} */
+    /** @type {unknown} */
     this.parentItem = parentItem;
     /** @type {object} */
     this.itemCaches = {};
@@ -48,7 +48,7 @@ export const ItemCache = class ItemCache {
 
   /**
    * @param {number} index
-   * @return {!GridItem | undefined}
+   * @return {unknown}
    */
   getItemForIndex(index) {
     const { cache, scaledIndex } = this.getCacheAndIndex(index);
@@ -179,7 +179,7 @@ export const DataProviderMixin = (superClass) =>
 
         /**
          * An array that contains the expanded items.
-         * @type {!Array<!GridItem>}
+         * @type {!Array<unknown>}
          */
         expandedItems: {
           type: Object,
@@ -243,15 +243,15 @@ export const DataProviderMixin = (superClass) =>
     /**
      * Returns a value that identifies the item. Uses `itemIdPath` if available.
      * Can be customized by overriding.
-     * @param {!GridItem} item
-     * @return {!GridItem | !unknown}
+     * @param {unknown} item
+     * @return {unknown}
      */
     getItemId(item) {
       return this.itemIdPath ? this.get(this.itemIdPath, item) : item;
     }
 
     /**
-     * @param {!GridItem} item
+     * @param {unknown} item
      * @return {boolean}
      * @protected
      */
@@ -284,7 +284,7 @@ export const DataProviderMixin = (superClass) =>
 
     /**
      * Expands the given item tree.
-     * @param {!GridItem} item
+     * @param {unknown} item
      */
     expandItem(item) {
       if (!this._isExpanded(item)) {
@@ -294,7 +294,7 @@ export const DataProviderMixin = (superClass) =>
 
     /**
      * Collapses the given item tree.
-     * @param {!GridItem} item
+     * @param {unknown} item
      */
     collapseItem(item) {
       if (this._isExpanded(item)) {
@@ -476,8 +476,8 @@ export const DataProviderMixin = (superClass) =>
     }
 
     /**
-     * @param {!GridItem} item1
-     * @param {!GridItem} item2
+     * @param {unknown} item1
+     * @param {unknown} item2
      * @return {boolean}
      * @protected
      */
@@ -486,8 +486,8 @@ export const DataProviderMixin = (superClass) =>
     }
 
     /**
-     * @param {!GridItem} item
-     * @param {!Array<!GridItem>} array
+     * @param {unknown} item
+     * @param {!Array<unknown>} array
      * @return {number}
      * @protected
      */

--- a/src/vaadin-grid-drag-and-drop-mixin.d.ts
+++ b/src/vaadin-grid-drag-and-drop-mixin.d.ts
@@ -38,7 +38,7 @@ interface DragAndDropMixin {
    *   - `model.level` Level of the tree represented with a horizontal offset of the toggle button.
    *   - `model.selected` Selected state.
    */
-  dragFilter: GridDragAndDropFilter | null | undefined;
+  dragFilter: GridDragAndDropFilter<any> | null | undefined;
 
   /**
    * A function that filters dropping on specific grid rows. The return value should be false
@@ -53,7 +53,7 @@ interface DragAndDropMixin {
    *   - `model.level` Level of the tree represented with a horizontal offset of the toggle button.
    *   - `model.selected` Selected state.
    */
-  dropFilter: GridDragAndDropFilter | null | undefined;
+  dropFilter: GridDragAndDropFilter<any> | null | undefined;
 
   _clearDragStyles(): void;
 
@@ -65,7 +65,7 @@ interface DragAndDropMixin {
    */
   filterDragAndDrop(): void;
 
-  _filterDragAndDrop(row: HTMLElement, model: GridItemModel): void;
+  _filterDragAndDrop(row: HTMLElement, model: GridItemModel<unknown>): void;
 }
 
 export { DragAndDropMixin, DragAndDropMixinConstructor };

--- a/src/vaadin-grid-dynamic-columns-mixin.d.ts
+++ b/src/vaadin-grid-dynamic-columns-mixin.d.ts
@@ -9,7 +9,7 @@ interface DynamicColumnsMixinConstructor {
 }
 
 interface DynamicColumnsMixin {
-  _getChildColumns(el: GridColumnGroupElement): GridColumnElement[];
+  _getChildColumns(el: GridColumnGroupElement): Array<GridColumnElement<unknown>>;
 
   _updateColumnTree(): void;
 

--- a/src/vaadin-grid-event-context-mixin.d.ts
+++ b/src/vaadin-grid-event-context-mixin.d.ts
@@ -25,7 +25,7 @@ interface EventContextMixin {
    * This may be the case eg. if the event is fired on the `<vaadin-grid>` element and not any deeper in the DOM, or if
    * the event targets the empty part of the grid body.
    */
-  getEventContext(event: Event): GridEventContext | object | null;
+  getEventContext(event: Event): GridEventContext<unknown> | object | null;
 }
 
 export { EventContextMixin, EventContextMixinConstructor };

--- a/src/vaadin-grid-filter-column.d.ts
+++ b/src/vaadin-grid-filter-column.d.ts
@@ -13,7 +13,7 @@ import { GridColumnElement } from './vaadin-grid-column.js';
  *    ...
  * ```
  */
-declare class GridFilterColumnElement extends GridColumnElement {
+declare class GridFilterColumnElement<T> extends GridColumnElement<T> {
   /**
    * Text to display as the label of the column filter text-field.
    */
@@ -27,7 +27,7 @@ declare class GridFilterColumnElement extends GridColumnElement {
 
 declare global {
   interface HTMLElementTagNameMap {
-    'vaadin-grid-filter-column': GridFilterColumnElement;
+    'vaadin-grid-filter-column': GridFilterColumnElement<unknown>;
   }
 }
 

--- a/src/vaadin-grid-keyboard-navigation-mixin.d.ts
+++ b/src/vaadin-grid-keyboard-navigation-mixin.d.ts
@@ -21,7 +21,7 @@ interface KeyboardNavigationMixin {
 
   _preventScrollerRotatingCellFocus(row: HTMLTableRowElement, index: number): void;
 
-  _getColumns(rowGroup?: HTMLTableSectionElement | null, rowIndex?: number): GridColumnElement[];
+  _getColumns(rowGroup?: HTMLTableSectionElement | null, rowIndex?: number): Array<GridColumnElement<unknown>>;
 
   _resetKeyboardNavigation(): void;
 

--- a/src/vaadin-grid-row-details-mixin.d.ts
+++ b/src/vaadin-grid-row-details-mixin.d.ts
@@ -1,4 +1,4 @@
-import { GridItem, GridRowDetailsRenderer } from './interfaces';
+import { GridRowDetailsRenderer } from './interfaces';
 
 declare function RowDetailsMixin<T extends new (...args: any[]) => {}>(base: T): T & RowDetailsMixinConstructor;
 
@@ -10,7 +10,7 @@ interface RowDetailsMixin {
   /**
    * An array containing references to items with open row details.
    */
-  detailsOpenedItems: Array<GridItem | null> | null | undefined;
+  detailsOpenedItems: Array<unknown> | null | undefined;
 
   _rowDetailsTemplate: HTMLTemplateElement | null;
 
@@ -25,27 +25,27 @@ interface RowDetailsMixin {
    *   - `model.index` The index of the item.
    *   - `model.item` The item.
    */
-  rowDetailsRenderer: GridRowDetailsRenderer | null | undefined;
+  rowDetailsRenderer: GridRowDetailsRenderer<any> | null | undefined;
 
   _detailsCells: HTMLElement[] | undefined;
 
   _configureDetailsCell(cell: HTMLElement): void;
 
-  _toggleDetailsCell(row: HTMLElement, item: GridItem): void;
+  _toggleDetailsCell(row: HTMLElement, item: unknown): void;
 
   _updateDetailsCellHeights(): void;
 
-  _isDetailsOpened(item: GridItem): boolean;
+  _isDetailsOpened(item: unknown): boolean;
 
   /**
    * Open the details row of a given item.
    */
-  openItemDetails(item: GridItem): void;
+  openItemDetails(item: unknown): void;
 
   /**
    * Close the details row of a given item.
    */
-  closeItemDetails(item: GridItem): void;
+  closeItemDetails(item: unknown): void;
 }
 
 export { RowDetailsMixin, RowDetailsMixinConstructor };

--- a/src/vaadin-grid-row-details-mixin.js
+++ b/src/vaadin-grid-row-details-mixin.js
@@ -15,7 +15,7 @@ export const RowDetailsMixin = (superClass) =>
       return {
         /**
          * An array containing references to items with open row details.
-         * @type {Array<GridItem> | null | undefined}
+         * @type {Array<unknown> | null | undefined}
          */
         detailsOpenedItems: {
           type: Array,
@@ -121,7 +121,7 @@ export const RowDetailsMixin = (superClass) =>
 
     /**
      * @param {!HTMLElement} row
-     * @param {!GridItem} item
+     * @param {unknown} item
      * @protected
      */
     _toggleDetailsCell(row, item) {
@@ -168,7 +168,7 @@ export const RowDetailsMixin = (superClass) =>
     }
 
     /**
-     * @param {!GridItem} item
+     * @param {unknown} item
      * @return {boolean}
      * @protected
      */
@@ -178,7 +178,7 @@ export const RowDetailsMixin = (superClass) =>
 
     /**
      * Open the details row of a given item.
-     * @param {!GridItem} item
+     * @param {unknown} item
      */
     openItemDetails(item) {
       if (!this._isDetailsOpened(item)) {
@@ -188,7 +188,7 @@ export const RowDetailsMixin = (superClass) =>
 
     /**
      * Close the details row of a given item.
-     * @param {!GridItem} item
+     * @param {unknown} item
      */
     closeItemDetails(item) {
       if (this._isDetailsOpened(item)) {

--- a/src/vaadin-grid-selection-column.d.ts
+++ b/src/vaadin-grid-selection-column.d.ts
@@ -35,7 +35,7 @@ export interface GridSelectionColumnEventMap extends HTMLElementEventMap, GridSe
  *
  * @fires {CustomEvent} select-all-changed - Fired when the `selectAll` property changes.
  */
-declare class GridSelectionColumnElement extends GridColumnElement {
+declare class GridSelectionColumnElement<T> extends GridColumnElement<T> {
   /**
    * Width of the cells for this column.
    */
@@ -61,20 +61,20 @@ declare class GridSelectionColumnElement extends GridColumnElement {
 
   addEventListener<K extends keyof GridSelectionColumnEventMap>(
     type: K,
-    listener: (this: GridSelectionColumnElement, ev: GridSelectionColumnEventMap[K]) => void,
+    listener: (this: GridSelectionColumnElement<T>, ev: GridSelectionColumnEventMap[K]) => void,
     options?: boolean | AddEventListenerOptions
   ): void;
 
   removeEventListener<K extends keyof GridSelectionColumnEventMap>(
     type: K,
-    listener: (this: GridSelectionColumnElement, ev: GridSelectionColumnEventMap[K]) => void,
+    listener: (this: GridSelectionColumnElement<T>, ev: GridSelectionColumnEventMap[K]) => void,
     options?: boolean | EventListenerOptions
   ): void;
 }
 
 declare global {
   interface HTMLElementTagNameMap {
-    'vaadin-grid-selection-column': GridSelectionColumnElement;
+    'vaadin-grid-selection-column': GridSelectionColumnElement<unknown>;
   }
 }
 

--- a/src/vaadin-grid-selection-mixin.d.ts
+++ b/src/vaadin-grid-selection-mixin.d.ts
@@ -1,5 +1,3 @@
-import { GridItem } from './interfaces';
-
 declare function SelectionMixin<T extends new (...args: any[]) => {}>(base: T): T & SelectionMixinConstructor;
 
 interface SelectionMixinConstructor {
@@ -10,29 +8,30 @@ interface SelectionMixin {
   /**
    * An array that contains the selected items.
    */
-  selectedItems: Array<GridItem | null> | null;
-  _isSelected(item: GridItem): boolean;
+  selectedItems: Array<unknown> | null;
+
+  _isSelected(item: unknown): boolean;
 
   /**
    * Selects the given item.
    *
    * @param item The item object
    */
-  selectItem(item: GridItem): void;
+  selectItem(item: unknown): void;
 
   /**
    * Deselects the given item if it is already selected.
    *
    * @param item The item object
    */
-  deselectItem(item: GridItem): void;
+  deselectItem(item: unknown): void;
 
   /**
    * Toggles the selected state of the given item.
    *
    * @param item The item object
    */
-  _toggleItem(item: GridItem): void;
+  _toggleItem(item: unknown): void;
 }
 
 export { SelectionMixin, SelectionMixinConstructor };

--- a/src/vaadin-grid-selection-mixin.js
+++ b/src/vaadin-grid-selection-mixin.js
@@ -13,7 +13,7 @@ export const SelectionMixin = (superClass) =>
       return {
         /**
          * An array that contains the selected items.
-         * @type {Array<GridItem>}
+         * @type {Array<unknown>}
          */
         selectedItems: {
           type: Object,
@@ -28,7 +28,7 @@ export const SelectionMixin = (superClass) =>
     }
 
     /**
-     * @param {!GridItem} item
+     * @param {unknown} item
      * @return {boolean}
      * @protected
      */
@@ -40,7 +40,7 @@ export const SelectionMixin = (superClass) =>
      * Selects the given item.
      *
      * @method selectItem
-     * @param {!GridItem} item The item object
+     * @param {unknown} item The item object
      */
     selectItem(item) {
       if (!this._isSelected(item)) {
@@ -52,7 +52,7 @@ export const SelectionMixin = (superClass) =>
      * Deselects the given item if it is already selected.
      *
      * @method deselect
-     * @param {!GridItem} item The item object
+     * @param {unknown} item The item object
      */
     deselectItem(item) {
       const index = this._getItemIndexInArray(item, this.selectedItems);
@@ -65,7 +65,7 @@ export const SelectionMixin = (superClass) =>
      * Toggles the selected state of the given item.
      *
      * @method toggle
-     * @param {!GridItem} item The item object
+     * @param {unknown} item The item object
      * @protected
      */
     _toggleItem(item) {

--- a/src/vaadin-grid-sort-column.d.ts
+++ b/src/vaadin-grid-sort-column.d.ts
@@ -28,7 +28,7 @@ export interface GridSortColumnEventMap extends HTMLElementEventMap, GridSortCol
  *
  * @fires {CustomEvent} direction-changed - Fired when the `direction` property changes.
  */
-declare class GridSortColumnElement extends GridColumnElement {
+declare class GridSortColumnElement<T> extends GridColumnElement<T> {
   /**
    * JS Path of the property in the item used for sorting the data.
    */
@@ -43,20 +43,20 @@ declare class GridSortColumnElement extends GridColumnElement {
 
   addEventListener<K extends keyof GridSortColumnEventMap>(
     type: K,
-    listener: (this: GridSortColumnElement, ev: GridSortColumnEventMap[K]) => void,
+    listener: (this: GridSortColumnElement<T>, ev: GridSortColumnEventMap[K]) => void,
     options?: boolean | AddEventListenerOptions
   ): void;
 
   removeEventListener<K extends keyof GridSortColumnEventMap>(
     type: K,
-    listener: (this: GridSortColumnElement, ev: GridSortColumnEventMap[K]) => void,
+    listener: (this: GridSortColumnElement<T>, ev: GridSortColumnEventMap[K]) => void,
     options?: boolean | EventListenerOptions
   ): void;
 }
 
 declare global {
   interface HTMLElementTagNameMap {
-    'vaadin-grid-sort-column': GridSortColumnElement;
+    'vaadin-grid-sort-column': GridSortColumnElement<unknown>;
   }
 }
 

--- a/src/vaadin-grid-styling-mixin.d.ts
+++ b/src/vaadin-grid-styling-mixin.d.ts
@@ -23,7 +23,7 @@ interface StylingMixin {
    *   - `model.level` Level of the tree represented with a horizontal offset of the toggle button.
    *   - `model.selected` Selected state.
    */
-  cellClassNameGenerator: GridCellClassNameGenerator | null | undefined;
+  cellClassNameGenerator: GridCellClassNameGenerator<any> | null | undefined;
 
   /**
    * Runs the `cellClassNameGenerator` for the visible cells.

--- a/src/vaadin-grid.js
+++ b/src/vaadin-grid.js
@@ -794,7 +794,7 @@ class GridElement extends ElementMixin(
 
   /**
    * @param {!HTMLElement} row
-   * @param {GridItem} item
+   * @param {unknown} item
    * @protected
    */
   _updateItem(row, item) {

--- a/test/typings/grid.types.ts
+++ b/test/typings/grid.types.ts
@@ -1,29 +1,31 @@
-import '../../src/vaadin-grid';
+import { GridElement } from '../../src/vaadin-grid';
 import '../../src/vaadin-grid-filter';
 import '../../src/vaadin-grid-selection-column';
 import '../../src/vaadin-grid-sorter';
 import '../../src/vaadin-grid-sort-column';
 import '../../src/vaadin-grid-tree-toggle';
-import { GridColumnElement, GridDropLocation, GridItem, GridItemModel, GridSorterDirection } from '../../src/interfaces';
+import { GridColumnElement, GridDropLocation, GridItemModel, GridSorterDirection } from '../../src/interfaces';
 
 const assert = <T>(value: T) => value;
 
-const grid = document.createElement('vaadin-grid');
+type User = { name: string; email: string };
+
+const grid = document.createElement('vaadin-grid') as GridElement<User>;
 
 grid.addEventListener('active-item-changed', (event) => {
-  assert<GridItem>(event.detail.value);
+  assert<User>(event.detail.value);
 });
 
 grid.addEventListener('cell-activate', (event) => {
-  assert<GridItemModel>(event.detail.model);
+  assert<GridItemModel<User>>(event.detail.model);
 });
 
 grid.addEventListener('column-reorder', (event) => {
-  assert<GridColumnElement[]>(event.detail.columns);
+  assert<Array<GridColumnElement<User>>>(event.detail.columns);
 });
 
 grid.addEventListener('column-resize', (event) => {
-  assert<GridColumnElement>(event.detail.resizedColumn);
+  assert<GridColumnElement<User>>(event.detail.resizedColumn);
 });
 
 grid.addEventListener('loading-changed', (event) => {
@@ -31,19 +33,19 @@ grid.addEventListener('loading-changed', (event) => {
 });
 
 grid.addEventListener('expanded-items-changed', (event) => {
-  assert<GridItem[]>(event.detail.value);
+  assert<User[]>(event.detail.value);
 });
 
 grid.addEventListener('selected-items-changed', (event) => {
-  assert<GridItem[]>(event.detail.value);
+  assert<User[]>(event.detail.value);
 });
 
 grid.addEventListener('grid-dragstart', (event) => {
-  assert<GridItem[]>(event.detail.draggedItems);
+  assert<User[]>(event.detail.draggedItems);
 });
 
 grid.addEventListener('grid-drop', (event) => {
-  assert<GridItem>(event.detail.dropTargetItem);
+  assert<User>(event.detail.dropTargetItem);
   assert<GridDropLocation>(event.detail.dropLocation);
 });
 


### PR DESCRIPTION
Fixes #2104

This is a breaking change which consists of the following:

1. Removes `GridItem` which is just an alias for `unknown` and therefore is pretty much useless;
2. Change certain types to use generics using the type cast like this:

```ts
const grid = this.shadowRoot.querySelector('vaadin-grid') as GridElement<User>
````

I had to copy-paste and override the related properties on the `GridElement` class instead of modifying relevant mixins. 
This is needed because of the TypeScript limitation, see https://github.com/vaadin/vaadin-combo-box/issues/985#issuecomment-749380363 and https://github.com/microsoft/TypeScript/issues/24122.