### PR TITLE
fix: do not move focus when focused in on grid via clicking backport

### DIFF
--- a/src/vaadin-grid-keyboard-navigation-mixin.html
+++ b/src/vaadin-grid-keyboard-navigation-mixin.html
@@ -499,13 +499,15 @@ This program is available under Apache License Version 2.0, available at https:/
 
       if (rootTarget === this.$.table ||
           rootTarget === this.$.focusexit) {
-        // The focus enters the top (bottom) of the grid, meaning that user has
-        // tabbed (shift-tabbed) into the grid. Move the focus to
-        // the first (the last) focusable.
-        this._predictFocusStepTarget(
-          rootTarget,
-          rootTarget === this.$.table ? 1 : -1
-        ).focus();
+        if (!this._isMousedown) {
+          // The focus enters the top (bottom) of the grid, meaning that user has
+          // tabbed (shift-tabbed) into the grid. Move the focus to
+          // the first (the last) focusable.
+          this._predictFocusStepTarget(
+            rootTarget,
+            rootTarget === this.$.table ? 1 : -1
+          ).focus();
+        }
         this._setInteracting(false);
       } else {
         this._detectInteracting(e);

--- a/test/keyboard-navigation.html
+++ b/test/keyboard-navigation.html
@@ -602,6 +602,19 @@
           expect(grid.shadowRoot.activeElement).to.equal(tabbableElements[3]);
         });
 
+        it('should not enter grid on table click', () => {
+          const tabbableElements = getTabbableElements(grid.shadowRoot);
+
+          // Click and focusin on table element
+          mouseDown(tabbableElements[0]);
+          const event = new CustomEvent('focusin', {bubbles: true, composed: true});
+          event.relatedTarget = focusable;
+          tabbableElements[0].dispatchEvent(event);
+
+          // Expect no focus on header cell
+          expect(grid.shadowRoot.activeElement).to.be.null;
+        });
+
         it('should set native focus to header on header cell click', () => {
           const tabbableElements = getTabbableElements(grid.shadowRoot);
           focusFirstHeaderCell();


### PR DESCRIPTION
## Description

Back-port of the [fix](https://github.com/vaadin/web-components/pull/7323) for the grid horizontal scroll click [issue](https://github.com/vaadin/web-components/issues/2911).

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.