### PR TITLE
fix: do not throw error when adding a new row while a column is hidden

### DIFF
--- a/src/vaadin-grid-column.js
+++ b/src/vaadin-grid-column.js
@@ -310,6 +310,11 @@ export const ColumnBaseMixin = (superClass) =>
 
     /** @private */
     __setColumnTemplateOrRenderer(template, renderer, cells) {
+      // no renderer or template needed in a hidden column
+      if (this.hidden) {
+        return;
+      }
+
       if (template && renderer) {
         throw new Error('You should only use either a renderer or a template');
       }
@@ -340,7 +345,7 @@ export const ColumnBaseMixin = (superClass) =>
 
     /** @private */
     _setBodyTemplateOrRenderer(template, renderer, cells) {
-      if ((template || renderer) && cells && !this.hidden) {
+      if ((template || renderer) && cells) {
         this.__setColumnTemplateOrRenderer(template, renderer, cells);
       }
     }

--- a/src/vaadin-grid-column.js
+++ b/src/vaadin-grid-column.js
@@ -340,7 +340,7 @@ export const ColumnBaseMixin = (superClass) =>
 
     /** @private */
     _setBodyTemplateOrRenderer(template, renderer, cells) {
-      if ((template || renderer) && cells) {
+      if ((template || renderer) && cells && !this.hidden) {
         this.__setColumnTemplateOrRenderer(template, renderer, cells);
       }
     }

--- a/test/column.test.js
+++ b/test/column.test.js
@@ -186,6 +186,12 @@ describe('column', () => {
         const details = grid.shadowRoot.querySelector('#items [part~="details-cell"]')._content;
         expect(details.textContent).to.equal('row-details');
       });
+
+      it('should not throw error when adding a new row with a hidden column', () => {
+        column.hidden = true;
+        flushGrid(grid);
+        expect(() => (grid.size = 11)).to.not.throw(Error);
+      });
     });
 
     describe('path', () => {


### PR DESCRIPTION
Fixes #2136.

A hidden column removes all of it cells from the DOM. 

https://github.com/vaadin/vaadin-grid/blob/6221b00683c82cd011126fa35cadcb4b64c9fa4f/src/vaadin-grid-column.js#L595

All columns's `_setBodyTemplateOrRenderer()` method are called when the `_cells` property changes (e.g.: a new row is added). 

https://github.com/vaadin/vaadin-grid/blob/6221b00683c82cd011126fa35cadcb4b64c9fa4f/src/vaadin-grid-column.js#L153

This in turn calls the column's `__setColumnTemplateOrRenderer()` method and here, for each cell in the column, the grid's `__getRowModel()` method is called with the cell's parent (i.e.: the `tr` element, obtained with `cell.parentElement`)

https://github.com/vaadin/vaadin-grid/blob/6221b00683c82cd011126fa35cadcb4b64c9fa4f/src/vaadin-grid-column.js#L312-L318

However, since the cells of a hidden column were removed from the DOM, their `parentElement` is `null`, thus throwing an error when trying to access any of its properties in the grid's  `__getRowModel()` method. 

https://github.com/vaadin/vaadin-grid/blob/6221b00683c82cd011126fa35cadcb4b64c9fa4f/src/vaadin-grid.js#L880-L889

Just added an extra check to make sure the `__setColumnTemplateOrRenderer()` only gets called from the `_setBodyTemplateOrRenderer()` method if the column is not hidden i.e.: visible.

