### PR TITLE
chore: align events JSDoc annotations [skip ci]

### DIFF
--- a/src/vaadin-grid-active-item-mixin.js
+++ b/src/vaadin-grid-active-item-mixin.js
@@ -82,6 +82,18 @@ export const ActiveItemMixin = (superClass) =>
     _isFocusable(target) {
       return isFocusable(target);
     }
+
+    /**
+     * Fired when the `activeItem` property changes.
+     *
+     * @event active-item-changed
+     */
+
+    /**
+     * Fired when the cell is activated with click or keyboard.
+     *
+     * @event cell-activate
+     */
   };
 
 /**

--- a/src/vaadin-grid-data-provider-mixin.js
+++ b/src/vaadin-grid-data-provider-mixin.js
@@ -515,4 +515,16 @@ export const DataProviderMixin = (superClass) =>
         this.scrollToIndex(index);
       }
     }
+
+    /**
+     * Fired when the `expandedItems` property changes.
+     *
+     * @event expanded-items-changed
+     */
+
+    /**
+     * Fired when the `loading` property changes.
+     *
+     * @event loading-changed
+     */
   };

--- a/src/vaadin-grid-selection-mixin.js
+++ b/src/vaadin-grid-selection-mixin.js
@@ -94,4 +94,10 @@ export const SelectionMixin = (superClass) =>
         this.deselectItem(instance.item);
       }
     }
+
+    /**
+     * Fired when the `selectedItems` property changes.
+     *
+     * @event selected-items-changed
+     */
   };


### PR DESCRIPTION
Added JSDoc annotations for events from the mixins which were missing from the [API docs](https://cdn.vaadin.com/vaadin-grid/6.0.0-alpha1/#/elements/vaadin-grid#events).