### PR TITLE
fix: column widths are properly resized from the first time it is exanded

### DIFF
--- a/src/vaadin-grid-data-provider-mixin.html
+++ b/src/vaadin-grid-data-provider-mixin.html
@@ -397,7 +397,7 @@ This program is available under Apache License Version 2.0, available at https:/
             this._debouncerApplyCachedData.flush();
           }
 
-          this.__itemsReceived();
+          this.__flushPendingRecalculateColumnWidths();
         });
       }
     }

--- a/src/vaadin-grid-scroller.html
+++ b/src/vaadin-grid-scroller.html
@@ -434,6 +434,19 @@ This program is available under Apache License Version 2.0, available at https:/
         super._resizeHandler();
         Polymer.flush();
       }
+
+      __isCreatingRows() {
+        // iron-list's _increasePoolIfNeeded function may have scheduled a debouncer
+        // that will re-invoke _increasePoolIfNeeded (in vaadin-grid-scroller)
+        const schedulingDebounceIncreasePool = this._debouncers
+          && this._debouncers._increasePoolIfNeeded
+          && this._debouncers._increasePoolIfNeeded.isActive();
+        // vaadin-grid-scroller's overridden _increasePoolIfNeeded may have scheduled a _debounceIncreasePool debouncer
+        const debouncingIncreasePoolActive = this._debounceIncreasePool && this._debounceIncreasePool.isActive();
+
+        // If either of the conditions are true, we consider the grid is still in the process of creating new rows
+        return schedulingDebounceIncreasePool || debouncingIncreasePoolActive;
+      }
     }
 
     customElements.define(GridScrollerElement.is, GridScrollerElement);

--- a/src/vaadin-grid-scroller.html
+++ b/src/vaadin-grid-scroller.html
@@ -212,6 +212,7 @@ This program is available under Apache License Version 2.0, available at https:/
                 // Ensure the rows are in order after increasing pool
                 this.__reorderChildNodes();
               }
+              this.__itemsReceived();
             });
         }
       }

--- a/src/vaadin-grid-scroller.html
+++ b/src/vaadin-grid-scroller.html
@@ -212,7 +212,7 @@ This program is available under Apache License Version 2.0, available at https:/
                 // Ensure the rows are in order after increasing pool
                 this.__reorderChildNodes();
               }
-              this.__itemsReceived();
+              this.__flushPendingRecalculateColumnWidths();
             });
         }
       }

--- a/src/vaadin-grid-tree-toggle.html
+++ b/src/vaadin-grid-tree-toggle.html
@@ -195,6 +195,13 @@ This program is available under Apache License Version 2.0, available at https:/
       _levelChanged(level) {
         const value = Number(level).toString();
         this.updateStyles({'---level': value});
+        // Async is to make DOM updates applied before evaluating the style
+        // update, required for polyfilled RTL support in MSIE and Edge.
+        this._debouncerUpdateLevel = Polymer.Debouncer.debounce(
+          this._debouncerUpdateLevel,
+          Polymer.Async.microTask,
+          () => this.updateStyles({'---level': value})
+        );
       }
     }
 

--- a/src/vaadin-grid-tree-toggle.html
+++ b/src/vaadin-grid-tree-toggle.html
@@ -194,14 +194,7 @@ This program is available under Apache License Version 2.0, available at https:/
       /** @private */
       _levelChanged(level) {
         const value = Number(level).toString();
-        this.style['---level'] = value;
-        // Async is to make DOM updates applied before evaluating the style
-        // update, required for polyfilled RTL support in MSIE and Edge.
-        this._debouncerUpdateLevel = Polymer.Debouncer.debounce(
-          this._debouncerUpdateLevel,
-          Polymer.Async.microTask,
-          () => this.updateStyles({'---level': value})
-        );
+        this.updateStyles({'---level': value});
       }
     }
 

--- a/src/vaadin-grid.html
+++ b/src/vaadin-grid.html
@@ -457,10 +457,12 @@ This program is available under Apache License Version 2.0, available at https:/
       }
 
       /** @protected */
+      // This function is more like "tryToResizeWidth" instead
       __itemsReceived() {
         if (this._recalculateColumnWidthOnceLoadingFinished
-          && !this._cache.isLoading()
-          && this.__hasRowsWithClientHeight()) {
+        && !this._cache.isLoading()
+        && this.__hasRowsWithClientHeight()
+            && (!this._debounceIncreasePool || !this._debounceIncreasePool.isActive())) {
           this._recalculateColumnWidthOnceLoadingFinished = false;
           this.recalculateColumnWidths();
         }

--- a/src/vaadin-grid.html
+++ b/src/vaadin-grid.html
@@ -457,7 +457,6 @@ This program is available under Apache License Version 2.0, available at https:/
       }
 
       /** @protected */
-      // This function is more like "tryToResizeWidth" instead
       __flushPendingRecalculateColumnWidths() {
         if (this._recalculateColumnWidthOnceLoadingFinished
         && !this._cache.isLoading()

--- a/src/vaadin-grid.html
+++ b/src/vaadin-grid.html
@@ -458,7 +458,7 @@ This program is available under Apache License Version 2.0, available at https:/
 
       /** @protected */
       // This function is more like "tryToResizeWidth" instead
-      __itemsReceived() {
+      __flushPendingRecalculateColumnWidths() {
         if (this._recalculateColumnWidthOnceLoadingFinished
         && !this._cache.isLoading()
         && this.__hasRowsWithClientHeight()
@@ -870,7 +870,7 @@ This program is available under Apache License Version 2.0, available at https:/
           this._render();
           e.stopPropagation();
           this.notifyResize();
-          this.__itemsReceived();
+          this.__flushPendingRecalculateColumnWidths();
 
           requestAnimationFrame(() => {
             this.__scrollToPendingIndex();

--- a/src/vaadin-grid.html
+++ b/src/vaadin-grid.html
@@ -461,7 +461,7 @@ This program is available under Apache License Version 2.0, available at https:/
         if (this._recalculateColumnWidthOnceLoadingFinished
         && !this._cache.isLoading()
         && this.__hasRowsWithClientHeight()
-            && (!this._debounceIncreasePool || !this._debounceIncreasePool.isActive())) {
+        && !this.__isCreatingRows()) {
           this._recalculateColumnWidthOnceLoadingFinished = false;
           this.recalculateColumnWidths();
         }
@@ -508,7 +508,7 @@ This program is available under Apache License Version 2.0, available at https:/
         if (!this._columnTree) {
           return; // No columns
         }
-        if (this._cache.isLoading()) {
+        if (this._cache.isLoading() || this.__isCreatingRows()) {
           this._recalculateColumnWidthOnceLoadingFinished = true;
         } else {
           const cols = this._getColumns().filter(col => !col.hidden && col.autoWidth);

--- a/test/column-auto-width.html
+++ b/test/column-auto-width.html
@@ -111,6 +111,34 @@
         });
       });
 
+
+      it('should recalculate column widths not until necessary rows have been rendered', () => {
+        // First, only render a single item
+        let size = 1;
+        grid.dataProvider = (params, callback) => {
+          callback(testItems.slice(0, params.pageSize), size);
+        };
+
+        // Have grid load the rest of the items
+        size = 4;
+        grid.clearCache();
+
+        // Invoke recalculateColumnWidths manually
+        //
+        // Before the fix, this would have executed immediately, since all the data items are already loaded,
+        // but since the DOM row elements haven't yet been created, the column widths would not get calculated
+        // from the expected set of samples.
+        // With the fix in place, the recalculateColumnWidths will not execute until the grid
+        // has also finished creating the necessary DOM row elements.
+        grid.recalculateColumnWidths();
+
+        // TODO: Investigate why two calls is necessary
+        flushGrid(grid);
+        flushGrid(grid);
+
+        expectColumnWidthsToBeOk(columns);
+      });
+
       it('should have correct column widths once visible', done => {
         grid.hidden = true;
         grid.items = testItems;

--- a/test/column-auto-width.html
+++ b/test/column-auto-width.html
@@ -111,6 +111,30 @@
         });
       });
 
+      it('should recalculate widths after iron-list is done creating rows', done => {
+        spy.reset();
+        // make the grid big enough to fit more than 25 items
+        grid.style.height = '1000px';
+
+        const items = [];
+        // create 25 narrow items (25 is the default iron-list pool size)
+        for (let i = 0; i < 25; i++) {
+          items.push({a: 'fubar', b: 'foo', c: 'foo', d: 'a'});
+        }
+        // create 10 wide items, for a total of 35 items
+        for (let i = 0; i < 10; i++) {
+          items.push({a: 'foo', b: 'foo bar baz', c: 'foo bar', d: 'bar'});
+        }
+        // set data
+        grid.items = [...items];
+
+        // Check columns width match the wider content.
+        // The second column has wider content after the initial pool size
+        whenColumnWidthsCalculated(() => {
+          expectColumnWidthsToBeOk(columns);
+          done();
+        });
+      });
 
       it('should recalculate column widths not until necessary rows have been rendered', () => {
         // First, only render a single item

--- a/test/column-auto-width.html
+++ b/test/column-auto-width.html
@@ -130,7 +130,6 @@
         // from the expected set of samples.
         // With the fix in place, the recalculateColumnWidths will not execute until the grid
         // has also finished creating the necessary DOM row elements.
-        // debugger;
         grid.recalculateColumnWidths();
 
         flushGrid(grid);

--- a/test/column-auto-width.html
+++ b/test/column-auto-width.html
@@ -130,10 +130,9 @@
         // from the expected set of samples.
         // With the fix in place, the recalculateColumnWidths will not execute until the grid
         // has also finished creating the necessary DOM row elements.
+        // debugger;
         grid.recalculateColumnWidths();
 
-        // TODO: Investigate why two calls is necessary
-        flushGrid(grid);
         flushGrid(grid);
 
         expectColumnWidthsToBeOk(columns);

--- a/test/helpers.html
+++ b/test/helpers.html
@@ -48,6 +48,12 @@
       grid._debouncerIgnoreNewWheel.flush();
     }
     grid._scrollHandler();
+    Polymer.flush();
+    while (grid._debounceIncreasePool) {
+      grid._debounceIncreasePool.flush();
+      grid._debounceIncreasePool = null;
+      Polymer.flush();
+    }
   };
 
   window.getCell = (grid, index) => {

--- a/test/tree-toggle.html
+++ b/test/tree-toggle.html
@@ -129,6 +129,7 @@
           let prevWidth = 0;
           for (let i = 1; i < 3; i++) {
             toggle.level = i;
+            toggle._debouncerUpdateLevel.flush();
             const width = spacer.getBoundingClientRect().width;
             expect(width).to.be.gt(prevWidth);
             prevWidth = width;

--- a/test/tree-toggle.html
+++ b/test/tree-toggle.html
@@ -129,7 +129,6 @@
           let prevWidth = 0;
           for (let i = 1; i < 3; i++) {
             toggle.level = i;
-            toggle._debouncerUpdateLevel.flush();
             const width = spacer.getBoundingClientRect().width;
             expect(width).to.be.gt(prevWidth);
             prevWidth = width;

--- a/test/tree-toggle.html
+++ b/test/tree-toggle.html
@@ -135,6 +135,15 @@
             prevWidth = width;
           }
         });
+
+        it('should increase width immediately after when changing level', () => {
+          const spacer = toggle.shadowRoot.querySelector('#level-spacer');
+          let width = spacer.getBoundingClientRect().width;
+          expect(width).to.be.eq(0);
+          toggle.level = 1;
+          width = spacer.getBoundingClientRect().width;
+          expect(width).to.be.gt(0);
+        });
       });
 
       describe('themability', () => {


### PR DESCRIPTION
## Description

There's a timing issue between the rendering of columns and the call to `recalculateColumnWidths()` when a tree toggle is clicked. This caused the method to be called before the tree columns were rendered and so would calculate their widths improperly (since no content is available, it will use much less space than the content actually needed).

The timing issue is fixed by adding a new method to check if iron-list is still creating rows and using it to determine when the `recalculateColumnWidths()` should be called.

In addition, the `level` CSS style must be set synchronously since it was also not being applied in time. When it did apply, the column width was already recalculated and then it would clip the content by the level-spacer's width.

Fixes https://github.com/vaadin/flow-components/issues/1855

## Type of change

- [x] Bugfix

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
