### PR TITLE
fix: disable grid section focus target in interaction mode (#1960) (CP 19.0)

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "@rollup/plugin-node-resolve": "^11.0.0",
     "@web/dev-server": "^0.1.17",
     "@web/test-runner": "^0.13.3",
+    "@web/test-runner-commands": "^0.4.5",
     "@web/test-runner-saucelabs": "^0.5.0",
     "eslint": "^7.13.0",
     "eslint-config-prettier": "^6.15.0",

--- a/src/vaadin-grid-keyboard-navigation-mixin.js
+++ b/src/vaadin-grid-keyboard-navigation-mixin.js
@@ -45,7 +45,27 @@ export const KeyboardNavigationMixin = (superClass) =>
         },
 
         /** @private */
-        _focusedColumnOrder: Number
+        _focusedColumnOrder: Number,
+
+        /**
+         * Indicates whether the grid is currently in interaction mode.
+         * In interaction mode the user is currently interacting with a control,
+         * such as an input or a select, within a cell.
+         * In interaction mode keyboard navigation between cells is disabled.
+         * Interaction mode also prevents the focus target cell of that section of
+         * the grid from receiving focus, allowing the user to switch focus to
+         * controls in adjacent cells, rather than focussing the outer cell
+         * itself.
+         * @type {boolean}
+         * @private
+         */
+        interacting: {
+          type: Boolean,
+          value: false,
+          reflectToAttribute: true,
+          readOnly: true,
+          observer: '_interactingChanged'
+        }
       };
     }
 
@@ -82,8 +102,16 @@ export const KeyboardNavigationMixin = (superClass) =>
         oldFocusable.setAttribute('tabindex', '-1');
       }
       if (focusable) {
-        focusable.setAttribute('tabindex', '0');
+        this._updateGridSectionFocusTarget(focusable);
       }
+    }
+
+    /** @private */
+    _interactingChanged() {
+      // Update focus targets when entering / exiting interaction mode
+      this._updateGridSectionFocusTarget(this._headerFocusable);
+      this._updateGridSectionFocusTarget(this._itemsFocusable);
+      this._updateGridSectionFocusTarget(this._footerFocusable);
     }
 
     /**
@@ -119,7 +147,7 @@ export const KeyboardNavigationMixin = (superClass) =>
       }
 
       this._detectInteracting(e);
-      if (this.hasAttribute('interacting') && keyGroup !== 'Interaction') {
+      if (this.interacting && keyGroup !== 'Interaction') {
         // When in the interacting mode, only the “Interaction” keys are handled.
         keyGroup = undefined;
       }
@@ -338,32 +366,32 @@ export const KeyboardNavigationMixin = (superClass) =>
       let wantInteracting;
       switch (key) {
         case 'Enter':
-          wantInteracting = this.hasAttribute('interacting') ? !localTargetIsTextInput : true;
+          wantInteracting = this.interacting ? !localTargetIsTextInput : true;
           break;
         case 'Escape':
           wantInteracting = false;
           break;
         case 'F2':
-          wantInteracting = !this.hasAttribute('interacting');
+          wantInteracting = !this.interacting;
           break;
       }
 
       const { cell } = this._parseEventPath(e.composedPath());
 
-      if (this.hasAttribute('interacting') !== wantInteracting) {
+      if (this.interacting !== wantInteracting) {
         if (wantInteracting) {
           const focusTarget = cell._content.querySelector('[focus-target]') || cell._content.firstElementChild;
           if (focusTarget) {
             e.preventDefault();
             focusTarget.focus();
-            this._toggleAttribute('interacting', true, this);
+            this._setInteracting(true);
             this._toggleAttribute('navigating', false, this);
           }
         } else {
           e.preventDefault();
           this._focusedColumnOrder = undefined;
           cell.focus();
-          this._toggleAttribute('interacting', false, this);
+          this._setInteracting(false);
           this._toggleAttribute('navigating', true, this);
         }
       }
@@ -473,7 +501,7 @@ export const KeyboardNavigationMixin = (superClass) =>
         // tabbed (shift-tabbed) into the grid. Move the focus to
         // the first (the last) focusable.
         this._predictFocusStepTarget(rootTarget, rootTarget === this.$.table ? 1 : -1).focus();
-        this._toggleAttribute('interacting', false, this);
+        this._setInteracting(false);
       } else {
         this._detectInteracting(e);
       }
@@ -490,16 +518,17 @@ export const KeyboardNavigationMixin = (superClass) =>
 
     /** @private */
     _onCellFocusIn(e) {
+      const location = this._getCellFocusEventLocation(e);
       this._detectInteracting(e);
 
-      if (e.composedPath().indexOf(this.$.table) === 3) {
-        const cell = e.composedPath()[0];
-        this._activeRowGroup = cell.parentNode.parentNode;
-        if (this._activeRowGroup === this.$.header) {
+      if (location) {
+        const { section, cell } = location;
+        this._activeRowGroup = section;
+        if (this.$.header === section) {
           this._headerFocusable = cell;
-        } else if (this._activeRowGroup === this.$.items) {
+        } else if (this.$.items === section) {
           this._itemsFocusable = cell;
-        } else if (this._activeRowGroup === this.$.footer) {
+        } else if (this.$.footer === section) {
           this._footerFocusable = cell;
         }
         // Inform cell content of the focus (used in <vaadin-grid-sorter>)
@@ -518,13 +547,14 @@ export const KeyboardNavigationMixin = (superClass) =>
       }
     }
 
-    /** @private */
+    /** @private
+     * Enables interaction mode if a cells descendant receives focus or keyboard
+     * input. Disables it if the event is not related to cell content.
+     * @param {!KeyboardEvent|!FocusEvent} e
+     */
     _detectInteracting(e) {
-      this._toggleAttribute(
-        'interacting',
-        e.composedPath().some((el) => el.localName === 'vaadin-grid-cell-content'),
-        this
-      );
+      const isInteracting = e.composedPath().some((el) => el.localName === 'vaadin-grid-cell-content');
+      this._setInteracting(isInteracting);
     }
 
     /** @private */
@@ -533,6 +563,21 @@ export const KeyboardNavigationMixin = (superClass) =>
       if (rowGroup === this.$.items) {
         this._focusedItemIndex = row.index;
       }
+    }
+
+    /** @private
+     * Enables or disables the focus target cell of the containing section of the
+     * grid from receiving focus, based on whether the user is interacting with
+     * that section of the grid.
+     * @param {HTMLTableCellElement} focusTargetCell
+     */
+    _updateGridSectionFocusTarget(focusTargetCell) {
+      if (!focusTargetCell) return;
+
+      const section = this._getGridSectionFromFocusTarget(focusTargetCell);
+      const isInteractingWithinActiveSection = this.interacting && section === this._activeRowGroup;
+
+      focusTargetCell.tabIndex = isInteractingWithinActiveSection ? -1 : 0;
     }
 
     /**
@@ -643,5 +688,48 @@ export const KeyboardNavigationMixin = (superClass) =>
     /** @private */
     _elementMatches(el, query) {
       return el.matches ? el.matches(query) : Array.from(el.parentNode.querySelectorAll(query)).indexOf(el) !== -1;
+    }
+
+    /**
+     * @typedef {Object} CellFocusEventLocation
+     * @property {HTMLTableSectionElement} section - The grid section element that contains the focused cell (header, body, or footer)
+     * @property {HTMLElement} cell - The cell element that received focus or is ancestor of the element that received focus
+     * @private
+     */
+    /**
+     * Takes a focus event and returns a location object describing in which
+     * section of the grid and in or on which cell the focus event occurred.
+     * The focus event may either target the cell itself or contents of the cell.
+     * If the event does not target a cell then null is returned.
+     * @param {FocusEvent} e
+     * @returns {CellFocusEventLocation | null}
+     * @private
+     */
+    _getCellFocusEventLocation(e) {
+      const path = e.composedPath();
+      const tableIndex = path.indexOf(this.$.table);
+      // Assuming ascending path to table is: [...,] th|td, tr, thead|tbody, table [,...]
+      const section = tableIndex >= 2 ? path[tableIndex - 1] : null;
+      const cell = tableIndex >= 3 ? path[tableIndex - 3] : null;
+
+      if (!section || !cell) return null;
+
+      return {
+        section,
+        cell
+      };
+    }
+
+    /**
+     * Helper method that maps a focus target cell to the containing grid section
+     * @param {HTMLTableCellElement} focusTargetCell
+     * @returns {HTMLTableSectionElement | null}
+     * @private
+     */
+    _getGridSectionFromFocusTarget(focusTargetCell) {
+      if (focusTargetCell === this._headerFocusable) return this.$.header;
+      if (focusTargetCell === this._itemsFocusable) return this.$.items;
+      if (focusTargetCell === this._footerFocusable) return this.$.footer;
+      return null;
     }
   };

--- a/test/keyboard-navigation.test.js
+++ b/test/keyboard-navigation.test.js
@@ -25,6 +25,7 @@ import '../vaadin-grid-column-group.js';
 
 // Detect if tests are running in Sauce Labs, see `web-test-runner.config.js`
 const isSauceLabsLauncher = window.browserLauncher === 'saucelabs';
+const itNoSauce = isSauceLabsLauncher ? it.skip : it;
 
 window.top.focus && window.top.focus();
 window.focus();
@@ -1617,20 +1618,17 @@ describe('keyboard navigation', () => {
     });
 
     // Skip: sendKeys is not supported in Sauce Labs launcher
-    (isSauceLabsLauncher ? it.skip : it)(
-      'should focus the next input element when tabbing in interaction mode',
-      async () => {
-        // Focus first input
-        right();
-        enter();
+    itNoSauce('should focus the next input element when tabbing in interaction mode', async () => {
+      // Focus first input
+      right();
+      enter();
 
-        const nextInput = getCellInput(0, 2);
+      const nextInput = getCellInput(0, 2);
 
-        await sendKeys({ press: 'Tab' });
+      await sendKeys({ press: 'Tab' });
 
-        expect(document.activeElement).to.equal(nextInput);
-      }
-    );
+      expect(document.activeElement).to.equal(nextInput);
+    });
 
     /**
      * This test is a workaround for the fact that the sendKeys command does not support shift+tabbing ATM
@@ -1638,39 +1636,33 @@ describe('keyboard navigation', () => {
      * was focused, despite the focus target cell being in the tab order between current and previous input
      */
     // Skip: sendKeys is not supported in Sauce Labs launcher
-    (isSauceLabsLauncher ? it.skip : it)(
-      'should skip the grid focus target when tabbing in interaction mode',
-      async () => {
-        // Focus first input
-        right();
-        enter();
+    itNoSauce('should skip the grid focus target when tabbing in interaction mode', async () => {
+      // Focus first input
+      right();
+      enter();
 
-        const nextInput = getCellInput(0, 2);
+      const nextInput = getCellInput(0, 2);
 
-        // Modify grid state to get the focus target cell in the tab order between current and next input
-        grid._itemsFocusable = getRowCell(0, 2);
+      // Modify grid state to get the focus target cell in the tab order between current and next input
+      grid._itemsFocusable = getRowCell(0, 2);
 
-        await sendKeys({ press: 'Tab' });
+      await sendKeys({ press: 'Tab' });
 
-        expect(document.activeElement).to.equal(nextInput);
-      }
-    );
+      expect(document.activeElement).to.equal(nextInput);
+    });
 
     // Skip: sendKeys is not supported in Sauce Labs launcher
-    (isSauceLabsLauncher ? it.skip : it)(
-      'should move cell focus target when focusing the next input element in interaction mode',
-      async () => {
-        // Focus first input
-        right();
-        enter();
+    itNoSauce('should move cell focus target when focusing the next input element in interaction mode', async () => {
+      // Focus first input
+      right();
+      enter();
 
-        const nextCell = getRowCell(0, 2);
+      const nextCell = getRowCell(0, 2);
 
-        await sendKeys({ press: 'Tab' });
+      await sendKeys({ press: 'Tab' });
 
-        expect(grid._itemsFocusable).to.equal(nextCell);
-      }
-    );
+      expect(grid._itemsFocusable).to.equal(nextCell);
+    });
 
     it('should focus the element with `focus-target` when entering interaction mode', () => {
       const cell = getRowCell(0, 1);

--- a/test/keyboard-navigation.test.js
+++ b/test/keyboard-navigation.test.js
@@ -8,6 +8,7 @@ import {
   up as mouseUp,
   keyboardEventFor
 } from '@polymer/iron-test-helpers/mock-interactions.js';
+import { sendKeys } from '@web/test-runner-commands';
 import {
   flushGrid,
   getCell,
@@ -99,10 +100,19 @@ function getRowFirstCell(rowIndex) {
   return getRowCell(rowIndex, 0);
 }
 
-function focusFirstBodyInput(rowIndex) {
-  const cell = getRowCell(rowIndex || 0, 1);
-
+function getCellInput(rowIndex, colIndex) {
+  const cell = getRowCell(rowIndex, colIndex);
   const input = getCellContent(cell).children[0];
+
+  if (!input.nodeName || input.nodeName.toLowerCase() !== 'input') {
+    throw new Error('Cell does not contain an input');
+  }
+
+  return input;
+}
+
+function focusFirstBodyInput(rowIndex) {
+  const input = getCellInput(rowIndex || 0, 1);
   input.focus();
   return input;
 }
@@ -1468,6 +1478,53 @@ describe('keyboard navigation', () => {
   });
 
   describe('interaction mode', () => {
+    before(async () => {
+      grid = fixtureSync(`
+      <vaadin-grid theme="no-border">
+        <template class="row-details">
+          <input type="text">
+        </template>
+        <vaadin-grid-column>
+          <template class="header"></template>
+          <template>[[index]] [[item]]</template>
+          <template class="footer"></template>
+        </vaadin-grid-column>
+        <vaadin-grid-column>
+          <template class="header">
+            <input>
+          </template>
+          <template>
+            <input>
+          </template>
+          <template class="footer">
+            <input>
+          </template>
+        </vaadin-grid-column>
+        <vaadin-grid-column>
+          <template class="header">
+            <input>
+          </template>
+          <template>
+            <input>
+          </template>
+          <template class="footer">
+            <input>
+          </template>
+        </vaadin-grid-column>
+      </vaadin-grid>
+    `);
+
+      scroller = grid.$.scroller;
+      header = grid.$.header;
+      body = grid.$.items;
+      footer = grid.$.footer;
+
+      grid._observer.flush();
+      flushGrid(grid);
+
+      await aTimeout(0);
+    });
+
     beforeEach(() => {
       focusItem(0);
       clickItem(0);
@@ -1482,7 +1539,7 @@ describe('keyboard navigation', () => {
     });
 
     it('should exit interaction mode when blurred', () => {
-      grid.setAttribute('interacting', '');
+      grid._setInteracting(true);
 
       focusable.focus();
 
@@ -1490,7 +1547,7 @@ describe('keyboard navigation', () => {
     });
 
     it('should exit interaction mode when tabbed into', () => {
-      grid.setAttribute('interacting', '');
+      grid._setInteracting(true);
 
       tabToHeader();
 
@@ -1498,7 +1555,7 @@ describe('keyboard navigation', () => {
     });
 
     it('should exit interaction mode when shift-tabbed into', () => {
-      grid.setAttribute('interacting', '');
+      grid._setInteracting(true);
 
       shiftTabToFooter();
 
@@ -1556,14 +1613,51 @@ describe('keyboard navigation', () => {
       spy.restore();
     });
 
-    it('should focus the next input element when tabbing in interaction mode', () => {
-      right(); // focus the cell with input.
+    // Skip: sendKeys is not supported in WTR when using web-driver
+    it.skip('should focus the next input element when tabbing in interaction mode', async () => {
+      // Focus first input
+      right();
       enter();
 
-      tab(getCellContent(getRowCell(0, 1)).children[0]); // tab in the input
+      const nextInput = getCellInput(0, 2);
 
-      // expecting focusable item cell to remain in place, instead actual focus moves.
-      expect(grid._itemsFocusable).to.equal(getRowCell(0, 1));
+      await sendKeys({ press: 'Tab' });
+
+      expect(document.activeElement).to.equal(nextInput);
+    });
+
+    /**
+     * This test is a workaround for the fact that the sendKeys command does not support shift+tabbing ATM
+     * Ideally the test would try to shift tab to the previous input and check that the input in a previous cell
+     * was focused, despite the focus target cell being in the tab order between current and previous input
+     */
+    // Skip: sendKeys is not supported in WTR when using web-driver
+    it.skip('should skip the grid focus target when tabbing in interaction mode', async () => {
+      // Focus first input
+      right();
+      enter();
+
+      const nextInput = getCellInput(0, 2);
+
+      // Modify grid state to get the focus target cell in the tab order between current and next input
+      grid._itemsFocusable = getRowCell(0, 2);
+
+      await sendKeys({ press: 'Tab' });
+
+      expect(document.activeElement).to.equal(nextInput);
+    });
+
+    // Skip: sendKeys is not supported in WTR when using web-driver
+    it.skip('should move cell focus target when focusing the next input element in interaction mode', async () => {
+      // Focus first input
+      right();
+      enter();
+
+      const nextCell = getRowCell(0, 2);
+
+      await sendKeys({ press: 'Tab' });
+
+      expect(grid._itemsFocusable).to.equal(nextCell);
     });
 
     it('should focus the element with `focus-target` when entering interaction mode', () => {
@@ -1728,7 +1822,7 @@ describe('keyboard navigation', () => {
     });
 
     it('should exit interaction mode with escape', () => {
-      grid.setAttribute('interacting', '');
+      grid._setInteracting(true);
 
       escape();
 

--- a/test/keyboard-navigation.test.js
+++ b/test/keyboard-navigation.test.js
@@ -23,6 +23,9 @@ import {
 import '../vaadin-grid.js';
 import '../vaadin-grid-column-group.js';
 
+// Detect if tests are running in Sauce Labs, see `web-test-runner.config.js`
+const isSauceLabsLauncher = window.browserLauncher === 'saucelabs';
+
 window.top.focus && window.top.focus();
 window.focus();
 
@@ -1613,52 +1616,61 @@ describe('keyboard navigation', () => {
       spy.restore();
     });
 
-    // Skip: sendKeys is not supported in WTR when using web-driver
-    it.skip('should focus the next input element when tabbing in interaction mode', async () => {
-      // Focus first input
-      right();
-      enter();
+    // Skip: sendKeys is not supported in Sauce Labs launcher
+    (isSauceLabsLauncher ? it.skip : it)(
+      'should focus the next input element when tabbing in interaction mode',
+      async () => {
+        // Focus first input
+        right();
+        enter();
 
-      const nextInput = getCellInput(0, 2);
+        const nextInput = getCellInput(0, 2);
 
-      await sendKeys({ press: 'Tab' });
+        await sendKeys({ press: 'Tab' });
 
-      expect(document.activeElement).to.equal(nextInput);
-    });
+        expect(document.activeElement).to.equal(nextInput);
+      }
+    );
 
     /**
      * This test is a workaround for the fact that the sendKeys command does not support shift+tabbing ATM
      * Ideally the test would try to shift tab to the previous input and check that the input in a previous cell
      * was focused, despite the focus target cell being in the tab order between current and previous input
      */
-    // Skip: sendKeys is not supported in WTR when using web-driver
-    it.skip('should skip the grid focus target when tabbing in interaction mode', async () => {
-      // Focus first input
-      right();
-      enter();
+    // Skip: sendKeys is not supported in Sauce Labs launcher
+    (isSauceLabsLauncher ? it.skip : it)(
+      'should skip the grid focus target when tabbing in interaction mode',
+      async () => {
+        // Focus first input
+        right();
+        enter();
 
-      const nextInput = getCellInput(0, 2);
+        const nextInput = getCellInput(0, 2);
 
-      // Modify grid state to get the focus target cell in the tab order between current and next input
-      grid._itemsFocusable = getRowCell(0, 2);
+        // Modify grid state to get the focus target cell in the tab order between current and next input
+        grid._itemsFocusable = getRowCell(0, 2);
 
-      await sendKeys({ press: 'Tab' });
+        await sendKeys({ press: 'Tab' });
 
-      expect(document.activeElement).to.equal(nextInput);
-    });
+        expect(document.activeElement).to.equal(nextInput);
+      }
+    );
 
-    // Skip: sendKeys is not supported in WTR when using web-driver
-    it.skip('should move cell focus target when focusing the next input element in interaction mode', async () => {
-      // Focus first input
-      right();
-      enter();
+    // Skip: sendKeys is not supported in Sauce Labs launcher
+    (isSauceLabsLauncher ? it.skip : it)(
+      'should move cell focus target when focusing the next input element in interaction mode',
+      async () => {
+        // Focus first input
+        right();
+        enter();
 
-      const nextCell = getRowCell(0, 2);
+        const nextCell = getRowCell(0, 2);
 
-      await sendKeys({ press: 'Tab' });
+        await sendKeys({ press: 'Tab' });
 
-      expect(grid._itemsFocusable).to.equal(nextCell);
-    });
+        expect(grid._itemsFocusable).to.equal(nextCell);
+      }
+    );
 
     it('should focus the element with `focus-target` when entering interaction mode', () => {
       const cell = getRowCell(0, 1);

--- a/web-test-runner.config.js
+++ b/web-test-runner.config.js
@@ -67,9 +67,26 @@ if (env === 'firefox' || env === 'safari') {
     }
   );
 
+  // Use custom HTML to set global flag that tests are running with
+  // the Sauce Labs Launcher. Can be used by tests to check if certain
+  // capabilities are available, such as sending keys to the browser.
+  const testRunnerHtml = (testFramework) => `
+    <!DOCTYPE html>
+    <html>
+      <body>
+        <script>
+          /* Mark tests as being run with the Sauce Labs launcher */
+          window.browserLauncher = 'saucelabs';
+        </script>
+        <script type="module" src="${testFramework}"></script>
+      </body>
+    </html>
+  `;
+
   config.files = tests;
   config.concurrency = env === 'firefox' ? 2 : 1;
   config.browsers = [sauceLabsLauncher(sauce[env])];
+  config.testRunnerHtml = testRunnerHtml;
 }
 
 module.exports = config;


### PR DESCRIPTION
Fixes: vaadin/vaadin-select#265
Warranty: Fixes moving focus between inputs in adjacent cells when in interaction mode