### PR TITLE
fix: defer scrollToIndex calls until columnTree is available (CP: 14)

### DIFF
--- a/src/vaadin-grid-data-provider-mixin.html
+++ b/src/vaadin-grid-data-provider-mixin.html
@@ -509,7 +509,7 @@ This program is available under Apache License Version 2.0, available at https:/
 
     scrollToIndex(index) {
       super.scrollToIndex(index);
-      if (!isNaN(index) && (this._cache.isLoading() || !this.clientHeight)) {
+      if (!isNaN(index) && (this._cache.isLoading() || !this.clientHeight || !this._columnTree)) {
         this.__pendingScrollToIndex = index;
       }
     }

--- a/test/scroll-to-index.html
+++ b/test/scroll-to-index.html
@@ -320,7 +320,7 @@
       });
     });
 
-    describe.only('before grid is fully initialized', () => {
+    describe('before grid is fully initialized', () => {
       let grid;
 
       beforeEach((done) => {

--- a/test/scroll-to-index.html
+++ b/test/scroll-to-index.html
@@ -48,6 +48,7 @@
       </vaadin-grid>
     </template>
   </test-fixture>
+
   <script>
     describe('Scroll to index', () => {
 
@@ -316,6 +317,22 @@
 
         grid.expandedItems = [parents[parents.length - 1]];
         grid.scrollToIndex(14);
+      });
+    });
+
+    describe.only('before grid is fully initialized', () => {
+      let grid;
+
+      beforeEach((done) => {
+        grid = fixture('small');
+        grid.items = Array.from({length: 100}, (_, index) => `Item ${index}`);
+        grid.scrollToIndex(50);
+        flushGrid(grid);
+        animationFrameFlush(done);
+      });
+
+      it('should scroll to index after items are rendered', () => {
+        expect(grid._firstVisibleIndex).to.equal(50);
       });
     });
   </script>


### PR DESCRIPTION
## Description

Backports https://github.com/vaadin/web-components/pull/8856 to Vaadin 14.

Fixes https://github.com/vaadin/flow-components/issues/6711

## Type of change

- [x] Bugfix
