### PR TITLE
chore: upgrade iOS Simulator version in Sauce tests to 12.2

### DIFF
--- a/wct.conf.js
+++ b/wct.conf.js
@@ -39,7 +39,7 @@ module.exports = {
         platformVersion: '11.0',
         browserName: 'Chrome',
       },
-      'iOS Simulator/iphone@10.3', // should be 9.x, but SauceLabs does not provide that
+      'iOS Simulator/iphone@12.2', // should be 9.x, but SauceLabs does not provide that
       'macOS 11/safari@latest',
       'Windows 10/microsoftedge@latest',
       'Windows 10/internet explorer@11',


### PR DESCRIPTION
## Description

Follow-up to #2253

It seems like SauceLabs no longer provides iOS 10.3 which could be possibly related to [Appium 2 migration](https://docs.saucelabs.com/mobile-apps/automated-testing/appium/appium-2-migration/#supported-drivers).

Here's the error from the most recent [PR build](https://github.com/vaadin/vaadin-grid/actions/runs/13243546373/job/36964353279) for #2254.

```
Error: Misconfigured -- Unsupported OS/browser/version/device combo: OS: 'unspecified', Browser: 'iphone', Version: '10.3.', Device: 'iPhone Simulator'
```

Let's try upgrading to 12.2 which should be still provided to see if tests can run in that version.

## Type of change

- Internal change