### PR TITLE
Cherrypick: Flush debounceIncreasePool on loadPage (#2131)

### DIFF
--- a/src/vaadin-grid-data-provider-mixin.js
+++ b/src/vaadin-grid-data-provider-mixin.js
@@ -342,7 +342,7 @@ export const DataProviderMixin = (superClass) =>
           filters: this._mapFilters(),
           parentItem: cache.parentItem
         };
-
+        this._debounceIncreasePool && this._debounceIncreasePool.flush();
         this.dataProvider(params, (items, size) => {
           if (size !== undefined) {
             cache.size = size;

--- a/test/data-provider.test.js
+++ b/test/data-provider.test.js
@@ -320,7 +320,7 @@ describe('data provider', () => {
         // Effective size should change in between the data requests
         expect(renderSpy.called).to.be.true;
         expect(increasePoolSpy.callCount).to.above(1);
-        expect(updateItemSpy.callCount).to.be.below(90);
+        expect(updateItemSpy.callCount).to.be.below(180);
       });
 
       it('should keep item expanded on itemIdPath change', () => {

--- a/test/scroll-to-index.test.js
+++ b/test/scroll-to-index.test.js
@@ -19,6 +19,11 @@ const fixtures = {
         <template>[[index]]</template>
       </vaadin-grid-column>
     </vaadin-grid>
+  `,
+  treeGrid: `
+    <vaadin-grid style="width: 200px; height: 500px;">
+      <vaadin-grid-tree-column path="name" header="foo" item-has-children-path="hasChildren"></vaadin-grid-tree-column>
+    </vaadin-grid>
   `
 };
 
@@ -201,6 +206,38 @@ describe('scroll to index', () => {
       grid.scrollToIndex(grid.items.length);
 
       expect(grid.$.items.children[0]._item.index).to.equal(0);
+    });
+  });
+  describe('Tree grid', () => {
+    // Issue https://github.com/vaadin/vaadin-grid/issues/2107
+    it('should display correctly when scrolled to bottom immediately after setting dataProvider', (done) => {
+      const grid = fixtures.treeGrid;
+      grid.size = 1;
+      const numberOfChidren = 250;
+      grid.itemIdPath = 'name';
+      const PARENT = { name: 'PARENT', hasChildren: true };
+      grid.dataProvider = ({ page, parentItem }, cb) => {
+        setTimeout(() => {
+          if (!parentItem) {
+            cb([PARENT], 1);
+            return;
+          }
+
+          const offset = page * grid.pageSize;
+          cb(
+            [...new Array(grid.pageSize)].map((_, index) => {
+              return { name: 'Child ' + (offset + index), hasChildren: false };
+            }),
+            numberOfChidren
+          );
+          if (page > 0) {
+            expect(grid._physicalCount).to.be.above(10);
+            done();
+          }
+        });
+      };
+      grid.expandedItems = [PARENT];
+      grid.scrollToIndex(250);
     });
   });
 });

--- a/test/scroll-to-index.test.js
+++ b/test/scroll-to-index.test.js
@@ -211,7 +211,7 @@ describe('scroll to index', () => {
   describe('Tree grid', () => {
     // Issue https://github.com/vaadin/vaadin-grid/issues/2107
     it('should display correctly when scrolled to bottom immediately after setting dataProvider', (done) => {
-      const grid = fixtures.treeGrid;
+      const grid = fixtureSync(fixtures.treeGrid);
       grid.size = 1;
       const numberOfChidren = 250;
       grid.itemIdPath = 'name';


### PR DESCRIPTION
fix: Flush debounceIncreasePool on loadPage
cherrypick: #2131
fixes: #2107
Warranty: Fixes TreeGrid regression where blank areas are displayed when an initial scroll happens.