### PR TITLE
cherry-pick fix: update filtering and sorting when grid and columns are attached / detached (#2122)

### DIFF
--- a/src/vaadin-grid-dynamic-columns-mixin.html
+++ b/src/vaadin-grid-dynamic-columns-mixin.html
@@ -86,8 +86,14 @@ This program is available under Apache License Version 2.0, available at https:/
           this._rowDetailsTemplate = rowDetailsTemplate;
         }
 
-        if (info.addedNodes.filter(this._isColumnElement).length > 0 ||
-          info.removedNodes.filter(this._isColumnElement).length > 0) {
+        const hasColumnElements = (nodeCollection) => nodeCollection.filter(this._isColumnElement).length > 0;
+        if (hasColumnElements(info.addedNodes) || hasColumnElements(info.removedNodes)) {
+          const allRemovedCells = info.removedNodes.flatMap((c) => c._allCells);
+          const filterNotConnected = (element) =>
+            allRemovedCells.filter((cell) => cell._content.contains(element)).length;
+
+          this.__removeSorters(this._sorters.filter(filterNotConnected));
+          this.__removeFilters(this._filters.filter(filterNotConnected));
           this._updateColumnTree();
         }
 

--- a/src/vaadin-grid-dynamic-columns-mixin.html
+++ b/src/vaadin-grid-dynamic-columns-mixin.html
@@ -88,7 +88,7 @@ This program is available under Apache License Version 2.0, available at https:/
 
         const hasColumnElements = (nodeCollection) => nodeCollection.filter(this._isColumnElement).length > 0;
         if (hasColumnElements(info.addedNodes) || hasColumnElements(info.removedNodes)) {
-          const allRemovedCells = info.removedNodes.flatMap((c) => c._allCells);
+          const allRemovedCells = info.removedNodes.reduce((list, c) => list.concat(c._allCells), []);
           const filterNotConnected = (element) =>
             allRemovedCells.filter((cell) => cell._content.contains(element)).length;
 

--- a/src/vaadin-grid-filter-mixin.html
+++ b/src/vaadin-grid-filter-mixin.html
@@ -33,13 +33,34 @@ This program is available under Apache License Version 2.0, available at https:/
 
     /** @private */
     _filterChanged(e) {
-      if (this._filters.indexOf(e.target) === -1) {
-        this._filters.push(e.target);
-      }
-
       e.stopPropagation();
 
-      if (this.dataProvider) {
+      this.__addFilter(e.target);
+      this.__applyFilters();
+    }
+
+    /** @private */
+    __removeFilters(filtersToRemove) {
+      if (filtersToRemove.length == 0) {
+        return;
+      }
+
+      this._filters = this._filters.filter((filter) => filtersToRemove.indexOf(filter) < 0);
+      this.__applyFilters();
+    }
+
+    /** @private */
+    __addFilter(filter) {
+      const filterIndex = this._filters.indexOf(filter);
+
+      if (filterIndex === -1) {
+        this._filters.push(filter);
+      }
+    }
+
+    /** @private */
+    __applyFilters() {
+      if (this.dataProvider && this.isAttached) {
         this.clearCache();
       }
     }

--- a/src/vaadin-grid-sort-mixin.html
+++ b/src/vaadin-grid-sort-mixin.html
@@ -70,30 +70,60 @@ This program is available under Apache License Version 2.0, available at https:/
     /** @private */
     _onSorterChanged(e) {
       const sorter = e.target;
+      e.stopPropagation();
+      this.__updateSorter(sorter);
+      this.__applySorters();
+    }
 
-      this._removeArrayItem(this._sorters, sorter);
+    /** @private */
+    __removeSorters(sortersToRemove) {
+      if (sortersToRemove.length == 0) {
+        return;
+      }
+
+      this._sorters = this._sorters.filter((sorter) => sortersToRemove.indexOf(sorter) < 0);
+      if (this.multiSort) {
+        this.__updateSortOrders();
+      }
+      this.__applySorters();
+    }
+
+    /** @private */
+    __updateSortOrders() {
+      this._sorters.forEach((sorter, index) => (sorter._order = this._sorters.length > 1 ? index : null), this);
+    }
+
+    /** @private */
+    __updateSorter(sorter) {
+      if (!sorter.direction && this._sorters.indexOf(sorter) === -1) {
+        return;
+      }
       sorter._order = null;
 
       if (this.multiSort) {
+        this._removeArrayItem(this._sorters, sorter);
         if (sorter.direction) {
           this._sorters.unshift(sorter);
         }
-
+        this.__updateSortOrders();
         this._sorters.forEach((sorter, index) => sorter._order = this._sorters.length > 1 ? index : null, this);
       } else {
         if (sorter.direction) {
-          this._sorters.forEach(sorter => {
+          const otherSorters = this._sorters.filter((s) => s != sorter);
+          this._sorters = [sorter];
+          otherSorters.forEach((sorter) => {
             sorter._order = null;
             sorter.direction = null;
           });
-          this._sorters = [sorter];
         }
       }
+    }
 
-      e.stopPropagation();
-
+    /** @private */
+    __applySorters() {
       if (this.dataProvider &&
-        // No need to clear cache if sorters didn't change
+        // No need to clear cache if sorters didn't change and grid is attached
+        this.isAttached &&
         JSON.stringify(this._previousSorters) !== JSON.stringify(this._mapSorters())) {
         this.clearCache();
       }

--- a/src/vaadin-grid-sorter.html
+++ b/src/vaadin-grid-sorter.html
@@ -141,14 +141,14 @@ This program is available under Apache License Version 2.0, available at https:/
             /** @private */
             _isConnected: {
               type: Boolean,
-              value: false
+              observer: '__isConnectedChanged'
             }
           };
         }
 
         static get observers() {
           return [
-            '_pathOrDirectionChanged(path, direction, _isConnected)',
+            '_pathOrDirectionChanged(path, direction)',
             '_directionOrOrderChanged(direction, _order)'
           ];
         }
@@ -172,14 +172,26 @@ This program is available under Apache License Version 2.0, available at https:/
         }
 
         /** @private */
-        _pathOrDirectionChanged(path, direction, isConnected) {
-          if (path === undefined || direction === undefined || isConnected === undefined) {
+        _pathOrDirectionChanged() {
+          this.__dispatchSorterChangedEvenIfPossible();
+        }
+
+        /** @private */
+        __isConnectedChanged(newValue, oldValue) {
+          if (oldValue === false) {
             return;
           }
 
-          if (isConnected) {
-            this.dispatchEvent(new CustomEvent('sorter-changed', {bubbles: true, composed: true}));
+          this.__dispatchSorterChangedEvenIfPossible();
+        }
+
+        /** @private */
+        __dispatchSorterChangedEvenIfPossible() {
+          if (this.path === undefined || this.direction === undefined || !this._isConnected) {
+            return;
           }
+
+          this.dispatchEvent(new CustomEvent('sorter-changed', {bubbles: true, composed: true}));
         }
 
         /** @private */

--- a/test/.eslintrc.json
+++ b/test/.eslintrc.json
@@ -36,6 +36,7 @@
     "getContainerCellContent": false,
     "getFirstVisibleItem": false,
     "getLastVisibleItem": false,
+    "getVisibleItems": false,
     "simulateScroll": false,
     "getScrollbarWidth": false,
     "scrollToEnd": false,

--- a/test/filtering.html
+++ b/test/filtering.html
@@ -116,7 +116,7 @@
     }
 
     describe('filtering', () => {
-      let grid;
+      let grid, filter;
 
       beforeEach(() => {
 
@@ -126,6 +126,7 @@
         if (grid._observer.flush) {
           grid._observer.flush();
         }
+        filter = grid._filters[0];
       });
 
       it('should have filters', () => {
@@ -136,6 +137,21 @@
 
       it('should have default inputs', () => {
         grid._filters.forEach(filter => expect(filter.$.filter.clientHeight).to.be.greaterThan(0));
+      });
+
+      it('should not keep references to filters when column is removed', () => {
+        grid.removeChild(grid.firstElementChild);
+        flushGrid(grid);
+        expect(grid._filters).to.not.contain(filter);
+      });
+
+      it('should keep references to filters for columns that are not removed', () => {
+        expect(grid._filters.length).to.eql(2);
+        expect(grid._filters[1].path).to.eql('last');
+        grid.removeChild(grid.firstElementChild.nextElementSibling);
+        flushGrid(grid);
+        expect(grid._filters.length).to.eql(1);
+        expect(grid._filters[0].path).to.eql('first');
       });
 
       it('should pass filters to dataProvider', done => {
@@ -221,8 +237,7 @@
     });
 
     describe('array data provider', () => {
-
-      let grid;
+      let grid, filterFirst, filterSecond;
 
       beforeEach(() => {
 
@@ -230,8 +245,11 @@
         flushGrid(grid);
 
         flushFilters(grid);
-        grid._filters[0].value = '';
-        grid._filters[1].value = '';
+        filterFirst = grid._filters[0];
+        filterSecond = grid._filters[1];
+
+        filterFirst.value = '';
+        filterSecond.value = '';
         flushFilters(grid);
         grid.items = [{
           first: 'foo',
@@ -260,6 +278,32 @@
         grid._filters[0].value = 'r';
         flushFilters(grid);
         expect(getBodyCellContent(grid, 0, 0).innerText).to.equal('bar');
+      });
+
+      it('should update filtering when column is removed', () => {
+        filterFirst.value = 'bar';
+        flushFilters(grid);
+
+        grid.removeChild(grid.firstElementChild);
+        flushGrid(grid);
+
+        expect(getVisibleItems(grid).length).to.equal(3);
+      });
+
+      it('should not filter items before grid is re-attached', () => {
+        filterFirst.value = 'bar';
+        flushFilters(grid);
+
+        const parentNode = grid.parentNode;
+        parentNode.removeChild(grid);
+        grid.removeChild(grid.firstElementChild);
+        flushGrid(grid);
+
+        expect(Object.keys(grid._cache.items).length).to.equal(1);
+
+        parentNode.appendChild(grid);
+
+        expect(Object.keys(grid._cache.items).length).to.equal(3);
       });
 
       it('should sort filtered items', () => {

--- a/test/sorting.html
+++ b/test/sorting.html
@@ -164,6 +164,7 @@
 
         beforeEach(() => {
           grid = fixture('dom-operations');
+          flushGrid(grid);
 
           // TODO: find better way to select
           columnFirst = grid.querySelectorAll('vaadin-grid-sort-column')[0];

--- a/test/sorting.html
+++ b/test/sorting.html
@@ -82,6 +82,15 @@
     </template>
   </test-fixture>
 
+  <test-fixture id="dom-operations">
+    <template>
+      <vaadin-grid style="width: 400px; height: 200px;" multi-sort>
+        <vaadin-grid-sort-column path="first" direction="desc"></vaadin-grid-sort-column>
+        <vaadin-grid-sort-column path="second" direction="asc"></vaadin-grid-sort-column>
+        <vaadin-grid-sort-column path="third" direction="desc"></vaadin-grid-sort-column>
+      </vaadin-grid>
+    </template>
+  </test-fixture>
   <script>
     describe('sorting', () => {
 
@@ -147,6 +156,82 @@
           const clickEvent = clickSorter(sorter);
 
           expect(clickEvent.defaultPrevented).to.be.true;
+        });
+      });
+
+      describe('DOM operations', () => {
+        let grid, sorterFirst, sorterSecond, sorterThird, columnFirst, columnThird;
+
+        beforeEach(() => {
+          grid = fixture('dom-operations');
+
+          // TODO: find better way to select
+          columnFirst = grid.querySelectorAll('vaadin-grid-sort-column')[0];
+          columnThird = grid.querySelectorAll('vaadin-grid-sort-column')[2];
+
+          sorterFirst = getHeaderCellContent(grid, 0, 0).querySelector('vaadin-grid-sorter');
+          sorterSecond = getHeaderCellContent(grid, 0, 1).querySelector('vaadin-grid-sorter');
+          sorterThird = getHeaderCellContent(grid, 0, 2).querySelector('vaadin-grid-sorter');
+
+          grid.items = [
+            {first: '1', second: '2', third: '3'},
+            {first: '2', second: '3', third: '1'},
+            {first: '3', second: '1', third: '2'}
+          ];
+
+          flushGrid(grid);
+        });
+
+        it('should preserve sort order for sorters when grid is re-attached', () => {
+          click(sorterSecond);
+          const parentNode = grid.parentNode;
+          parentNode.removeChild(grid);
+          parentNode.appendChild(grid);
+
+          expect(sorterFirst._order).to.equal(2);
+          expect(sorterSecond._order).to.equal(0);
+          expect(sorterThird._order).to.equal(1);
+        });
+
+        it('should not keep references to sorters when column is removed', () => {
+          grid.removeChild(columnFirst);
+          flushGrid(grid);
+          expect(grid._sorters).to.not.contain(sorterFirst);
+        });
+
+        it('should update sorting when column is removed', () => {
+          grid.removeChild(columnThird);
+          flushGrid(grid);
+
+          expect(getBodyCellContent(grid, 0, 0).innerText).to.equal('3');
+          expect(getBodyCellContent(grid, 1, 0).innerText).to.equal('1');
+          expect(getBodyCellContent(grid, 2, 0).innerText).to.equal('2');
+
+          expect(getBodyCellContent(grid, 0, 1).innerText).to.equal('1');
+          expect(getBodyCellContent(grid, 1, 1).innerText).to.equal('2');
+          expect(getBodyCellContent(grid, 2, 1).innerText).to.equal('3');
+        });
+
+        it('should update sort order when column removed and grid is not attached', () => {
+          const parentNode = grid.parentNode;
+          parentNode.removeChild(grid);
+
+          grid.removeChild(columnThird);
+          flushGrid(grid);
+          expect(sorterFirst._order).to.equal(1);
+          expect(sorterSecond._order).to.equal(0);
+        });
+
+        it('should not sort items before grid is re-attached', () => {
+          const parentNode = grid.parentNode;
+          parentNode.removeChild(grid);
+
+          grid.removeChild(columnThird);
+          flushGrid(grid);
+          expect(getBodyCellContent(grid, 0, 1).innerText).to.equal('2');
+
+          parentNode.appendChild(grid);
+          expect(getBodyCellContent(grid, 0, 1).innerText).to.equal('1');
         });
       });
 
@@ -389,7 +474,7 @@
             grid.dataProvider.reset();
             sorterFirst.direction = 'desc';
 
-            expect(grid.dataProvider.args[1][0].sortOrders.length).to.eql(1);
+            expect(grid.dataProvider.args[0][0].sortOrders.length).to.eql(1);
           });
 
           it('should remove order from sorters', () => {


### PR DESCRIPTION
fix: update filtering and sorting when grid and columns are attached / detached (#2122)

Fixes: #1969
Warranty: Fixes exception related to sorting when recreating columns