### PR TITLE
fix: correctly show rows after showing hidden column and clearing grid filter

### DIFF
--- a/src/vaadin-grid-column.html
+++ b/src/vaadin-grid-column.html
@@ -322,6 +322,9 @@ This program is available under Apache License Version 2.0, available at https:/
       }
 
       cells.forEach(cell => {
+        if (!cell.parentElement) {
+          return;
+        }
         const model = this._grid.__getRowModel(cell.parentElement);
 
         if (renderer) {

--- a/src/vaadin-grid-column.html
+++ b/src/vaadin-grid-column.html
@@ -322,10 +322,15 @@ This program is available under Apache License Version 2.0, available at https:/
       }
 
       cells.forEach(cell => {
-        if (!cell.parentElement) {
+        const parent = cell.parentElement;
+
+        // When a column is made hidden and shown again, in some instances it breaks rendering of rows for grid
+        // this happens when parent element of cell is null, which might not be set correctly during rendering
+        // the newly shown column, this check simply avoid that case
+        if (!parent) {
           return;
         }
-        const model = this._grid.__getRowModel(cell.parentElement);
+        const model = this._grid.__getRowModel(parent);
 
         if (renderer) {
           cell._renderer = renderer;

--- a/test/filtering.html
+++ b/test/filtering.html
@@ -70,6 +70,15 @@
     </template>
   </test-fixture>
 
+  <test-fixture id="grid-with-external-filter">
+    <template>
+      <vaadin-grid>
+        <vaadin-grid-column path="first"></vaadin-grid-column>
+        <vaadin-grid-column id="last" path="last"></vaadin-grid-column>
+      </vaadin-grid>
+    </template>
+  </test-fixture>
+
   <script>
 
     describe('filter', () => {
@@ -330,6 +339,39 @@
         expect(flushFilters.bind(this, grid)).to.not.throw(Error);
       });
 
+    });
+
+    describe('in-memory filtering and hiding a column', () => {
+      it('should correctly display items after filter is cleared and column is visible', () => {
+        const grid = fixture('grid-with-external-filter');
+        const column = grid.querySelector('#last');
+        // this is the minimum amount of items that this bug happens
+        const itemCount = 56;
+        const items = Array.apply(null, Array(itemCount)).map((_, i) => {
+          return {
+            first: 'foo' + i,
+            last: 'bar' + i
+          };
+        });
+        grid.items = items;
+        flushGrid(grid);
+
+        // filter the data and hide one column
+        column.hidden = true;
+        grid.items = items.filter(item => item.first === 'foo55');
+        flushGrid(grid);
+
+        // clear filter and show column again
+        column.hidden = false;
+        grid.items = items;
+        flushGrid(grid);
+    
+        const bodyRows = getRows(grid.$.items);
+        const rowCells = getRowCells(bodyRows[5]);
+        const cellContent = getCellContent(rowCells[1]).textContent;
+    
+        expect(cellContent).to.be.equal('bar5');
+      });
     });
   </script>
 

--- a/test/filtering.html
+++ b/test/filtering.html
@@ -342,10 +342,10 @@
     });
 
     describe('in-memory filtering and hiding a column', () => {
-      it('should correctly display items after filter is cleared and column is visible', () => {
+      it('should correctly display items after filter is cleared and column is made visible', () => {
         const grid = fixture('grid-with-external-filter');
         const column = grid.querySelector('#last');
-        // this is the minimum amount of items that this bug happens
+        // this is the minimum amount of items that should be in data-provider in order to see the bug
         const itemCount = 56;
         const items = Array.apply(null, Array(itemCount)).map((_, i) => {
           return {
@@ -365,7 +365,8 @@
         column.hidden = false;
         grid.items = items;
         flushGrid(grid);
-    
+
+        // get cell content of 5th row and check if it is displayed correctly
         const bodyRows = getRows(grid.$.items);
         const rowCells = getRowCells(bodyRows[5]);
         const cellContent = getCellContent(rowCells[1]).textContent;


### PR DESCRIPTION
## Description

When grid is used with an in-memory data provider with more than 50 items, after applying a filter and hiding a column and respectively making the column visible and filter cleared (in this particular order),  grid breaks and it won't show items correctly unless page is refreshed. 

The current fix simply resolves by checking for cell parent not being null in `__setColumnTemplateOrRenderer` method, and by doing so the issue is resolved. I have added a relevant test case which tests this particular behaviour.

This PR is rebased on top of master (which includes all changes made into running tests)

Fixes https://github.com/vaadin/flow-components/issues/2330

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
