### PR TITLE
cherry-pick: check if grid column is attached

### DIFF
--- a/src/vaadin-grid.js
+++ b/src/vaadin-grid.js
@@ -508,7 +508,9 @@ class GridElement extends ElementMixin(
     }
 
     if (this._columnTree) {
-      this._columnTree[this._columnTree.length - 1].forEach((c) => c.notifyPath && c.notifyPath('_cells.*', c._cells));
+      this._columnTree[this._columnTree.length - 1].forEach(
+        (c) => c.isConnected && c.notifyPath && c.notifyPath('_cells.*', c._cells)
+      );
     }
 
     beforeNextRender(this, () => {

--- a/test/column.test.js
+++ b/test/column.test.js
@@ -552,4 +552,13 @@ describe('column', () => {
       expect(column._bodyTemplate).to.eql(template2);
     });
   });
+
+  it('should not throw an exception when size is changed after removing column', () => {
+    expect(grid.size).to.equal(10);
+    expect(column.isConnected).to.be.true;
+    column.remove();
+    expect(column.isConnected).to.be.false;
+    expect(() => (grid.size = 11)).not.to.throw();
+    expect(grid.size).to.equal(11);
+  });
 });


### PR DESCRIPTION
fix: check if grid column is attached (vaadin/web-components#195)

Fixes: vaadin/vaadin-grid#1981
Warranty: Prevent an exception when changing the size after removing columns