### PR TITLE
chore: update dependencies of checkbox and text-field

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -56,8 +56,8 @@
     "iron-a11y-keys-behavior": "^v2.0.0",
     "iron-a11y-announcer": "^v2.0.0",
     "vaadin-themable-mixin": "vaadin/vaadin-themable-mixin#^1.6.1",
-    "vaadin-checkbox": "vaadin/vaadin-checkbox#^2.4.0",
-    "vaadin-text-field": "vaadin/vaadin-text-field#^2.7.0",
+    "vaadin-checkbox": "vaadin/vaadin-checkbox#^2.6.0",
+    "vaadin-text-field": "vaadin/vaadin-text-field#^2.10.0",
     "vaadin-lumo-styles": "vaadin/vaadin-lumo-styles#^1.6.0",
     "vaadin-material-styles": "vaadin/vaadin-material-styles#^1.3.2",
     "vaadin-element-mixin": "vaadin/vaadin-element-mixin#^2.4.1"

--- a/package-lock-p3.json
+++ b/package-lock-p3.json
@@ -1,12 +1,12 @@
 {
   "name": "@vaadin/vaadin-grid",
-  "version": "5.9.1",
+  "version": "5.9.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@vaadin/vaadin-grid",
-      "version": "5.9.1",
+      "version": "5.9.7",
       "license": "Apache-2.0",
       "dependencies": {
         "@polymer/iron-a11y-announcer": "^3.0.0",
@@ -14,11 +14,11 @@
         "@polymer/iron-resizable-behavior": "^3.0.0",
         "@polymer/iron-scroll-target-behavior": "^3.0.0",
         "@polymer/polymer": "^3.0.0",
-        "@vaadin/vaadin-checkbox": "^2.4.0",
+        "@vaadin/vaadin-checkbox": "^2.6.0",
         "@vaadin/vaadin-element-mixin": "^2.4.1",
         "@vaadin/vaadin-lumo-styles": "^1.6.0",
         "@vaadin/vaadin-material-styles": "^1.3.2",
-        "@vaadin/vaadin-text-field": "^2.7.0",
+        "@vaadin/vaadin-text-field": "^2.10.0",
         "@vaadin/vaadin-themable-mixin": "^1.6.1"
       },
       "devDependencies": {
@@ -1934,9 +1934,9 @@
       }
     },
     "node_modules/@vaadin/vaadin-checkbox": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-checkbox/-/vaadin-checkbox-2.5.1.tgz",
-      "integrity": "sha512-Y7GfhOmZPJvAudda7SqCkXaYwC0bUwqyIW9D+P/KjTECKuvwxLaQSl2PssWv0q2ZMk5JV9I2d1ABz8y8r/qb7g==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-checkbox/-/vaadin-checkbox-2.6.0.tgz",
+      "integrity": "sha512-QFyjFuaGhXlk1Imcm4SKna40IS7P+jDE01OCKBHYztIQWqRuTuCVrB3gml85chbMS6+Ap2Vid2vefnidzziz8g==",
       "dependencies": {
         "@polymer/polymer": "^3.0.0",
         "@vaadin/vaadin-control-state-mixin": "^2.2.1",
@@ -2069,9 +2069,9 @@
       }
     },
     "node_modules/@vaadin/vaadin-text-field": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-text-field/-/vaadin-text-field-2.9.0.tgz",
-      "integrity": "sha512-y7z/w/nKFlcUDZiys7Nz5apkmHrsoydhghooDJdfTiydx/fzp4dO1pqxoKlrB624seJZe9DpnCYd7Yx8kzYnGw==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-text-field/-/vaadin-text-field-2.10.0.tgz",
+      "integrity": "sha512-jO2c2Ix5T2M2biNaR0DvyPZCb2BhwCZJnu5R5PtP5Mr2nH1EYyGVer5gh0z54vsgGe8Bl8/xe0GOmYJbeJYc2w==",
       "dependencies": {
         "@polymer/polymer": "^3.0.0",
         "@vaadin/vaadin-control-state-mixin": "^2.2.1",
@@ -15366,9 +15366,9 @@
       }
     },
     "@vaadin/vaadin-checkbox": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-checkbox/-/vaadin-checkbox-2.5.1.tgz",
-      "integrity": "sha512-Y7GfhOmZPJvAudda7SqCkXaYwC0bUwqyIW9D+P/KjTECKuvwxLaQSl2PssWv0q2ZMk5JV9I2d1ABz8y8r/qb7g==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-checkbox/-/vaadin-checkbox-2.6.0.tgz",
+      "integrity": "sha512-QFyjFuaGhXlk1Imcm4SKna40IS7P+jDE01OCKBHYztIQWqRuTuCVrB3gml85chbMS6+Ap2Vid2vefnidzziz8g==",
       "requires": {
         "@polymer/polymer": "^3.0.0",
         "@vaadin/vaadin-control-state-mixin": "^2.2.1",
@@ -15501,9 +15501,9 @@
       }
     },
     "@vaadin/vaadin-text-field": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-text-field/-/vaadin-text-field-2.9.0.tgz",
-      "integrity": "sha512-y7z/w/nKFlcUDZiys7Nz5apkmHrsoydhghooDJdfTiydx/fzp4dO1pqxoKlrB624seJZe9DpnCYd7Yx8kzYnGw==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-text-field/-/vaadin-text-field-2.10.0.tgz",
+      "integrity": "sha512-jO2c2Ix5T2M2biNaR0DvyPZCb2BhwCZJnu5R5PtP5Mr2nH1EYyGVer5gh0z54vsgGe8Bl8/xe0GOmYJbeJYc2w==",
       "requires": {
         "@polymer/polymer": "^3.0.0",
         "@vaadin/vaadin-control-state-mixin": "^2.2.1",


### PR DESCRIPTION
## Description

Update `vaadin-text-field` to `2.10.0` and `vaadin-checkbox` to `2.6.0`

