### PR TITLE
fix: make explicit data request when clearing cache with no initial pool (CP: #2119)

### DIFF
--- a/src/vaadin-grid-data-provider-mixin.html
+++ b/src/vaadin-grid-data-provider-mixin.html
@@ -427,7 +427,7 @@ This program is available under Apache License Version 2.0, available at https:/
       this._hasData = false;
       this._assignModels();
 
-      if (!this._effectiveSize) {
+      if (!this._effectiveSize || !this._initialPoolCreated) {
         this._loadPage(0, this._cache);
       }
     }

--- a/test/data-provider.html
+++ b/test/data-provider.html
@@ -606,6 +606,35 @@
       });
     });
 
+    describe('attached', () => {
+
+      it('should have rows when attached and shown after cache is cleared on hidden grid', done => {
+        const grid = document.createElement('vaadin-grid');
+        const col = document.createElement('vaadin-grid-column');
+        col.setAttribute('path', 'item');
+        grid.appendChild(col);
+
+        grid.size = 1;
+        grid.dataProvider = function(params, callback) {
+          callback([{item: 'A'}]);
+        };
+
+        grid.style.display = 'none';
+        document.body.appendChild(grid);
+
+        setTimeout(() => {
+          grid.clearCache();
+          grid.removeAttribute('style');
+          expect(getCellContent(getFirstVisibleItem(grid)).textContent).to.equal('A');
+
+          // Grid should be removed after test as was attached to body.
+          document.body.removeChild(grid);
+          done();
+        });
+      });
+
+    });
+
     describe('fixture table', () => {
       let container, grid;
 


### PR DESCRIPTION
* fix: increase pool before clearing cache when sorting; add test

* Enhance the fix by making explicit data request

* Remove height condition

* Move the test

* Apply Serhii's suggestions

Co-authored-by: Serhii Kulykov <iamkulykov@gmail.com>

* Update test

Co-authored-by: Serhii Kulykov <iamkulykov@gmail.com>